### PR TITLE
Use relevant images in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,11 @@ endif
 # developing on. This target exposes temporarily the image registry, pushes the
 # image, and remove the route in the end.
 .PHONY: image-to-cluster
+ifdef IMAGE_FORMAT
+image-to-cluster:
+	@echo "We're in a CI environment, skipping image-to-cluster target."
+else
 image-to-cluster: openshift-user image
-ifndef IMAGE_FORMAT
 	@echo "Temporarily exposing the default route to the image registry"
 	@oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
 	@echo "Pushing image $(IMAGE_PATH):$(TAG) to the image registry"

--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,11 @@ endif
 # IMAGE_PATH variable, it'll expand to the component we need.
 check-if-ci:
 ifdef IMAGE_FORMAT
+	@echo "IMAGE_FORMAT variable detected. We're in a CI enviornment."
 	$(eval component = $(APP_NAME))
 	$(eval IMAGE_PATH = $(IMAGE_FORMAT))
+else
+	@echo "IMAGE_FORMAT variable missing. We're in local enviornment."
 endif
 
 # If IMAGE_FORMAT is not defined, it means that we're not running on CI, so we


### PR DESCRIPTION
This allows us to take into use the operator image that was built from
CI. It leverages the already existing `$IMAGE_FORMAT` variable, in order
to get the appropriate path of the image to use.

On the other hand, when running locally this also enables the capability of building the image and pushing it to the cluster we're working on. Thus making running the e2e tests with a relevant image easier.