### PR TITLE
Two fixes in e2e tests so that we can fix our scanner image

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -231,12 +231,28 @@ func TestE2E(t *testing.T) {
 				}
 
 				// At this point, both scans should be non-compliant given our current content
-				scanResultIsExpected(f, namespace, workerScanName, complianceoperatorv1alpha1.ResultNonCompliant)
-				scanResultIsExpected(f, namespace, masterScanName, complianceoperatorv1alpha1.ResultNonCompliant)
+				err = scanResultIsExpected(f, namespace, workerScanName, complianceoperatorv1alpha1.ResultNonCompliant)
+				if err != nil {
+					return err
+				}
+
+				err = scanResultIsExpected(f, namespace, masterScanName, complianceoperatorv1alpha1.ResultNonCompliant)
+				if err != nil {
+					return err
+				}
+
 
 				// Each scan should produce two remediations
-				assertNumRemediations(f, suiteName, workerScanName, "worker", 2)
-				assertNumRemediations(f, suiteName, masterScanName, "master", 2)
+				err = assertNumRemediations(f, suiteName, workerScanName, "worker", 2)
+				if err != nil {
+					return err
+				}
+
+				err = assertNumRemediations(f, suiteName, masterScanName, "master", 2)
+				if err != nil {
+					return err
+				}
+
 
 				return nil
 			},

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -26,6 +26,7 @@ func TestE2E(t *testing.T) {
 					Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
 						Profile: "xccdf_org.ssgproject.content_profile_coreos-ncp",
 						Content: "ssg-ocp4-ds.xml",
+						Rule:	 "xccdf_org.ssgproject.content_rule_no_netrc_files",
 					},
 				}
 				// use TestCtx's create helper to create the object and add a cleanup function for the new object
@@ -55,6 +56,7 @@ func TestE2E(t *testing.T) {
 					Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
 						Profile:      "xccdf_org.ssgproject.content_profile_coreos-ncp",
 						Content:      "ssg-ocp4-ds.xml",
+						Rule:	 	  "xccdf_org.ssgproject.content_rule_no_netrc_files",
 						NodeSelector: selectWorkers,
 					},
 				}
@@ -138,6 +140,7 @@ func TestE2E(t *testing.T) {
 					Spec: complianceoperatorv1alpha1.ComplianceScanSpec{
 						Profile: "xccdf_org.ssgproject.content_profile_coreos-ncp",
 						Content: "ssg-ocp4-ds.xml",
+						Rule:	 "xccdf_org.ssgproject.content_rule_no_netrc_files",
 					},
 				}
 				// use TestCtx's create helper to create the object and add a cleanup function for the new object

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -241,14 +241,21 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
-
 				// Each scan should produce two remediations
-				err = assertNumRemediations(f, suiteName, workerScanName, "worker", 2)
+				workerRemediations := []string {
+					fmt.Sprintf("%s-no-empty-passwords", workerScanName),
+					fmt.Sprintf("%s-no-direct-root-logins", workerScanName),
+				}
+				err = assertHasRemediations(f, suiteName, workerScanName, "worker",  workerRemediations)
 				if err != nil {
 					return err
 				}
 
-				err = assertNumRemediations(f, suiteName, masterScanName, "master", 2)
+				masterRemediations := []string {
+					fmt.Sprintf("%s-no-empty-passwords", masterScanName),
+					fmt.Sprintf("%s-no-direct-root-logins", masterScanName),
+				}
+				err = assertHasRemediations(f, suiteName, masterScanName, "master", masterRemediations)
 				if err != nil {
 					return err
 				}

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -242,10 +242,19 @@ func getRemediationsFromScan(f *framework.Framework, suiteName, scanName string)
 	return scanSuiteRemediations.Items
 }
 
-func assertNumRemediations(f *framework.Framework, suiteName, scanName, roleLabel string, expRemediations int) error {
+func assertHasRemediations(f *framework.Framework, suiteName, scanName, roleLabel string, remNameList []string) error {
+	var scanSuiteMapNames = make(map[string]bool)
+
 	scanSuiteRemediations := getRemediationsFromScan(f, suiteName, scanName)
-	if len(scanSuiteRemediations) != expRemediations {
-		return fmt.Errorf("expected %d remediations, got %d", expRemediations, len(scanSuiteRemediations))
+	for _, rem := range scanSuiteRemediations {
+		scanSuiteMapNames[rem.Name] = true
+	}
+
+	for _, expRem := range remNameList {
+		_, ok := scanSuiteMapNames[expRem]
+		if !ok {
+			return fmt.Errorf("expected remediation %s not found", expRem)
+		}
 	}
 
 	for _, rem := range scanSuiteRemediations {


### PR DESCRIPTION
Our scanner image is currently broken in the sense that it does not report
non-compliance. Before we fix the scanner image, we need to make sure the
tests will keep passing.

The second patch fixes an embarassing issue where checks were not actually
checked..