### PR TITLE
Use nodeSelector instead of nodeName to schedule pod

### DIFF
--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -36,6 +36,7 @@ const (
 	OpenSCAPScriptCmLabel     = "cm-script"
 	OpenSCAPScriptEnvLabel    = "cm-env"
 	OpenSCAPNodePodLabel      = "node-scan/"
+	NodeHostnameLabel         = "kubernetes.io/hostname"
 )
 
 // Add creates a new ComplianceScan Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -502,7 +503,9 @@ func newPodForNode(scanInstance *complianceoperatorv1alpha1.ComplianceScan, node
 					Effect:   "NoSchedule",
 				},
 			},
-			NodeName:      node.Name,
+			NodeSelector: map[string]string{
+				NodeHostnameLabel: node.Labels[NodeHostnameLabel],
+			},
 			RestartPolicy: corev1.RestartPolicyNever,
 			Volumes: []corev1.Volume{
 				{


### PR DESCRIPTION
The nodeName skips the scheduler, while the nodeSelector still goes
through it. We would need this in order to get extra features (such as
dynamic PersistentVolume provisioning), which the scheduler enables.