### PR TITLE
Add Dockerfile specifically for CI

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,22 @@
+# Step one: build compliance-operator
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
+
+COPY . .
+RUN make
+
+# Step two: containerize compliance-operator
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ENV OPERATOR=/usr/local/bin/compliance-operator \
+    USER_UID=1001 \
+    USER_NAME=compliance-operator
+
+# install operator binary
+COPY --from=builder /opt/app-root/src/build/_output/bin/compliance-operator ${OPERATOR}
+
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}


### PR DESCRIPTION
On the first pass it'll build the compliace-operator binary. On the
second one it'll take the built binary and package it in the ocp builder image.