### PR TITLE
Fix olm-catalog template to point to right image

### DIFF
--- a/deploy/olm-catalog/compliance-operator/0.1.0/compliance-operator.v0.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/0.1.0/compliance-operator.v0.1.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
       An operator which runs OpenSCAP and allows you to check your cluster for
       security vulnerabilities and to keep your it compliant with the
       security benchmark you need.
-    containerImage: quay.io/openshift/compliance-operator:latest
+    containerImage: quay.io/compliance-operator/compliance-operator:latest
     createdAt: 2020-01-28T08:00:00Z
     support: OpenShift Security & Compliance
     repository: https://github.com/openshift/compliance-operator


### PR DESCRIPTION
The containerImage in olm-catalog was pointing to `quay.io/openshift/compliance-operator:latest` but that image doesn't exist. It should point to `quay.io/compliance-operator/compliance-operator:latest`
