### PR TITLE
Add missing permissions to make service monitor work

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -55,6 +55,30 @@ rules:
   - deployments/finalizers
   verbs:
   - update
+- apiGroups:
+  - ""
+  resources:
+  - services    # Services is the way we provide metrics for the operator
+  - services/finalizers
+  verbs:
+  - create      # The operator needs to create a service to expose the metrics
+  - get
+  - update
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - "get"
+  - "create"
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  resourceNames:
+  - compliance-operator
+  verbs:
+  - "update"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
These are needed to get the service monitor/prometheus integration
working. The errors we were seeing in the cluster were the following:

    {"level":"info","ts":1576249372.479048,"logger":"cmd","msg":"Could not create metrics Service","error":"failed to create or get service for metrics: services is forbidden: User \"system:serviceaccount:openshift-compliance:compliance-operator\" cannot create resource \"services\" in API group \"\" in the namespace \"openshift-compliance\""}

Subsequently, after adding the permissoin to create services,
we get the following error:

    {"level":"info","ts":1576254975.3094187,"logger":"cmd","msg":"Could not create ServiceMonitor object","error":"servicemonitors.monitoring.coreos.com is forbidden: User \"system:serviceaccount:openshift-compliance:compliance-operator\" cannot create resource \"servicemonitors\" in API group \"monitoring.coreos.com\" in the namespace \"openshift-compliance\""}

Finally... we need to allow finalizers to be set:

    {"level":"info","ts":1576257007.6144686,"logger":"cmd","msg":"Could not create ServiceMonitor object","error":"servicemonitors.monitoring.coreos.com \"compliance-operator-metrics\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}

With this it should work!