### PR TITLE
While in RUNNING state Return to LAUNCHING state if pod is mising

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -3,10 +3,12 @@ package e2e
 import (
 	goctx "context"
 	"fmt"
+	"math/rand"
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	complianceoperatorv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/complianceoperator/v1alpha1"
 )
@@ -123,6 +125,51 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 				return scanResultIsExpected(t, f, namespace, "test-scan-w-invalid-profile", complianceoperatorv1alpha1.ResultError)
+			},
+		},
+		testExecution{
+			Name: "TestMissingPodInRunningState",
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+				exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-missing-pod-scan",
+						Namespace: namespace,
+					},
+					Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
+						Profile: "xccdf_org.ssgproject.content_profile_coreos-ncp",
+						Content: "ssg-ocp4-ds.xml",
+					},
+				}
+				// use TestCtx's create helper to create the object and add a cleanup function for the new object
+				err := f.Client.Create(goctx.TODO(), exampleComplianceScan, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+				if err != nil {
+					return err
+				}
+				err = waitForScanStatus(t, f, namespace, "test-missing-pod-scan", complianceoperatorv1alpha1.PhaseRunning)
+				if err != nil {
+					return err
+				}
+				pods, err := getPodsForScan(f, namespace, "test-missing-pod-scan")
+				if err != nil {
+					return err
+				}
+				if len(pods) < 1 {
+					return fmt.Errorf("No pods gotten from query for the scan")
+				}
+				podToDelete := pods[rand.Intn(len(pods))]
+				// Delete pod ASAP
+				zeroSeconds := int64(0)
+				do := client.DeleteOptions{GracePeriodSeconds: &zeroSeconds}
+				err = f.Client.Delete(goctx.TODO(), &podToDelete, &do)
+				if err != nil {
+					return err
+				}
+				err = waitForScanStatus(t, f, namespace, "test-missing-pod-scan", complianceoperatorv1alpha1.PhaseDone)
+				if err != nil {
+					return err
+				}
+
+				return scanResultIsExpected(t, f, namespace, "test-missing-pod-scan", complianceoperatorv1alpha1.ResultCompliant)
 			},
 		},
 	)

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -139,6 +139,21 @@ func getNodesWithSelector(f *framework.Framework, labelselector map[string]strin
 	return nodes.Items
 }
 
+func getPodsForScan(f *framework.Framework, namespace, scanName string) ([]corev1.Pod, error) {
+	selectPods := map[string]string{
+		"complianceScan": scanName,
+	}
+	var pods corev1.PodList
+	lo := &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(selectPods),
+	}
+	err := f.Client.List(goctx.TODO(), &pods, lo)
+	if err != nil {
+		return nil, err
+	}
+	return pods.Items, nil
+}
+
 // getConfigMapsFromScan lists the configmaps from the specified openscap scan instance
 func getConfigMapsFromScan(f *framework.Framework, scaninstance *complianceoperatorv1alpha1.ComplianceScan) []corev1.ConfigMap {
 	var configmaps corev1.ConfigMapList


### PR DESCRIPTION
This will effectively attempt to launch the pods again if a pod is
missing. This ensures that all the nodes get a pod be scanned.