### PR TITLE
WIP: Use the go 1.13 builder container image

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Step one: build compliance-operator
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
 
 WORKDIR /go/src/github.com/openshift/compliance-operator
 


### PR DESCRIPTION
We're using 1.12 cause at the time of creation we didn't have it available. Lets try to switch!