### PR TITLE
Use a configMap as the script source for the openscap container, not the container's entrypoint

### DIFF
--- a/images/openscap/Dockerfile
+++ b/images/openscap/Dockerfile
@@ -1,0 +1,18 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+LABEL \
+    name="openscap-ocp" \
+    run="podman run --privileged -v /:/host  -eHOSTROOT=/host -ePROFILE=xccdf_org.ssgproject.content_profile_coreos-fedramp -eCONTENT=ssg-ocp4-ds.xml -eREPORT_DIR=/reports -eRULE=xccdf_org.ssgproject.content_rule_selinux_state" \
+    io.k8s.display-name="OpenSCAP container for OCP4 node scans" \
+    io.k8s.description="OpenSCAP security scanner for scanning hosts through a host mount" \
+    io.openshift.tags="compliance openscap scan" \
+    io.openshift.wants="scap-content"
+
+# The repo will only be needed until RHEL-8.2 comes out
+COPY \
+    jhrozek-openscap-with-chroot-epel-8.repo /etc/yum.repos.d/
+
+RUN true \
+    && microdnf install -y openscap-scanner \
+    && microdnf clean all \
+    && true

--- a/images/openscap/Dockerfile.ci
+++ b/images/openscap/Dockerfile.ci
@@ -1,0 +1,18 @@
+FROM registry.svc.ci.openshift.org/origin/4.3:base
+
+LABEL \
+    name="openscap-ocp" \
+    run="podman run --privileged -v /:/host  -eHOSTROOT=/host -ePROFILE=xccdf_org.ssgproject.content_profile_coreos-fedramp -eCONTENT=ssg-ocp4-ds.xml -eREPORT_DIR=/reports -eRULE=xccdf_org.ssgproject.content_rule_selinux_state" \
+    io.k8s.display-name="OpenSCAP container for OCP4 node scans" \
+    io.k8s.description="OpenSCAP security scanner for scanning hosts through a host mount" \
+    io.openshift.tags="compliance openscap scan" \
+    io.openshift.wants="scap-content"
+
+# The repo will only be needed until RHEL-8.2 comes out
+COPY \
+    jhrozek-openscap-with-chroot-epel-8.repo /etc/yum.repos.d/
+
+RUN true \
+    && microdnf install -y openscap-scanner \
+    && microdnf clean all \
+    && true

--- a/images/openscap/jhrozek-openscap-with-chroot-epel-8.repo
+++ b/images/openscap/jhrozek-openscap-with-chroot-epel-8.repo
@@ -1,0 +1,10 @@
+[copr:copr.fedorainfracloud.org:jhrozek:openscap-with-chroot]
+name=Copr repo for openscap-with-chroot owned by jhrozek
+baseurl=https://copr-be.cloud.fedoraproject.org/results/jhrozek/openscap-with-chroot/epel-8-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/jhrozek/openscap-with-chroot/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -2,13 +2,7 @@ package compliancescan
 
 import (
 	"context"
-	// we can suppress the gosec warning about sha1 here because we don't use sha1 for crypto
-	// purposes, but only as a string shortener
-	// #nosec G505
-	"crypto/sha1"
 	"fmt"
-	"io"
-	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -474,23 +468,7 @@ func newPodForNode(scanInstance *complianceoperatorv1alpha1.ComplianceScan, node
 // pod names are limited to 63 chars, inclusive. Try to use a friendly name, if that can't be done,
 // just use a hash. Either way, the node would be present in a label of the pod.
 func podForNodeName(scanName, nodeName string) string {
-	const maxPodLen = 63
-
-	// first, try to use the full scan and node name
-	podName := fmt.Sprintf("%s-%s-pod", scanName, nodeName)
-	if len(podName) < maxPodLen {
-		return podName
-	}
-
-	// if that's too long, just hash the name. It's not very user friendly, but whatever
-	// we could in theory also use the nodeName up to the first dot, but that would open
-	// up conflicts, so let's not..
-	// we can suppress the gosec warning about sha1 here because we don't use sha1 for crypto
-	// purposes, but only as a string shortener
-	// #nosec G401
-	hasher := sha1.New()
-	io.WriteString(hasher, fmt.Sprintf("%s-%s-pod", scanName, nodeName))
-	return "openscap-pod-" + fmt.Sprintf("%x", hasher.Sum(nil))
+	return dnsLengthName("openscap-pod","%s-%s-pod", scanName, nodeName)
 }
 
 // TODO: this probably should not be a method, it doesn't modify reconciler, maybe we

--- a/pkg/controller/compliancescan/compliancescan_controller_test.go
+++ b/pkg/controller/compliancescan/compliancescan_controller_test.go
@@ -92,16 +92,25 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 		Context("With two pods in the cluster", func() {
 			BeforeEach(func() {
 				// Create the pods for the test
+				podName1 := fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance1.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance1.Name),
+						Name: podName1,
 					},
 				})
+
+				podName2 := fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance2.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance2.Name),
+						Name: podName2,
 					},
 				})
