### PR TITLE
Ensure scanstatuses in compliancesuite is not nil

### DIFF
--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/dsnet/compress/bzip2"
 	"github.com/go-logr/logr"
-	mcfgv1 "github.com/openshift/compliance-operator/pkg/apis/machineconfiguration/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	complianceoperatorv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/complianceoperator/v1alpha1"
+	mcfgv1 "github.com/openshift/compliance-operator/pkg/apis/machineconfiguration/v1"
 	"github.com/openshift/compliance-operator/pkg/controller/common"
 	"github.com/openshift/compliance-operator/pkg/utils"
 )
@@ -519,6 +519,10 @@ func (r *ReconcileComplianceSuite) reconcileRemediations(namespacedName types.Na
 
 	// Update the suite status
 	suiteCopy := suite.DeepCopy()
+	// Make sure we don't try to use the value as-is if it's nil
+	if suiteCopy.Status.ScanStatuses == nil {
+		suiteCopy.Status.ScanStatuses = []complianceoperatorv1alpha1.ComplianceScanStatusWrapper{}
+	}
 	suiteCopy.Status.RemediationOverview = remOverview
 	logger.Info("Remediations", "remOverview", remOverview)
 	return r.client.Status().Update(context.TODO(), suiteCopy)


### PR DESCRIPTION
We were getting errors in CI due to this.

e.g.

```
        {"level":"error","ts":1581074209.1986895,"logger":"controller_compliancesuite","msg":"Retriable error","Request.Namespace":"openshift-compliance","Request.Name":"test-suite-two-scans","error":"ComplianceSuite.complianceoperator.compliance.openshift.io \"test-suite-two-scans\" is invalid: status.scanStatuses: Invalid value: \"null\": status.scanStatuses in body must be of type array: \"null\"","stacktrace":"github.com/openshift/compliance-operator/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/src/github.com/openshift/compliance-operator/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/openshift/compliance-operator/pkg/controller/common.ReturnWithRetriableError\n\t/go/src/github.com/openshift/compliance-operator/pkg/controller/common/errors.go:49\ngithub.com/openshift/compliance-operator/pkg/controller/compliancesuite.(*ReconcileComplianceSuite).Reconcile\n\t/go/src/github.com/openshift/compliance-operator/pkg/controller/compliancesuite/compliancesuite_controller.go:129\ngithub.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:256\ngithub.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232\ngithub.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/src/github.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211\ngithub.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/src/github.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152\ngithub.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/src/github.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153\ngithub.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait.Until\n\t/go/src/github.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```