### PR TITLE
Two trivial patches

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -38,7 +38,7 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
-				return scanResultIsExpected(t, f, namespace, "test-single-scan", complianceoperatorv1alpha1.ResultCompliant)
+				return scanResultIsExpected(f, namespace, "test-single-scan", complianceoperatorv1alpha1.ResultCompliant)
 			},
 		},
 		testExecution{
@@ -74,7 +74,7 @@ func TestE2E(t *testing.T) {
 						"The number of reports doesn't match the number of selected nodes: "+
 							"%d reports / %d nodes", len(configmaps), len(nodes))
 				}
-				return scanResultIsExpected(t, f, namespace, "test-filtered-scan", complianceoperatorv1alpha1.ResultCompliant)
+				return scanResultIsExpected(f, namespace, "test-filtered-scan", complianceoperatorv1alpha1.ResultCompliant)
 			},
 		},
 		testExecution{
@@ -99,7 +99,7 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				return scanResultIsExpected(t, f, namespace, "test-scan-w-invalid-content", complianceoperatorv1alpha1.ResultError)
+				return scanResultIsExpected(f, namespace, "test-scan-w-invalid-content", complianceoperatorv1alpha1.ResultError)
 			},
 		},
 		testExecution{
@@ -124,7 +124,7 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				return scanResultIsExpected(t, f, namespace, "test-scan-w-invalid-profile", complianceoperatorv1alpha1.ResultError)
+				return scanResultIsExpected(f, namespace, "test-scan-w-invalid-profile", complianceoperatorv1alpha1.ResultError)
 			},
 		},
 		testExecution{
@@ -149,7 +149,7 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				pods, err := getPodsForScan(f, namespace, "test-missing-pod-scan")
+				pods, err := getPodsForScan(f, "test-missing-pod-scan")
 				if err != nil {
 					return err
 				}
@@ -169,7 +169,7 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
-				return scanResultIsExpected(t, f, namespace, "test-missing-pod-scan", complianceoperatorv1alpha1.ResultCompliant)
+				return scanResultIsExpected(f, namespace, "test-missing-pod-scan", complianceoperatorv1alpha1.ResultCompliant)
 			},
 		},
 	)

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -84,7 +84,7 @@ func setupComplianceOperatorCluster(t *testing.T, ctx *framework.TestCtx) {
 
 // waitForScanStatus will poll until the compliancescan that we're lookingfor reaches a certain status, or until
 // a timeout is reached.
-func waitForScanStatus(t *testing.T, f *framework.Framework, namespace, name string, targetStaus complianceoperatorv1alpha1.ComplianceScanStatusPhase) error {
+func waitForScanStatus(t *testing.T, f *framework.Framework, namespace, name string, targetStatus complianceoperatorv1alpha1.ComplianceScanStatusPhase) error {
 	exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{}
 	var lastErr error
 	// retry and ignore errors until timeout
@@ -99,7 +99,7 @@ func waitForScanStatus(t *testing.T, f *framework.Framework, namespace, name str
 			return false, nil
 		}
 
-		if exampleComplianceScan.Status.Phase == targetStaus {
+		if exampleComplianceScan.Status.Phase == targetStatus {
 			return true, nil
 		}
 		t.Logf("Waiting for run of %s compliancescan (%s)\n", name, exampleComplianceScan.Status.Phase)

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -117,7 +117,7 @@ func waitForScanStatus(t *testing.T, f *framework.Framework, namespace, name str
 	return nil
 }
 
-func scanResultIsExpected(t *testing.T, f *framework.Framework, namespace, name string, expectedResult complianceoperatorv1alpha1.ComplianceScanStatusResult) error {
+func scanResultIsExpected(f *framework.Framework, namespace, name string, expectedResult complianceoperatorv1alpha1.ComplianceScanStatusResult) error {
 	cs := &complianceoperatorv1alpha1.ComplianceScan{}
 	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, cs)
 	if err != nil {
@@ -139,7 +139,7 @@ func getNodesWithSelector(f *framework.Framework, labelselector map[string]strin
 	return nodes.Items
 }
 
-func getPodsForScan(f *framework.Framework, namespace, scanName string) ([]corev1.Pod, error) {
+func getPodsForScan(f *framework.Framework, scanName string) ([]corev1.Pod, error) {
 	selectPods := map[string]string{
 		"complianceScan": scanName,
 	}


### PR DESCRIPTION
Found while working on the compliance remediation e2e tests. One fixes a
variable name and the other removes unused parameters of our helper funcions.