### PR TITLE
fix operator-sdk go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -373,7 +373,7 @@ github.com/operator-framework/operator-marketplace v0.0.0-20190216021216-57300a3
 github.com/operator-framework/operator-registry v1.0.1/go.mod h1:1xEdZjjUg2hPEd52LG3YQ0jtwiwEGdm98S1TH5P4RAA=
 github.com/operator-framework/operator-registry v1.0.4/go.mod h1:hve6YwcjM2nGVlscLtNsp9sIIBkNZo6jlJgzWw7vP9s=
 github.com/operator-framework/operator-registry v1.1.1/go.mod h1:7D4WEwL+EKti5npUh4/u64DQhawCBRugp8Ql20duUb4=
-github.com/operator-framework/operator-sdk v0.12.0 h1:aD4qPbSAbZgRj1jFdFLq/dBI4P4aKX8d4rJowyQtTYM=
+github.com/operator-framework/operator-sdk v0.12.0 h1:9eAD1L8e6pPCpFCAacBUVf2eloDkRuVm29GTCOktLqQ=
 github.com/operator-framework/operator-sdk v0.12.0/go.mod h1:mW8isQxiXlLCVf2E+xqflkQAVLOTbiqjndKdkKIrR0M=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=


### PR DESCRIPTION
This is to correct this error seen when building manually and in a container:
```
go: extracting k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
go: downloading k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2
go: extracting k8s.io/client-go v0.0.0-20190918200256-06eb1244587a
verifying github.com/operator-framework/operator-sdk@v0.12.0: checksum mismatch
        downloaded: h1:9eAD1L8e6pPCpFCAacBUVf2eloDkRuVm29GTCOktLqQ=
        go.sum:     h1:aD4qPbSAbZgRj1jFdFLq/dBI4P4aKX8d4rJowyQtTYM=

SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.

For more information, see 'go help module-auth'.
```

Note, I didn't change this manually, but took the following steps to let operator-sdk restore go.sum:
In a GOPATH with an empty pkg/mod/cache
1. Delete go.sum and go.mod
2. Run `operator-sdk print-deps > go.mod`
3. Run `go mod tidy`
4. Run `make` to confirm build.

```
$ operator-sdk version
operator-sdk version: "v0.12.0", commit: "2445fcda834ca4b7cf0d6c38fba6317fb219b469", go version: "go1.13.3 linux/amd64"
$ go version
go version go1.13.3 linux/amd64

```
@openshift/infrastructure-security-compliance 