### PR TITLE
Add end to end tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ OC?=oc
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./_output/*")
 
 #.PHONY: all build clean install uninstall fmt simplify check run
-.PHONY: all operator-sdk build clean clean-cache clean-modcache clean-output fmt simplify verify vet mod-verify gosec gendeepcopy test-unit run
+.PHONY: all operator-sdk build clean clean-cache clean-modcache clean-output fmt simplify verify vet mod-verify gosec gendeepcopy test-unit run e2e
 
 all: build #check install
 
@@ -78,6 +78,12 @@ gendeepcopy: operator-sdk
 
 test-unit: fmt
 	@$(GO) test $(TEST_OPTIONS) $(PKGS)
+
+e2e:
+	@echo "Creating '$(NAMESPACE)' namespace/project"
+	@oc create -f deploy/ns.yaml || true
+	@echo "Running e2e tests"
+	@operator-sdk test local ./tests/e2e --namespace "$(NAMESPACE)" --go-test-flags "-v"
 
 push: build
 	$(RUNTIME) tag $(IMAGE_PATH) $(IMAGE_PATH):$(TAG)

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -64,3 +64,15 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: compliance-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes  # We need to list the nodes to be able to selectively scan
+  verbs:
+  - list

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -27,3 +27,16 @@ roleRef:
   namespace: openshift-compliance
   name: scc-priv
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: compliance-operator
+subjects:
+- kind: ServiceAccount
+  name: compliance-operator
+  namespace: openshift-compliance
+roleRef:
+  kind: ClusterRole
+  name: compliance-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/apis/complianceoperator/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/complianceoperator/v1alpha1/compliancescan_types.go
@@ -4,14 +4,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+// +genclient
+
+type ComplianceScanStatusPhase string
 
 const (
-	PhasePending   = "PENDING"
-	PhaseLaunching = "LAUNCHING"
-	PhaseRunning   = "RUNNING"
-	PhaseDone      = "DONE"
+	PhasePending   ComplianceScanStatusPhase = "PENDING"
+	PhaseLaunching ComplianceScanStatusPhase = "LAUNCHING"
+	PhaseRunning   ComplianceScanStatusPhase = "RUNNING"
+	PhaseDone      ComplianceScanStatusPhase = "DONE"
 )
 
 // ComplianceScanSpec defines the desired state of ComplianceScan
@@ -33,7 +34,7 @@ type ComplianceScanStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
-	Phase string `json:"phase,omitempty"`
+	Phase ComplianceScanStatusPhase `json:"phase,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -1,0 +1,11 @@
+package e2e
+
+import (
+	"testing"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+)
+
+func TestMain(m *testing.M) {
+	framework.MainEntry(m)
+}

--- a/tests/e2e/single_scan_test.go
+++ b/tests/e2e/single_scan_test.go
@@ -1,0 +1,111 @@
+package e2e
+
+import (
+	goctx "context"
+	"fmt"
+	"testing"
+	"time"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/compliance-operator/pkg/apis"
+	complianceoperatorv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/complianceoperator/v1alpha1"
+)
+
+var (
+	retryInterval        = time.Second * 5
+	timeout              = time.Second * 120
+	cleanupRetryInterval = time.Second * 1
+	cleanupTimeout       = time.Second * 5
+)
+
+func waitForScanDoneStatus(t *testing.T, f *framework.Framework, namespace, name string) error {
+	exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{}
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, exampleComplianceScan)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				t.Logf("Waiting for availability of %s compliancescan\n", name)
+				return false, nil
+			}
+			return false, err
+		}
+
+		if exampleComplianceScan.Status.Phase == complianceoperatorv1alpha1.PhaseDone {
+			return true, nil
+		}
+		t.Logf("Waiting for run of %s compliancescan (%s)\n", name, exampleComplianceScan.Status.Phase)
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	t.Logf("ComplianceScan ready (%s)\n", exampleComplianceScan.Status.Phase)
+	return nil
+}
+
+func TestSingleScan(t *testing.T) {
+	compliancescan := &complianceoperatorv1alpha1.ComplianceScanList{}
+	err := framework.AddToFrameworkScheme(apis.AddToScheme, compliancescan)
+	if err != nil {
+		t.Fatalf("TEST SETUP: failed to add custom resource scheme to framework: %v", err)
+	}
+	// run subtests
+	t.Run("testgroup", func(t *testing.T) {
+		t.Run("simple-cluster", ComplianceOperatorCluster)
+	})
+}
+
+func complianceScanTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		return fmt.Errorf("could not get namespace: %v", err)
+	}
+	exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-scan",
+			Namespace: namespace,
+		},
+		Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
+			Profile: "xccdf_org.ssgproject.content_profile_coreos-ncp",
+			Content: "ssg-ocp4-ds.xml",
+		},
+	}
+	// use TestCtx's create helper to create the object and add a cleanup function for the new object
+	err = f.Client.Create(goctx.TODO(), exampleComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	if err != nil {
+		return err
+	}
+	return waitForScanDoneStatus(t, f, namespace, "example-scan")
+}
+
+func ComplianceOperatorCluster(t *testing.T) {
+	t.Parallel()
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup()
+	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	if err != nil {
+		t.Fatalf("failed to initialize cluster resources: %v", err)
+	}
+	t.Log("Initialized cluster resources")
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// get global framework variables
+	f := framework.Global
+	// wait for compliance-operator to be ready
+	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "compliance-operator", 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = complianceScanTest(t, f, ctx); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR enabled end to end tests through the `e2e` makefile target.

It uses the operator-sdk e2e test framework in order to set everything up and run the operator in the Kubernetes cluster that's configured in the `KUBECONFIG` environment variable.

With this test I actually found out that we were missing some permissions for the operator (listing Kubernetes nodes), so I added those permissions as part of this PR.