### PR TITLE
e2e: Test ComplianceScan filtered with nodeSelector

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	goctx "context"
+	"fmt"
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
@@ -28,6 +29,42 @@ func TestSingleScanSucceeds(t *testing.T) {
 			return err
 		}
 		return waitForScanStatus(t, f, namespace, "example-scan", complianceoperatorv1alpha1.PhaseDone)
+	})
+}
+
+func TestScanWithNodeSelectorFiltersCorrectly(t *testing.T) {
+	executeTest(t, func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+		selectWorkers := map[string]string{
+			"node-role.kubernetes.io/worker": "",
+		}
+		testComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-filtered-scan",
+				Namespace: namespace,
+			},
+			Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
+				Profile:      "xccdf_org.ssgproject.content_profile_coreos-ncp",
+				Content:      "ssg-ocp4-ds.xml",
+				NodeSelector: selectWorkers,
+			},
+		}
+		// use TestCtx's create helper to create the object and add a cleanup function for the new object
+		err := f.Client.Create(goctx.TODO(), testComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+		if err != nil {
+			return err
+		}
+		err = waitForScanStatus(t, f, namespace, "test-filtered-scan", complianceoperatorv1alpha1.PhaseDone)
+		if err != nil {
+			return err
+		}
+		nodes := getNodesWithSelector(f, selectWorkers)
+		configmaps := getConfigMapsFromScan(f, testComplianceScan)
+		if len(nodes) != len(configmaps) {
+			return fmt.Errorf(
+				"The number of reports doesn't match the number of selected nodes: "+
+					"%d reports / %d nodes", len(configmaps), len(nodes))
+		}
+		return nil
 	})
 }
 


### PR DESCRIPTION
Adds an e2e test that filters the compliance scan with a node selector. The test checks that the number of generated configmaps are the same as the number of nodes that are selected with the filter (in this case, the worker nodes).