### PR TITLE
Pass OPERATOR_NAME env variable when running operator locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ build: fmt
 run:
 	WATCH_NAMESPACE=$(NAMESPACE) \
 	KUBERNETES_CONFIG=$(KUBECONFIG) \
+	OPERATOR_NAME=compliance-operator \
 	operator-sdk up local --namespace $(NAMESPACE)
 
 clean:


### PR DESCRIPTION
This allows logs to be properly formatted.