### PR TITLE
Do Makefile `all` target only build the code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ TEST_OPTIONS?=
 E2E_SKIP_CONTAINER_PUSH?=false
 
 .PHONY: all
-all: build verify test-unit ## Test and Build the compliance-operator
+all: build ## Test and Build the compliance-operator
 
 .PHONY: help
 help: ## Show this help screen


### PR DESCRIPTION
Currently the `all` target will build, verify and run the unit tests for
the project. We probably don't want that, since we use this target for
the go-build test. So lets make it only do builds.

We already have other tests that run the unit tests and verifications.