### PR TITLE
Create e2e-local makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,9 @@ endif
 	@echo "Running e2e tests"
 	unset GOFLAGS && $(GOPATH)/bin/operator-sdk test local ./tests/e2e --image "$(IMAGE_PATH)" --namespace "$(NAMESPACE)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
 
+e2e-local: operator-sdk ## Run the end-to-end tests on a locally running operator (e.g. using make run)
+	unset GOFLAGS && $(GOPATH)/bin/operator-sdk test local ./tests/e2e --up-local --image "$(IMAGE_PATH)" --namespace "$(NAMESPACE)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
+
 # This checks if we're in a CI environment by checking the IMAGE_FORMAT
 # environmnet variable. if we are, lets ues the image from CI and use this
 # operator as the component.


### PR DESCRIPTION
This target allows you to run the end-to-end tests against a locally
running compliance-operator.

For instance, in one terminal you'll be running:

    make run

and in another one you can run

    make e2e-local

This will run the tests without pushing an image to the cluster, and
use the local operator.