### PR TITLE
Use go 1.12 for ocp/builder image

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Step one: build compliance-operator
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 
 COPY . .
 RUN make


### PR DESCRIPTION
we were trying to use 1.13 which doesn't exist as a tag yet :cry: 