### PR TITLE
[WIP] Check for the node status as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ E2E_SKIP_CONTAINER_PUSH?=false
 # Pass extra flags to the e2e test run.
 # e.g. to run a specific test in the e2e test suite, do:
 # 	make e2e E2E_GO_TEST_FLAGS="-v -run TestE2E/TestScanWithNodeSelectorFiltersCorrectly"
-E2E_GO_TEST_FLAGS?=-v -timeout 60m
+E2E_GO_TEST_FLAGS?=-v -timeout 120m
 
 .PHONY: all
 all: build ## Test and Build the compliance-operator

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -365,7 +365,7 @@ func TestE2E(t *testing.T) {
 				remCheck := &complianceoperatorv1alpha1.ComplianceRemediation{}
 				err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: workersNoRootLoginsRemName, Namespace: namespace}, remCheck)
 				if err == nil {
-					return fmt.Errorf("remediation found unexpectedly")
+					return fmt.Errorf("remediation %s found unexpectedly", workersNoRootLoginsRemName)
 				} else if !errors.IsNotFound(err) {
 					t.Errorf("Unexpected error %v", err)
 					return err

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -302,7 +302,7 @@ func waitForMachinePoolUpdate(t *testing.T, mcClient *mcfgClient.Machineconfigur
 	}
 
 	// Should we make this configurable? Maybe 5 minutes is not enough time for slower clusters?
-	wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+	err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
 		pool, err := mcClient.MachineConfigPools().Get(name, metav1.GetOptions{})
 		if err != nil {
 			// even not found is a hard error here
@@ -340,6 +340,10 @@ func waitForMachinePoolUpdate(t *testing.T, mcClient *mcfgClient.Machineconfigur
 			pool.Status.UnavailableMachineCount)
 		return false, nil
 	})
+
+	if err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
It appears we might have a race in the e2e tests. Let's see if checking for the node status in addition to the MCP status helps here.

Also adds a forgotten error check