### PR TITLE
Add prefixes to the scans created by the compliancesuite

### DIFF
--- a/pkg/apis/complianceoperator/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/complianceoperator/v1alpha1/complianceremediation_types.go
@@ -3,8 +3,9 @@ package v1alpha1
 import (
 	"fmt"
 
-	mcfgv1 "github.com/openshift/compliance-operator/pkg/apis/machineconfiguration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mcfgv1 "github.com/openshift/compliance-operator/pkg/apis/machineconfiguration/v1"
 )
 
 type RemediationApplicationState string
@@ -26,6 +27,8 @@ const (
 	SuiteLabel = "complianceoperator.openshift.io/suite"
 	// ScanLabel defines the label that associates the Remediation with the scan
 	ScanLabel = "complianceoperator.openshift.io/scan"
+	// ScanWrapLabel defines the label that associates the scan with the suite's scan reference
+	ScanWrapLabel = "complianceoperator.openshift.io/suite-scan"
 )
 
 type ComplianceRemediationSpecMeta struct {

--- a/pkg/apis/complianceoperator/v1alpha1/compliancesuite_types.go
+++ b/pkg/apis/complianceoperator/v1alpha1/compliancesuite_types.go
@@ -36,6 +36,12 @@ type ComplianceSuiteSpec struct {
 	Scans []ComplianceScanSpecWrapper `json:"scans"`
 }
 
+// GetScanNameFromSuite Gets us a predictable name for the underlying
+// ComplianceScans that the Suite deploys
+func GetScanNameFromSuite(suite *ComplianceSuite, scanWrapName string) string {
+	return suite.Name + "-" + scanWrapName
+}
+
 // ComplianceSuiteStatus defines the observed state of ComplianceSuite
 // +k8s:openapi-gen=true
 type ComplianceSuiteStatus struct {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -234,12 +234,14 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
+				realWorkerScanName := complianceoperatorv1alpha1.GetScanNameFromSuite(exampleComplianceSuite, workerScanName)
 				// At this point, both scans should be non-compliant given our current content
-				err = scanResultIsExpected(f, namespace, workerScanName, complianceoperatorv1alpha1.ResultNonCompliant)
+				err = scanResultIsExpected(f, namespace, realWorkerScanName, complianceoperatorv1alpha1.ResultNonCompliant)
 				if err != nil {
 					return err
 				}
-				err = scanResultIsExpected(f, namespace, masterScanName, complianceoperatorv1alpha1.ResultNonCompliant)
+				realMasterScanName := complianceoperatorv1alpha1.GetScanNameFromSuite(exampleComplianceSuite, masterScanName)
+				err = scanResultIsExpected(f, namespace, realMasterScanName, complianceoperatorv1alpha1.ResultNonCompliant)
 				if err != nil {
 					return err
 				}

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -166,7 +166,8 @@ func waitForSuiteScansStatus(t *testing.T, f *framework.Framework, namespace, na
 				return false, nil
 			}
 
-			lastErr = waitForScanStatus(t, f, namespace, scanStatus.Name, targetStatus)
+			scanName := complianceoperatorv1alpha1.GetScanNameFromSuite(suite, scanStatus.Name)
+			lastErr = waitForScanStatus(t, f, namespace, scanName, targetStatus)
 			if lastErr != nil {
 				// If the status was present in the suite, then /any/ error
 				// should fail the test as the scans should be read /from/
@@ -494,4 +495,3 @@ func unApplyRemediationAndCheck(t *testing.T, f *framework.Framework, mcClient *
 	t.Logf("Machines updated with remediation")
 	return nil
 }
-


### PR DESCRIPTION
In order to make the names unique, this patch adds a prefix to the name
of the compliancescans created by the compliancesuite controller. This
way, we can have multiple suites that create scans with similar names
without conflict.

This closes #84