### PR TITLE
remediation-aggregator image fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,9 @@ push: image
 	# resultserver
 	$(RUNTIME) tag $(RESULTSERVER_IMAGE_PATH) $(RESULTSERVER_IMAGE_PATH):$(TAG)
 	$(RUNTIME) push $(RESULTSERVER_IMAGE_PATH):$(TAG)
+	# remediation-aggregator
+	$(RUNTIME) tag $(REMEDIATION_AGGREGATOR_IMAGE_PATH) $(REMEDIATION_AGGREGATOR_IMAGE_PATH):$(TAG)
+	$(RUNTIME) push $(REMEDIATION_AGGREGATOR_IMAGE_PATH):$(TAG)
 
 versionPath=$(shell GO111MODULE=on go list -f {{.Dir}} k8s.io/code-generator/cmd/client-gen)
 codegeneratorRoot=$(versionPath:/cmd/client-gen=)

--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,8 @@ image-to-cluster:
 	$(eval RESULTSCOLLECTOR_IMAGE_PATH = $(IMAGE_FORMAT))
 	$(eval component = compliance-resultserver)
 	$(eval RESULTSERVER_IMAGE_PATH = $(IMAGE_FORMAT))
+	$(eval component = compliance-remediation-aggregator)
+	$(eval REMEDIATION_AGGREGATOR_IMAGE_PATH = $(IMAGE_FORMAT))
 else
 image-to-cluster: namespace openshift-user image
 	@echo "IMAGE_FORMAT variable missing. We're in local enviornment."

--- a/Makefile
+++ b/Makefile
@@ -211,11 +211,13 @@ endif
 	@echo "Replacing workload references in deploy/operator.yaml"
 	@sed -i 's%$(IMAGE_REPO)/$(RESULTSCOLLECTOR_IMAGE_NAME):latest%$(RESULTSCOLLECTOR_IMAGE_PATH)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(RESULTSERVER_IMAGE_NAME):latest%$(RESULTSERVER_IMAGE_PATH)%' deploy/operator.yaml
+	@sed -i 's%$(IMAGE_REPO)/$(REMEDIATION_AGGREGATOR_IMAGE_NAME):latest%$(REMEDIATION_AGGREGATOR_IMAGE_PATH)%' deploy/operator.yaml
 	@echo "Running e2e tests"
 	unset GOFLAGS && $(GOPATH)/bin/operator-sdk test local ./tests/e2e --image "$(OPERATOR_IMAGE_PATH)" --namespace "$(NAMESPACE)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
 	@echo "Restoring image references in deploy/operator.yaml"
 	@sed -i 's%$(RESULTSCOLLECTOR_IMAGE_PATH)%$(IMAGE_REPO)/$(RESULTSCOLLECTOR_IMAGE_NAME):latest%' deploy/operator.yaml
 	@sed -i 's%$(RESULTSERVER_IMAGE_PATH)%$(IMAGE_REPO)/$(RESULTSERVER_IMAGE_NAME):latest%' deploy/operator.yaml
+	@sed -i 's%$(REMEDIATION_AGGREGATOR_IMAGE_PATH)%$(IMAGE_REPO)/$(REMEDIATION_AGGREGATOR_IMAGE_NAME):latest%' deploy/operator.yaml
 
 e2e-local: operator-sdk ## Run the end-to-end tests on a locally running operator (e.g. using make run)
 	@echo "WARNING: This will temporarily modify deploy/operator.yaml"
@@ -267,6 +269,7 @@ image-to-cluster: namespace openshift-user image
 	$(eval OPERATOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(APP_NAME):$(TAG))
 	$(eval RESULTSCOLLECTOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(RESULTSCOLLECTOR_IMAGE_NAME):$(TAG))
 	$(eval RESULTSERVER_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(RESULTSERVER_IMAGE_NAME):$(TAG))
+	$(eval REMEDIATION_AGGREGATOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(REMEDIATION_AGGREGATOR_IMAGE_NAME):$(TAG))
 endif
 
 .PHONY: namespace

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -37,8 +37,8 @@ spec:
               value: "quay.io/compliance-operator/resultscollector:latest"
             - name: RESULT_SERVER_IMAGE
               value: "quay.io/compliance-operator/resultserver:latest"
-            - name: AGGREGATOR_IMAGE
-              value: "quay.io/jhrozek/aggregator:latest"
+            - name: REMEDIATION_AGGREGATOR_IMAGE
+              value: "quay.io/compliance-operator/remediation-aggregator:latest"
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/pkg/controller/compliancescan/utils.go
+++ b/pkg/controller/compliancescan/utils.go
@@ -29,7 +29,7 @@ var componentDefaults = []struct {
 	{"quay.io/compliance-operator/resultscollector:latest", "LOG_COLLECTOR_IMAGE"},
 	{"quay.io/jhrozek/openscap-ocp:latest", "OPENSCAP_IMAGE"},
 	{"quay.io/compliance-operator/resultserver:latest", "RESULT_SERVER_IMAGE"},
-	{"quay.io/jhrozek/remediation-aggregator", "AGGREGATOR_IMAGE"},
+	{"quay.io/compliance-operator/remediation-aggregator", "REMEDIATION_AGGREGATOR_IMAGE"},
 }
 
 // GetComponentImage returns a full image pull spec for a given component


### PR DESCRIPTION
* enables is as part of the push target
* uses the image from quay.io
* uses the expected name in the env util
* enables it in the image-to-cluster target so local testing can work