### PR TITLE
Add permission to delete deployments

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -38,6 +38,7 @@ rules:
   - watch
   - create
   - update
+  - delete      # The compliance-scan controller deletes the resultserver in the DONE phase
 - apiGroups:
   - complianceoperator.compliance.openshift.io
   resources:


### PR DESCRIPTION
This is needed to clean up the resultserver after the scan.