### PR TITLE
Make call to gofmt more compact by using `go fmt`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,7 @@ clean:
 	@rm -rf $(TARGET_DIR)
 
 fmt:
-	@gofmt -l -w cmd && \
-	gofmt -l -w pkg
+	@go fmt $(PKGS)
 
 simplify:
 	@gofmt -s -l -w $(SRC)


### PR DESCRIPTION
`go fmt` ultimately calls gofmt. This way we don't need to run it
explicitly per each package, and it'll just use the environment variable
we already have.