### PR TITLE
Build the operator as part of the image build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,18 @@
+# Step one: build compliance-operator
+FROM registry.access.redhat.com/ubi8/go-toolset as builder
+
+WORKDIR /go/src/github.com/openshift/compliance-operator
+
+ARG ARG_GOPROXY="https://proxy.golang.org"
+ARG ARG_GOSUMDB="sum.golang.org"
+
+ENV GOPROXY=$ARG_GOPROXY
+ENV GOSUMDB=$ARG_GOSUMDB
+
+COPY . .
+RUN make
+
+# Step two: containerize compliance-operator
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/compliance-operator \
@@ -5,7 +20,7 @@ ENV OPERATOR=/usr/local/bin/compliance-operator \
     USER_NAME=compliance-operator
 
 # install operator binary
-COPY build/_output/bin/compliance-operator ${OPERATOR}
+COPY --from=builder /go/src/github.com/openshift/compliance-operator/build/_output/bin/compliance-operator ${OPERATOR}
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup


### PR DESCRIPTION
This makes our dockerfile to be a multi-stage build.

On the first pass it'll build the compliace-operator binary. On the
second one it'll take the built binary and package it in the UBI image.