### PR TITLE
Consistently use constants across the codebase

### DIFF
--- a/pkg/apis/machineconfiguration/v1/machineconfig_types.go
+++ b/pkg/apis/machineconfiguration/v1/machineconfig_types.go
@@ -23,6 +23,10 @@ type MachineConfigSpec struct {
 	FIPS bool `json:"fips"`
 }
 
+const (
+	McRoleKey = "machineconfiguration.openshift.io/role"
+)
+
 // MachineConfig is the Schema for the machineconfigs API
 // +genclient
 // +genclient:noStatus

--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -27,11 +27,6 @@ import (
 
 var log = logf.Log.WithName("controller_complianceremediation")
 
-// FIXME: maybe move some of the constants into a separate file?
-const (
-	mcRoleKey = "machineconfiguration.openshift.io/role"
-)
-
 // Add creates a new ComplianceRemediation Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -154,7 +149,7 @@ func (r *ReconcileComplianceRemediation) reconcileMcRemediation(instance *compli
 	}
 
 	logger.Info("Will create or update MC", "name", name)
-	mergedMc := mergeMachineConfigs(mcList, name, instance.Labels[mcRoleKey])
+	mergedMc := mergeMachineConfigs(mcList, name, instance.Labels[mcfgv1.McRoleKey])
 
 	// if the mergedMc was nil, then we should remove the resulting MC, probably the last selected
 	// remediation was deselected
@@ -217,7 +212,7 @@ func getAppliedMcRemediations(r *ReconcileComplianceRemediation, rem *compliance
 	scanSuiteSelector := make(map[string]string)
 	scanSuiteSelector[complianceoperatorv1alpha1.SuiteLabel] = rem.Labels[complianceoperatorv1alpha1.SuiteLabel]
 	scanSuiteSelector[complianceoperatorv1alpha1.ScanLabel] = rem.Labels[complianceoperatorv1alpha1.ScanLabel]
-	scanSuiteSelector[mcRoleKey] = rem.Labels[mcRoleKey]
+	scanSuiteSelector[mcfgv1.McRoleKey] = rem.Labels[mcfgv1.McRoleKey]
 
 	listOpts := client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(scanSuiteSelector),
@@ -290,7 +285,7 @@ func mergeMachineConfigs(configs []*mcfgv1.MachineConfig, name string, roleLabel
 	}
 
 	mergedMc.Labels = make(map[string]string)
-	mergedMc.Labels[mcRoleKey] = roleLabel
+	mergedMc.Labels[mcfgv1.McRoleKey] = roleLabel
 
 	return mergedMc
 }

--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	mcfgv1 "github.com/openshift/compliance-operator/pkg/apis/machineconfiguration/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -345,10 +346,10 @@ func createRemediations(r *ReconcileComplianceSuite, suite *complianceoperatorv1
 		if rem.Labels == nil {
 			rem.Labels = make(map[string]string)
 		}
-		rem.Labels["complianceoperator.openshift.io/suite"] = suite.Name
-		rem.Labels["complianceoperator.openshift.io/scan"] = scan.Name
-		rem.Labels["machineconfiguration.openshift.io/role"] = getScanRoleLabel(scan.Spec.NodeSelector)
-		if rem.Labels["machineconfiguration.openshift.io/role"] == "" {
+		rem.Labels[complianceoperatorv1alpha1.SuiteLabel] = suite.Name
+		rem.Labels[complianceoperatorv1alpha1.ScanLabel] = scan.Name
+		rem.Labels[mcfgv1.McRoleKey] = getScanRoleLabel(scan.Spec.NodeSelector)
+		if rem.Labels[mcfgv1.McRoleKey] == "" {
 			return fmt.Errorf("scan %s has no role assignment", scan.Name)
 		}
 
@@ -472,7 +473,7 @@ func (r *ReconcileComplianceSuite) reconcileRemediations(namespacedName types.Na
 	// Construct the list of the statuses
 	remOverview := make([]complianceoperatorv1alpha1.ComplianceRemediationNameStatus, len(remList.Items))
 	for idx, rem := range remList.Items {
-		remOverview[idx].ScanName = rem.Labels["complianceoperator.openshift.io/scan"]
+		remOverview[idx].ScanName = rem.Labels[complianceoperatorv1alpha1.ScanLabel]
 		remOverview[idx].RemediationName = rem.Name
 		remOverview[idx].Type = rem.Spec.Type
 		remOverview[idx].Apply = rem.Spec.Apply


### PR DESCRIPTION
We copy-pasted string labels on some places and used constants with the
same value on other places. Let's consolidate the mess by:
    - defining the machineconfiguration.openshift.io/role label in the
      MC types go file
    - consistently using complianceoperatorv1alpha1.ScanLabel and
      complianceoperatorv1alpha1.SuiteLabel instead of their string
      values