### PR TITLE
E2E tests: Add tests for remediations

### DIFF
--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -23,6 +23,7 @@ import (
 	mcfgv1 "github.com/openshift/compliance-operator/pkg/apis/machineconfiguration/v1"
 	"github.com/openshift/compliance-operator/pkg/controller/common"
 	mcfgClient "github.com/openshift/compliance-operator/pkg/generated/clientset/versioned/typed/machineconfiguration/v1"
+
 )
 
 var log = logf.Log.WithName("controller_complianceremediation")


### PR DESCRIPTION
Adds a test that runs a scan, applies a remediation, checks the MC has
been created, runs the scan again to make sure that one finding is gone,
removes the MC to not leave things around and finally waits for the
nodes to come back up.