### PR TITLE
Refactor e2e tests for readability

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -32,7 +32,6 @@ func TestSingleScanSucceeds(t *testing.T) {
 }
 
 func TestScanWithInvalidContentFails(t *testing.T) {
-	t.Skip("NOTE(jaosorior): We're skipping this test until we get CI to use the current built image.")
 	executeTest(t, func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
 		exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
 			ObjectMeta: metav1.ObjectMeta{

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	goctx "context"
-	"fmt"
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
@@ -12,76 +11,44 @@ import (
 )
 
 func TestSingleScanSucceeds(t *testing.T) {
-	ctx := setupTestRequirements(t)
-	defer ctx.Cleanup()
-
-	setupComplianceOperatorCluster(t, ctx)
-
-	// get global framework variables
-	f := framework.Global
-
-	if err := doSingleComplianceScanTest(t, f, ctx); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func doSingleComplianceScanTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		return fmt.Errorf("could not get namespace: %v", err)
-	}
-	exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-scan",
-			Namespace: namespace,
-		},
-		Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
-			Profile: "xccdf_org.ssgproject.content_profile_coreos-ncp",
-			Content: "ssg-ocp4-ds.xml",
-		},
-	}
-	// use TestCtx's create helper to create the object and add a cleanup function for the new object
-	err = f.Client.Create(goctx.TODO(), exampleComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-	if err != nil {
-		return err
-	}
-	return waitForScanStatus(t, f, namespace, "example-scan", complianceoperatorv1alpha1.PhaseDone)
+	executeTest(t, func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+		exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-scan",
+				Namespace: namespace,
+			},
+			Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
+				Profile: "xccdf_org.ssgproject.content_profile_coreos-ncp",
+				Content: "ssg-ocp4-ds.xml",
+			},
+		}
+		// use TestCtx's create helper to create the object and add a cleanup function for the new object
+		err := f.Client.Create(goctx.TODO(), exampleComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+		if err != nil {
+			return err
+		}
+		return waitForScanStatus(t, f, namespace, "example-scan", complianceoperatorv1alpha1.PhaseDone)
+	})
 }
 
 func TestScanWithInvalidContentFails(t *testing.T) {
 	t.Skip("NOTE(jaosorior): We're skipping this test until we get CI to use the current built image.")
-	ctx := setupTestRequirements(t)
-	defer ctx.Cleanup()
-
-	setupComplianceOperatorCluster(t, ctx)
-
-	// get global framework variables
-	f := framework.Global
-
-	if err := doScanWithInvalidContentFails(t, f, ctx); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func doScanWithInvalidContentFails(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		return fmt.Errorf("could not get namespace: %v", err)
-	}
-	exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-scan",
-			Namespace: namespace,
-		},
-		Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
-			Profile: "xccdf_org.ssgproject.content_profile_coreos-ncp",
-			Content: "ssg-ocp4-non-existent.xml",
-		},
-	}
-	// use TestCtx's create helper to create the object and add a cleanup function for the new object
-	err = f.Client.Create(goctx.TODO(), exampleComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-	if err != nil {
-		return err
-	}
-	return waitForScanStatus(t, f, namespace, "example-scan", complianceoperatorv1alpha1.PhaseDone)
+	executeTest(t, func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+		exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-scan",
+				Namespace: namespace,
+			},
+			Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
+				Profile: "xccdf_org.ssgproject.content_profile_coreos-ncp",
+				Content: "ssg-ocp4-non-existent.xml",
+			},
+		}
+		// use TestCtx's create helper to create the object and add a cleanup function for the new object
+		err := f.Client.Create(goctx.TODO(), exampleComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+		if err != nil {
+			return err
+		}
+		return waitForScanStatus(t, f, namespace, "example-scan", complianceoperatorv1alpha1.PhaseDone)
+	})
 }

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -14,6 +14,30 @@ import (
 	complianceoperatorv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/complianceoperator/v1alpha1"
 )
 
+// executeTest sets up everything that a e2e test needs to run, and executes the test.
+func executeTest(t *testing.T, doTestFn func(*testing.T, *framework.Framework, *framework.TestCtx, string) error) {
+	ctx := setupTestRequirements(t)
+	defer ctx.Cleanup()
+
+	setupComplianceOperatorCluster(t, ctx)
+
+	// get global framework variables
+	f := framework.Global
+
+	ns, err := ctx.GetNamespace()
+	if err != nil {
+		t.Fatalf("could not get namespace: %v", err)
+	}
+
+	if err := doTestFn(t, f, ctx, ns); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// setupTestRequirements Adds the items to the client's schema (So we can use our objects in the client)
+// and creates a test context.
+//
+// NOTE: Whenever we add new types to the operator, we need to register them here for the e2e tests.
 func setupTestRequirements(t *testing.T) *framework.TestCtx {
 	compliancescan := &complianceoperatorv1alpha1.ComplianceScanList{}
 	err := framework.AddToFrameworkScheme(apis.AddToScheme, compliancescan)
@@ -23,6 +47,8 @@ func setupTestRequirements(t *testing.T) *framework.TestCtx {
 	return framework.NewTestCtx(t)
 }
 
+// setupComplianceOperatorCluster creates a compliance-operator cluster and the resources it needs to operate
+// such as the namespace, permissions, etc.
 func setupComplianceOperatorCluster(t *testing.T, ctx *framework.TestCtx) {
 	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
@@ -42,6 +68,8 @@ func setupComplianceOperatorCluster(t *testing.T, ctx *framework.TestCtx) {
 	}
 }
 
+// waitForScanStatus will poll until the compliancescan that we're lookingfor reaches a certain status, or until
+// a timeout is reached.
 func waitForScanStatus(t *testing.T, f *framework.Framework, namespace, name string, targetStaus complianceoperatorv1alpha1.ComplianceScanStatusPhase) error {
 	exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{}
 	var lastErr error


### PR DESCRIPTION
This wraps the e2e functions in order to hide the setup and focus on
readability of the tests.

It also adds documentation for the helper functions.