### PR TITLE
Add interface for non-retriable errors

### DIFF
--- a/pkg/controller/common/errors.go
+++ b/pkg/controller/common/errors.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// NonRetriableCtrlError wraps errors with the addition of having
+// the information for the error being non-retriable
+type NonRetriableCtrlError struct {
+	err      error
+	canRetry bool
+}
+
+func (cerr NonRetriableCtrlError) Error() string {
+	return cerr.err.Error()
+}
+
+// blank assignment to verify that RetriableCtrlError implements error
+var _ error = &NonRetriableCtrlError{}
+
+// IsRetriable exposes if the error is retriable or not
+func (cerr NonRetriableCtrlError) IsRetriable() bool {
+	return cerr.canRetry
+}
+
+// WrapNonRetriableCtrlError wraps an error with the RetriableCtrlError interface
+func WrapNonRetriableCtrlError(err error) *NonRetriableCtrlError {
+	return &NonRetriableCtrlError{
+		canRetry: false,
+		err:      err,
+	}
+}
+
+// IsRetriable returns whether the error is retriable or not using the
+// NonRetriableCtrlError interface
+func IsRetriable(err error) bool {
+	ccErr, ok := err.(*NonRetriableCtrlError)
+	if ok {
+		return ccErr.IsRetriable()
+	}
+	return true
+}
+
+// ReturnWithRetriableError will check if the error is retriable we return it.
+// If it's not retriable, we return nil so the reconciler doesn't keep looping.
+func ReturnWithRetriableError(log logr.Logger, err error) (reconcile.Result, error) {
+	if IsRetriable(err) {
+		log.Error(err, "Retriable error")
+		return reconcile.Result{}, err
+	}
+	log.Error(err, "Non-retriable error")
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/common/errors_suite_test.go
+++ b/pkg/controller/common/errors_suite_test.go
@@ -1,0 +1,13 @@
+package common_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common Suite")
+}

--- a/pkg/controller/common/errors_test.go
+++ b/pkg/controller/common/errors_test.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+)
+
+var _ = Describe("NonRetriable error wrapper", func() {
+	var logger logr.Logger
+	BeforeEach(func() {
+		logger = zapr.NewLogger(zap.NewNop())
+	})
+
+	Context("With a non-wrapped error", func() {
+		var err error
+		BeforeEach(func() {
+			err = fmt.Errorf("Some error")
+		})
+
+		It("Should be considered retriable", func() {
+			Expect(IsRetriable(err)).To(BeTrue())
+		})
+
+		It("Should return the error", func() {
+			_, retriableErr := ReturnWithRetriableError(logger, err)
+			Expect(retriableErr).To(Not(BeNil()))
+		})
+	})
+
+	Context("With a wrapped error", func() {
+		var err error
+		BeforeEach(func() {
+			err = WrapNonRetriableCtrlError(fmt.Errorf("Some error"))
+		})
+
+		It("Should output the same wrapped error", func() {
+			Expect(err.Error()).To(Equal("Some error"))
+		})
+
+		It("Should be not considered retriable", func() {
+			Expect(IsRetriable(err)).To(BeFalse())
+		})
+
+		It("Should not return the error", func() {
+			_, retriableErr := ReturnWithRetriableError(logger, err)
+			Expect(retriableErr).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
This creates an error wrapper called `NonRetriableCtrlError` which
represents an error that's fatal and should not be retried on the
controller.

This changes the logic in the controllers to use this specific
NonRetriableCtrlError as opposed to the wrapper that was implemented
originally.

It also adds the logic of retry/no-retry for errors in the
compliancesuite controller.