### PR TITLE
Add compliance scan result to status

### DIFF
--- a/deploy/crds/complianceoperator.compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/complianceoperator.compliance.openshift.io_compliancescans_crd.yaml
@@ -34,10 +34,6 @@ spec:
             content:
               type: string
             contentImage:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: string
             nodeSelector:
               additionalProperties:
@@ -51,11 +47,13 @@ spec:
         status:
           description: ComplianceScanStatus defines the observed state of ComplianceScan
           properties:
+            errormsg:
+              type: string
             phase:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "operator-sdk generate k8s" to regenerate
-                code after modifying this file Add custom validation using kubebuilder
-                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              description: Represents the status of the compliance scan run.
+              type: string
+            result:
+              description: Represents the result of the compliance scan
               type: string
           type: object
       type: object

--- a/pkg/apis/complianceoperator/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/complianceoperator/v1alpha1/compliancescan_types.go
@@ -6,7 +6,7 @@ import (
 
 // +genclient
 
-// ComplianceScanStatusPhase represents the status of the compliancescan run.
+// Represents the status of the compliance scan run.
 type ComplianceScanStatusPhase string
 
 const (
@@ -18,6 +18,18 @@ const (
 	PhaseRunning ComplianceScanStatusPhase = "RUNNING"
 	// PhaseDone represents the scan pods being done and the results being available
 	PhaseDone ComplianceScanStatusPhase = "DONE"
+)
+
+// Represents the result of the compliance scan
+type ComplianceScanStatusResult string
+
+const (
+	// ResultCompliant represents the compliance scan having succeeded
+	ResultCompliant ComplianceScanStatusResult = "COMPLIANT"
+	// ResultError represents a compliance scan pod having failed to run the scan or encountered an error
+	ResultError ComplianceScanStatusResult = "ERROR"
+	// ResultNonCompliant represents the compliance scan having found a gap
+	ResultNonCompliant ComplianceScanStatusResult = "NON-COMPLIANT"
 )
 
 // ComplianceScanSpec defines the desired state of ComplianceScan
@@ -33,7 +45,9 @@ type ComplianceScanSpec struct {
 // ComplianceScanStatus defines the observed state of ComplianceScan
 // +k8s:openapi-gen=true
 type ComplianceScanStatus struct {
-	Phase ComplianceScanStatusPhase `json:"phase,omitempty"`
+	Phase        ComplianceScanStatusPhase  `json:"phase,omitempty"`
+	Result       ComplianceScanStatusResult `json:"result,omitempty"`
+	ErrorMessage string                     `json:"errormsg,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/complianceoperator/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/complianceoperator/v1alpha1/compliancescan_types.go
@@ -6,21 +6,23 @@ import (
 
 // +genclient
 
+// ComplianceScanStatusPhase represents the status of the compliancescan run.
 type ComplianceScanStatusPhase string
 
 const (
-	PhasePending   ComplianceScanStatusPhase = "PENDING"
+	// PhasePending represents the scan pending to be scheduled
+	PhasePending ComplianceScanStatusPhase = "PENDING"
+	// PhaseLaunching represents being scheduled and launching pods to run the scans
 	PhaseLaunching ComplianceScanStatusPhase = "LAUNCHING"
-	PhaseRunning   ComplianceScanStatusPhase = "RUNNING"
-	PhaseDone      ComplianceScanStatusPhase = "DONE"
+	// PhaseRunning represents the scan being ran by the pods and waiting for the results
+	PhaseRunning ComplianceScanStatusPhase = "RUNNING"
+	// PhaseDone represents the scan pods being done and the results being available
+	PhaseDone ComplianceScanStatusPhase = "DONE"
 )
 
 // ComplianceScanSpec defines the desired state of ComplianceScan
 // +k8s:openapi-gen=true
 type ComplianceScanSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 	ContentImage string            `json:"contentImage,omitempty"`
 	Profile      string            `json:"profile,omitempty"`
 	Rule         string            `json:"rule,omitempty"`
@@ -31,9 +33,6 @@ type ComplianceScanSpec struct {
 // ComplianceScanStatus defines the observed state of ComplianceScan
 // +k8s:openapi-gen=true
 type ComplianceScanStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 	Phase ComplianceScanStatusPhase `json:"phase,omitempty"`
 }
 

--- a/pkg/apis/complianceoperator/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/complianceoperator/v1alpha1/zz_generated.openapi.go
@@ -70,9 +70,8 @@ func schema_pkg_apis_complianceoperator_v1alpha1_ComplianceScanSpec(ref common.R
 				Properties: map[string]spec.Schema{
 					"contentImage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run \"operator-sdk generate k8s\" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html",
-							Type:        []string{"string"},
-							Format:      "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"profile": {
@@ -122,9 +121,20 @@ func schema_pkg_apis_complianceoperator_v1alpha1_ComplianceScanStatus(ref common
 				Properties: map[string]spec.Schema{
 					"phase": {
 						SchemaProps: spec.SchemaProps{
-							Description: "INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run \"operator-sdk generate k8s\" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html",
-							Type:        []string{"string"},
-							Format:      "",
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"result": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"errormsg": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -31,7 +31,12 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				return waitForScanStatus(t, f, namespace, "test-single-scan", complianceoperatorv1alpha1.PhaseDone)
+				err = waitForScanStatus(t, f, namespace, "test-single-scan", complianceoperatorv1alpha1.PhaseDone)
+				if err != nil {
+					return err
+				}
+
+				return scanResultIsExpected(t, f, namespace, "test-single-scan", complianceoperatorv1alpha1.ResultCompliant)
 			},
 		},
 		testExecution{
@@ -67,7 +72,7 @@ func TestE2E(t *testing.T) {
 						"The number of reports doesn't match the number of selected nodes: "+
 							"%d reports / %d nodes", len(configmaps), len(nodes))
 				}
-				return nil
+				return scanResultIsExpected(t, f, namespace, "test-filtered-scan", complianceoperatorv1alpha1.ResultCompliant)
 			},
 		},
 		testExecution{
@@ -88,7 +93,11 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				return waitForScanStatus(t, f, namespace, "test-scan-w-invalid-content", complianceoperatorv1alpha1.PhaseDone)
+				err = waitForScanStatus(t, f, namespace, "test-scan-w-invalid-content", complianceoperatorv1alpha1.PhaseDone)
+				if err != nil {
+					return err
+				}
+				return scanResultIsExpected(t, f, namespace, "test-scan-w-invalid-content", complianceoperatorv1alpha1.ResultError)
 			},
 		},
 		testExecution{
@@ -109,7 +118,11 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				return waitForScanStatus(t, f, namespace, "test-scan-w-invalid-profile", complianceoperatorv1alpha1.PhaseDone)
+				err = waitForScanStatus(t, f, namespace, "test-scan-w-invalid-profile", complianceoperatorv1alpha1.PhaseDone)
+				if err != nil {
+					return err
+				}
+				return scanResultIsExpected(t, f, namespace, "test-scan-w-invalid-profile", complianceoperatorv1alpha1.ResultError)
 			},
 		},
 	)

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	goctx "context"
+	"fmt"
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
@@ -113,6 +114,18 @@ func waitForScanStatus(t *testing.T, f *framework.Framework, namespace, name str
 		return timeouterr
 	}
 	t.Logf("ComplianceScan ready (%s)\n", exampleComplianceScan.Status.Phase)
+	return nil
+}
+
+func scanResultIsExpected(t *testing.T, f *framework.Framework, namespace, name string, expectedResult complianceoperatorv1alpha1.ComplianceScanStatusResult) error {
+	cs := &complianceoperatorv1alpha1.ComplianceScan{}
+	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, cs)
+	if err != nil {
+		return err
+	}
+	if cs.Status.Result != expectedResult {
+		return fmt.Errorf("The ComplianceScan Result wasn't what we expected. Got '%s', expected '%s'", cs.Status.Result, expectedResult)
+	}
 	return nil
 }
 


### PR DESCRIPTION
The result represents the result of the OpenSCAP scan. Which can be:
    
* non-compliance
* error
* compliant
    
This adds this as an extra value to the Status in the CRD.