### PR TITLE
Fix environment variable from the result server

### DIFF
--- a/pkg/controller/compliancescan/utils.go
+++ b/pkg/controller/compliancescan/utils.go
@@ -28,7 +28,7 @@ var componentDefaults = []struct {
 }{
 	{"quay.io/compliance-operator/resultscollector:latest", "LOG_COLLECTOR_IMAGE"},
 	{"quay.io/jhrozek/openscap-ocp:latest", "OPENSCAP_IMAGE"},
-	{"quay.io/compliance-operator/resultserver:latest", "RESULT_SERVER"},
+	{"quay.io/compliance-operator/resultserver:latest", "RESULT_SERVER_IMAGE"},
 	{"quay.io/jhrozek/remediation-aggregator", "AGGREGATOR_IMAGE"},
 }
 


### PR DESCRIPTION
This fixes the environment variable name from the resultserver so we can
start taking the freshly built images into use.