+
+				// Set the pod-node mappings in labels
+				setPodForNodeName(compliancescaninstance, nodeinstance1.Name, podName1)
+				setPodForNodeName(compliancescaninstance, nodeinstance2.Name, podName2)
+				reconciler.client.Update(context.TODO(), compliancescaninstance)
+
 				// Set state to RUNNING
 				compliancescaninstance.Status.Phase = complianceoperatorv1alpha1.PhaseRunning
 				reconciler.client.Status().Update(context.TODO(), compliancescaninstance)
@@ -118,22 +127,31 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 		Context("With two pods that succeeded in the cluster", func() {
 			BeforeEach(func() {
 				// Create the pods for the test
+				podName1 := fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance1.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance1.Name),
+						Name: podName1,
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
 					},
 				})
+
+				podName2 := fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance2.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance2.Name),
+						Name: podName2,
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
 					},
 				})
+
+				// Set the pod-node mappings in labels
+				setPodForNodeName(compliancescaninstance, nodeinstance1.Name, podName1)
+				setPodForNodeName(compliancescaninstance, nodeinstance2.Name, podName2)
+				reconciler.client.Update(context.TODO(), compliancescaninstance)
+
 				// Set state to RUNNING
 				compliancescaninstance.Status.Phase = complianceoperatorv1alpha1.PhaseRunning
 				reconciler.client.Status().Update(context.TODO(), compliancescaninstance)

