### PR TITLE
Up e2e test timeout

### DIFF
--- a/tests/e2e/single_scan_test.go
+++ b/tests/e2e/single_scan_test.go
@@ -19,9 +19,9 @@ import (
 
 var (
 	retryInterval        = time.Second * 5
-	timeout              = time.Second * 120
+	timeout              = time.Minute * 10
 	cleanupRetryInterval = time.Second * 1
-	cleanupTimeout       = time.Second * 5
+	cleanupTimeout       = time.Minute * 5
 )
 
 func waitForScanDoneStatus(t *testing.T, f *framework.Framework, namespace, name string) error {


### PR DESCRIPTION
It was too short (2 min). So lets give it 10, which would be a
reasonable time for the operator to pull all the images it needs and run
the tests.