### PR TITLE
deploy: change operator image to internal repo

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: compliance-operator
           # Replace this with the built image name
-          image: quay.io/jhrozek/compliance-operator
+          image: image-registry.openshift-image-registry.svc:5000/openshift-compliance/compliance-operator:latest
           command:
           - compliance-operator
           imagePullPolicy: Always


### PR DESCRIPTION
This makes a in-cluster deployment easier with make image-to-cluster