### PR TITLE
Prepare to unbundle

### DIFF
--- a/cmd/remediation-aggregator/main.go
+++ b/cmd/remediation-aggregator/main.go
@@ -252,8 +252,8 @@ func createRemediations(crClient *complianceCrClient, scan *complianceoperatorv1
 		}
 		rem.Labels[complianceoperatorv1alpha1.ScanLabel] = scan.Name
 		rem.Labels[complianceoperatorv1alpha1.SuiteLabel] = scan.Labels["compliancesuite"]
-		rem.Labels[mcfgv1.McRoleKey] = getScanRoleLabel(scan.Spec.NodeSelector)
-		if rem.Labels[mcfgv1.McRoleKey] == "" {
+		rem.Labels[mcfgv1.MachineConfigRoleLabelKey] = getScanRoleLabel(scan.Spec.NodeSelector)
+		if rem.Labels[mcfgv1.MachineConfigRoleLabelKey] == "" {
 			return fmt.Errorf("scan %s has no role assignment", scan.Name)
 		}
 

--- a/pkg/apis/machineconfiguration/v1/machineconfig_types.go
+++ b/pkg/apis/machineconfiguration/v1/machineconfig_types.go
@@ -24,7 +24,7 @@ type MachineConfigSpec struct {
 }
 
 const (
-	McRoleKey = "machineconfiguration.openshift.io/role"
+	MachineConfigRoleLabelKey = "machineconfiguration.openshift.io/role"
 )
 
 // MachineConfig is the Schema for the machineconfigs API

--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -149,7 +149,7 @@ func (r *ReconcileComplianceRemediation) reconcileMcRemediation(instance *compli
 	}
 
 	logger.Info("Will create or update MC", "name", name)
-	mergedMc := mergeMachineConfigs(mcList, name, instance.Labels[mcfgv1.McRoleKey])
+	mergedMc := mergeMachineConfigs(mcList, name, instance.Labels[mcfgv1.MachineConfigRoleLabelKey])
 
 	// if the mergedMc was nil, then we should remove the resulting MC, probably the last selected
 	// remediation was deselected
@@ -212,7 +212,7 @@ func getAppliedMcRemediations(r *ReconcileComplianceRemediation, rem *compliance
 	scanSuiteSelector := make(map[string]string)
 	scanSuiteSelector[complianceoperatorv1alpha1.SuiteLabel] = rem.Labels[complianceoperatorv1alpha1.SuiteLabel]
 	scanSuiteSelector[complianceoperatorv1alpha1.ScanLabel] = rem.Labels[complianceoperatorv1alpha1.ScanLabel]
-	scanSuiteSelector[mcfgv1.McRoleKey] = rem.Labels[mcfgv1.McRoleKey]
+	scanSuiteSelector[mcfgv1.MachineConfigRoleLabelKey] = rem.Labels[mcfgv1.MachineConfigRoleLabelKey]
 
 	listOpts := client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(scanSuiteSelector),
@@ -285,7 +285,7 @@ func mergeMachineConfigs(configs []*mcfgv1.MachineConfig, name string, roleLabel
 	}
 
 	mergedMc.Labels = make(map[string]string)
-	mergedMc.Labels[mcfgv1.McRoleKey] = roleLabel
+	mergedMc.Labels[mcfgv1.MachineConfigRoleLabelKey] = roleLabel
 
 	return mergedMc
 }

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -293,7 +293,7 @@ func assertHasRemediations(t *testing.T, f *framework.Framework, suiteName, scan
 	}
 
 	for _, rem := range scanSuiteRemediations {
-		if rem.Labels["machineconfiguration.openshift.io/role"] != roleLabel {
+		if rem.Labels[mcfgv1.MachineConfigRoleLabelKey] != roleLabel {
 			return fmt.Errorf("expected that scan %s is labeled for role %s", scanName, roleLabel)
 		}
 	}


### PR DESCRIPTION
I am trying to unbundle MachineConfig API from the Compliance Operator as these two started to diverge.

First roadblock, I have hit was the McRoleKey not available in the original MachineConfig. I did submit the variable on the MachineConfig side at openshift/machine-config-operator#1418 and here I rename the bundled variable in Compliance Operator so we get closer to the original.

We can wait for openshift/machine-config-operator#1418 being merged by we don't need to.