### PR TITLE
Re-use same operator cluster to run e2e tests

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -11,101 +11,106 @@ import (
 	complianceoperatorv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/complianceoperator/v1alpha1"
 )
 
-func TestSingleScanSucceeds(t *testing.T) {
-	executeTest(t, func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
-		exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "example-scan",
-				Namespace: namespace,
+func TestE2E(t *testing.T) {
+	executeTests(t,
+		testExecution{
+			Name: "TestSingleScanSucceeds",
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+				exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-single-scan",
+						Namespace: namespace,
+					},
+					Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
+						Profile: "xccdf_org.ssgproject.content_profile_coreos-ncp",
+						Content: "ssg-ocp4-ds.xml",
+					},
+				}
+				// use TestCtx's create helper to create the object and add a cleanup function for the new object
+				err := f.Client.Create(goctx.TODO(), exampleComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+				if err != nil {
+					return err
+				}
+				return waitForScanStatus(t, f, namespace, "test-single-scan", complianceoperatorv1alpha1.PhaseDone)
 			},
-			Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
-				Profile: "xccdf_org.ssgproject.content_profile_coreos-ncp",
-				Content: "ssg-ocp4-ds.xml",
+		},
+		testExecution{
+			Name: "TestScanWithNodeSelectorFiltersCorrectly",
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+				selectWorkers := map[string]string{
+					"node-role.kubernetes.io/worker": "",
+				}
+				testComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-filtered-scan",
+						Namespace: namespace,
+					},
+					Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
+						Profile:      "xccdf_org.ssgproject.content_profile_coreos-ncp",
+						Content:      "ssg-ocp4-ds.xml",
+						NodeSelector: selectWorkers,
+					},
+				}
+				// use TestCtx's create helper to create the object and add a cleanup function for the new object
+				err := f.Client.Create(goctx.TODO(), testComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+				if err != nil {
+					return err
+				}
+				err = waitForScanStatus(t, f, namespace, "test-filtered-scan", complianceoperatorv1alpha1.PhaseDone)
+				if err != nil {
+					return err
+				}
+				nodes := getNodesWithSelector(f, selectWorkers)
+				configmaps := getConfigMapsFromScan(f, testComplianceScan)
+				if len(nodes) != len(configmaps) {
+					return fmt.Errorf(
+						"The number of reports doesn't match the number of selected nodes: "+
+							"%d reports / %d nodes", len(configmaps), len(nodes))
+				}
+				return nil
 			},
-		}
-		// use TestCtx's create helper to create the object and add a cleanup function for the new object
-		err := f.Client.Create(goctx.TODO(), exampleComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-		if err != nil {
-			return err
-		}
-		return waitForScanStatus(t, f, namespace, "example-scan", complianceoperatorv1alpha1.PhaseDone)
-	})
-}
-
-func TestScanWithNodeSelectorFiltersCorrectly(t *testing.T) {
-	executeTest(t, func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
-		selectWorkers := map[string]string{
-			"node-role.kubernetes.io/worker": "",
-		}
-		testComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-filtered-scan",
-				Namespace: namespace,
+		},
+		testExecution{
+			Name: "TestScanWithInvalidContentFails",
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+				exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-scan-w-invalid-content",
+						Namespace: namespace,
+					},
+					Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
+						Profile: "xccdf_org.ssgproject.content_profile_coreos-ncp",
+						Content: "ssg-ocp4-non-existent.xml",
+					},
+				}
+				// use TestCtx's create helper to create the object and add a cleanup function for the new object
+				err := f.Client.Create(goctx.TODO(), exampleComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+				if err != nil {
+					return err
+				}
+				return waitForScanStatus(t, f, namespace, "test-scan-w-invalid-content", complianceoperatorv1alpha1.PhaseDone)
 			},
-			Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
-				Profile:      "xccdf_org.ssgproject.content_profile_coreos-ncp",
-				Content:      "ssg-ocp4-ds.xml",
-				NodeSelector: selectWorkers,
+		},
+		testExecution{
+			Name: "TestScanWithInvalidProfileFails",
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+				exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-scan-w-invalid-profile",
+						Namespace: namespace,
+					},
+					Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
+						Profile: "xccdf_org.ssgproject.content_profile_coreos-unexistent",
+						Content: "ssg-ocp4-ds.xml",
+					},
+				}
+				// use TestCtx's create helper to create the object and add a cleanup function for the new object
+				err := f.Client.Create(goctx.TODO(), exampleComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+				if err != nil {
+					return err
+				}
+				return waitForScanStatus(t, f, namespace, "test-scan-w-invalid-profile", complianceoperatorv1alpha1.PhaseDone)
 			},
-		}
-		// use TestCtx's create helper to create the object and add a cleanup function for the new object
-		err := f.Client.Create(goctx.TODO(), testComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-		if err != nil {
-			return err
-		}
-		err = waitForScanStatus(t, f, namespace, "test-filtered-scan", complianceoperatorv1alpha1.PhaseDone)
-		if err != nil {
-			return err
-		}
-		nodes := getNodesWithSelector(f, selectWorkers)
-		configmaps := getConfigMapsFromScan(f, testComplianceScan)
-		if len(nodes) != len(configmaps) {
-			return fmt.Errorf(
-				"The number of reports doesn't match the number of selected nodes: "+
-					"%d reports / %d nodes", len(configmaps), len(nodes))
-		}
-		return nil
-	})
-}
-
-func TestScanWithInvalidContentFails(t *testing.T) {
-	executeTest(t, func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
-		exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "example-scan",
-				Namespace: namespace,
-			},
-			Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
-				Profile: "xccdf_org.ssgproject.content_profile_coreos-ncp",
-				Content: "ssg-ocp4-non-existent.xml",
-			},
-		}
-		// use TestCtx's create helper to create the object and add a cleanup function for the new object
-		err := f.Client.Create(goctx.TODO(), exampleComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-		if err != nil {
-			return err
-		}
-		return waitForScanStatus(t, f, namespace, "example-scan", complianceoperatorv1alpha1.PhaseDone)
-	})
-}
-
-func TestScanWithInvalidProfileFails(t *testing.T) {
-	executeTest(t, func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
-		exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "example-scan",
-				Namespace: namespace,
-			},
-			Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
-				Profile: "xccdf_org.ssgproject.content_profile_coreos-unexistent",
-				Content: "ssg-ocp4-ds.xml",
-			},
-		}
-		// use TestCtx's create helper to create the object and add a cleanup function for the new object
-		err := f.Client.Create(goctx.TODO(), exampleComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-		if err != nil {
-			return err
-		}
-		return waitForScanStatus(t, f, namespace, "example-scan", complianceoperatorv1alpha1.PhaseDone)
-	})
+		},
+	)
 }


### PR DESCRIPTION
This tries to optimize the e2e test run by using the same operator for
each test run, instead of tearing everything up and down with each test.

This takes the form of wrapping each test to run the setup and teardown
as part of the helper code, and creating a structure to define the tests
in.