--- a/pkg/controller/compliancescan/config.go
+++ b/pkg/controller/compliancescan/config.go
@@ -1,0 +1,170 @@
+package compliancescan
+
+import (
+	"context"
+	complianceoperatorv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/complianceoperator/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// configMap that contains the default script
+	OpenScapScriptConfigMapName = "openscap-container-entrypoint"
+	// This is how the script would be mounted
+	OpenScapScriptPath = "/scripts/openscap-container-entrypoint"
+
+	// a configMap with env vars for the script
+	OpenScapEnvConfigMapName = "openscap-env-map"
+
+	// environment variables the default script consumes
+	OpenScapHostRootEnvName  = "HOSTROOT"
+	OpenScapProfileEnvName   = "PROFILE"
+	OpenScapContentEnvName   = "CONTENT"
+	OpenScapReportDirEnvName = "REPORT_DIR"
+	OpenScapRuleEnvName      = "RULE"
+)
+
+var defaultOpenScapScriptContents = `#!/bin/bash
+
+if [ -z $HOSTROOT ]; then
+    echo "hostroot not set"
+    exit 1
+fi
+
+if [ -z $PROFILE ]; then
+    echo "profile not set"
+    exit 1
+fi
+
+if [ -z $CONTENT ]; then
+    echo "content not set"
+    exit 1
+fi
+
+if [ -z $REPORT_DIR ]; then
+    echo "report_dit not set"
+    exit 1
+fi
+
+cmd=(
+    oscap-chroot $HOSTROOT xccdf eval \
+    --fetch-remote-resources \
+    --profile $PROFILE \
+    --report /tmp/scan-report.xml \
+    --results-arf /tmp/report.xml
+    )
+
+if [ ! -z $RULE ]; then
+    cmd+=(--rule $RULE)
+fi
+
+cmd+=($CONTENT)
+
+# The whole purpose of the shell entrypoint is to semi-atomically
+# move the results file when the command is done so the log collector
+# picks up the whole thing and not a partial file
+echo "Running oscap-chroot as ${cmd[@]}"
+"${cmd[@]}"
+rv=$?
+echo "The scanner returned $rv"
+test -f /tmp/report.xml && mv /tmp/report.xml $REPORT_DIR
+exit $rv
+`
+
+func createConfigMaps(r *ReconcileComplianceScan, scriptCmName, envCmName string, scan *complianceoperatorv1alpha1.ComplianceScan) error {
+	cm := &corev1.ConfigMap{}
+
+	if err := r.client.Get(context.TODO(), types.NamespacedName{
+		Name:      scriptCmName,
+		Namespace: scan.Namespace,
+	}, cm); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+		if err := r.client.Create(context.TODO(), defaultOpenScapScriptCm(scriptCmName, scan)); err != nil {
+			return err
+		}
+	}
+
+	if err := r.client.Get(context.TODO(), types.NamespacedName{
+		Name:      envCmName,
+		Namespace: scan.Namespace,
+	}, cm); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+		if err := r.client.Create(context.TODO(), defaultOpenScapEnvCm(envCmName, scan)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func defaultOpenScapScriptCm(name string, scan *complianceoperatorv1alpha1.ComplianceScan) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: scan.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				asOwner(scan),
+			},
+		},
+		Data: map[string]string{
+			OpenScapScriptConfigMapName: defaultOpenScapScriptContents,
+		},
+	}
+}
+
+func defaultOpenScapEnvCm(name string, scan *complianceoperatorv1alpha1.ComplianceScan) *corev1.ConfigMap {
+	content := scan.Spec.Content
+	if !strings.HasPrefix(scan.Spec.Content, "/") {
+		content = "/content/" + scan.Spec.Content
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: scan.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				asOwner(scan),
+			},
+		},
+		Data: map[string]string{
+			OpenScapHostRootEnvName:  "/host",
+			OpenScapProfileEnvName:   scan.Spec.Profile,
+			OpenScapContentEnvName:   content,
+			OpenScapReportDirEnvName: "/reports",
+		},
+	}
+
+	if scan.Spec.Rule != "" {
+		cm.Data[OpenScapRuleEnvName] = scan.Spec.Rule
+	}
+
+	return cm
+}
+
+func scriptCmForScan(scan *complianceoperatorv1alpha1.ComplianceScan) string {
+	return dnsLengthName("scap-entrypoint-", "%s-%s", scan.Name, OpenScapScriptConfigMapName)
+}
+
+func envCmForScan(scan *complianceoperatorv1alpha1.ComplianceScan) string {
+	return dnsLengthName("scap-env-", "%s-%s", scan.Name, OpenScapEnvConfigMapName)
+}
+
+func asOwner(scan *complianceoperatorv1alpha1.ComplianceScan) metav1.OwnerReference {
+	bTrue := true
+
+	return metav1.OwnerReference{
+		APIVersion: scan.APIVersion,
+		Kind:       scan.Kind,
+		Name:       scan.Name,
+		UID:        scan.UID,
+		Controller: &bTrue,
+	}
+}

--- a/pkg/controller/compliancescan/utils.go
+++ b/pkg/controller/compliancescan/utils.go
@@ -1,6 +1,12 @@
 package compliancescan
 
 import (
+	// we can suppress the gosec warning about sha1 here because we don't use sha1 for crypto
+	// purposes, but only as a string shortener
+	// #nosec G505
+	"crypto/sha1"
+	"fmt"
+	"io"
 	"os"
 )
 
@@ -31,4 +37,22 @@ func GetComponentImage(component ComplianceComponent) string {
 		imageTag = comp.defaultImage
 	}
 	return imageTag
+}
+
+func dnsLengthName(hashPrefix string, format string, a ...interface{}) string {
+	const maxDnsLen = 64
+
+	friendlyName := fmt.Sprintf(format, a...)
+	if len(friendlyName) < maxDnsLen {
+		return friendlyName
+	}
+
+	// If that's too long, just hash the name. It's not very user friendly, but whatever
+	//
+	// We can suppress the gosec warning about sha1 here because we don't use sha1 for crypto
+	// purposes, but only as a string shortener
+	// #nosec G401
+	hasher := sha1.New()
+	io.WriteString(hasher, friendlyName)
+	return hashPrefix + fmt.Sprintf("%x", hasher.Sum(nil))
 }


### PR DESCRIPTION
The openscap container uses a script baked into the container image that
represents the container's entry point. This patch instead uses a
configmap mounted into the container as an entrypoint and another
configmap with environment variables that fine-tune the entrypoint
script.

This has two advantages:
    1) All the logic is in one place, we no longer need to synchronize
    changes between the container image logic and the controller logic
    2) The openscap container image can be really dumb, just installing
    the scap scanner.

A follow-up patch will add another Dockerfile to the project so that we
can stop relying on the openscap container from a third party repository
and instead build another image from the operator repository.