### PR TITLE
Ecplicitly export needed go environment files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ TEST_OPTIONS?=
 E2E_SKIP_CONTAINER_PUSH?=false
 
 .PHONY: all
-all: build verify test-unit ## Test and Build the compliance-operator
+all: build ## Test and Build the compliance-operator
 
 .PHONY: help
 help: ## Show this help screen


### PR DESCRIPTION
We can't set them via `go env -w` nor by passing the command before the
`go` command.