### PR TITLE
e2e tests: Be resilient to temporary unavailability of k8s

### DIFF
--- a/tests/e2e/single_scan_test.go
+++ b/tests/e2e/single_scan_test.go
@@ -35,6 +35,9 @@ func waitForScanDoneStatus(t *testing.T, f *framework.Framework, namespace, name
 			} else if apierrors.IsServiceUnavailable(err) {
 				t.Logf("The cluster is currently unavailable... Lets keep waiting. Got: %v\n", err)
 				return false, nil
+			} else if apierrors.IsTimeout(err) {
+				t.Logf("The get call timed out... Lets keep waiting. Might be a temporary issue. Got: %v\n", err)
+				return false, nil
 			}
 			return false, err
 		}

--- a/tests/e2e/single_scan_test.go
+++ b/tests/e2e/single_scan_test.go
@@ -32,6 +32,9 @@ func waitForScanDoneStatus(t *testing.T, f *framework.Framework, namespace, name
 			if apierrors.IsNotFound(err) {
 				t.Logf("Waiting for availability of %s compliancescan\n", name)
 				return false, nil
+			} else if apierrors.IsServiceUnavailable(err) {
+				t.Logf("The cluster is currently unavailable... Lets keep waiting. Got: %v\n", err)
+				return false, nil
 			}
 			return false, err
 		}


### PR DESCRIPTION
The tests are flaky due to leader re-elections in etcd. The following
error is logged every once in a while:

     single_scan_test.go:109: rpc error: code = Unavailable desc = etcdserver: leader changed

So lets try to be more resilient in our tests.