### PR TITLE
Change quay namespace from Makefile to use compliance-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RESULTSCOLLECTOR_IMAGE_NAME=$(RESULTSCOLLECTORBIN)
 
 # Container image variables
 # =========================
-IMAGE_REPO?=quay.io/jhrozek
+IMAGE_REPO?=quay.io/compliance-operator
 RUNTIME?=podman
 
 # Image path to use. Set this if you want to use a specific path for building


### PR DESCRIPTION
As we move towards using the compliance-operator organization in quay
for building our images, we need to start building them with the
appropraite namespace as well. This changes the makefile to use the new
org.