### PR TITLE
Make minor OLM release and enhance publishing workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,6 +322,12 @@ gen-mcfg-client: code-generator
 	cp -r $(GOPATH)/src/github.com/openshift/compliance-operator/pkg/generated pkg/
 
 .PHONY: publish
-publish:
+publish: csv publish-bundle
+
+.PHONY: csv
+csv:
 	$(GOPATH)/bin/operator-sdk olm-catalog gen-csv --csv-version "$(COURIER_PACKAGE_VERSION)" --update-crds
+
+.PHONY: publish-bundle
+publish-bundle:
 	$(COURIER_CMD) push "$(COURIER_OPERATOR_DIR)" "$(COURIER_QUAY_NAMESPACE)" "$(COURIER_PACKAGE_NAME)" "$(COURIER_PACKAGE_VERSION)" "basic $(COURIER_QUAY_TOKEN)"

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ COURIER_CMD=operator-courier
 COURIER_PACKAGE_NAME=compliance-operator-bundle
 COURIER_OPERATOR_DIR=deploy/olm-catalog/compliance-operator
 COURIER_QUAY_NAMESPACE=compliance-operator
-COURIER_PACKAGE_VERSION?="0.1.0"
+COURIER_PACKAGE_VERSION?=0.1.1
+OLD_COURIER_PACKAGE_VERSION?=0.1.0
 COURIER_QUAY_TOKEN?= $(shell cat ~/.quay)
 
 .PHONY: all
@@ -326,7 +327,7 @@ publish: csv publish-bundle
 
 .PHONY: csv
 csv:
-	$(GOPATH)/bin/operator-sdk olm-catalog gen-csv --csv-version "$(COURIER_PACKAGE_VERSION)" --update-crds
+	$(GOPATH)/bin/operator-sdk olm-catalog gen-csv --csv-version "$(COURIER_PACKAGE_VERSION)" --from-version "$(OLD_COURIER_PACKAGE_VERSION)" --update-crds
 
 .PHONY: publish-bundle
 publish-bundle:

--- a/Makefile
+++ b/Makefile
@@ -323,4 +323,5 @@ gen-mcfg-client: code-generator
 
 .PHONY: publish
 publish:
+	$(GOPATH)/bin/operator-sdk olm-catalog gen-csv --csv-version "$(COURIER_PACKAGE_VERSION)" --update-crds
 	$(COURIER_CMD) push "$(COURIER_OPERATOR_DIR)" "$(COURIER_QUAY_NAMESPACE)" "$(COURIER_PACKAGE_NAME)" "$(COURIER_PACKAGE_VERSION)" "basic $(COURIER_QUAY_TOKEN)"

--- a/deploy/olm-catalog/compliance-operator/0.1.1/compliance-operator.v0.1.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/0.1.1/compliance-operator.v0.1.1.clusterserviceversion.yaml
@@ -1,0 +1,331 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "complianceoperator.compliance.openshift.io/v1alpha1",
+          "kind": "ComplianceRemediation",
+          "metadata": {
+            "labels": {
+              "complianceoperator.openshift.io/scan": "example-scan",
+              "complianceoperator.openshift.io/suite": "example-suite",
+              "machineconfiguration.openshift.io/role": "worker"
+            },
+            "name": "example-remediation-worker-no-direct-root-login",
+            "namespace": "openshift-compliance"
+          },
+          "spec": {
+            "apply": false,
+            "machineConfigContents": {
+              "apiVersion": "machineconfiguration.openshift.io/v1",
+              "kind": "MachineConfig",
+              "spec": {
+                "config": {
+                  "ignition": {
+                    "version": "2.2.0"
+                  },
+                  "storage": {
+                    "files": [
+                      {
+                        "contents": {
+                          "source": "data:,"
+                        },
+                        "filesystem": "root",
+                        "mode": 384,
+                        "path": "/etc/securetty"
+                      }
+                    ]
+                  }
+                },
+                "fips": false,
+                "kernelArguments": [
+                  ""
+                ],
+                "osImageURL": ""
+              }
+            },
+            "type": "MachineConfig"
+          }
+        },
+        {
+          "apiVersion": "complianceoperator.compliance.openshift.io/v1alpha1",
+          "kind": "ComplianceScan",
+          "metadata": {
+            "name": "example-compliancescan"
+          },
+          "spec": {
+            "content": "ssg-ocp4-ds.xml",
+            "profile": "xccdf_org.ssgproject.content_profile_coreos-ncp"
+          }
+        },
+        {
+          "apiVersion": "complianceoperator.compliance.openshift.io/v1alpha1",
+          "kind": "ComplianceSuite",
+          "metadata": {
+            "name": "example-compliancesuite"
+          },
+          "spec": {
+            "autoApplyRemediations": true,
+            "scans": [
+              {
+                "content": "ssg-ocp4-ds.xml",
+                "contentImage": "quay.io/jhrozek/ocp4-openscap-content:latest",
+                "name": "workers-scan",
+                "nodeSelector": {
+                  "node-role.kubernetes.io/worker": ""
+                },
+                "profile": "xccdf_org.ssgproject.content_profile_coreos-ncp"
+              },
+              {
+                "content": "ssg-ocp4-ds.xml",
+                "contentImage": "quay.io/jhrozek/ocp4-openscap-content:latest",
+                "name": "masters-scan",
+                "nodeSelector": {
+                  "node-role.kubernetes.io/master": ""
+                },
+                "profile": "xccdf_org.ssgproject.content_profile_coreos-ncp"
+              }
+            ]
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: OpenShift Optional, Security
+    certified: "false"
+    containerImage: quay.io/compliance-operator/compliance-operator:latest
+    createdAt: "2020-01-28T08:00:00Z"
+    description: |
+      An operator which runs OpenSCAP and allows you to check your cluster for
+      security vulnerabilities and to keep your it compliant with the
+      security benchmark you need.
+    repository: https://github.com/openshift/compliance-operator
+    support: OpenShift Security & Compliance
+  name: compliance-operator.v0.1.1
+  namespace: openshift-compliance
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: ComplianceRemediation is the Schema for the complianceremediations
+        API
+      kind: ComplianceRemediation
+      name: complianceremediations.complianceoperator.compliance.openshift.io
+      version: v1alpha1
+    - description: ComplianceScan is the Schema for the compliancescans API
+      kind: ComplianceScan
+      name: compliancescans.complianceoperator.compliance.openshift.io
+      version: v1alpha1
+    - description: ComplianceSuite is the Schema for the compliancesuites API
+      kind: ComplianceSuite
+      name: compliancesuites.complianceoperator.compliance.openshift.io
+      version: v1alpha1
+  description: |
+    An operator which runs OpenSCAP and allows you to check your cluster for
+    security vulnerabilities and to keep your it compliant with the
+    security benchmark you need.
+  displayName: Compliance Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - machineconfiguration.openshift.io
+          resources:
+          - machineconfigs
+          verbs:
+          - list
+          - get
+          - patch
+          - create
+          - watch
+          - update
+          - delete
+        serviceAccountName: compliance-operator
+      deployments:
+      - name: compliance-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: compliance-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: compliance-operator
+            spec:
+              containers:
+              - command:
+                - compliance-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: compliance-operator
+                - name: OPENSCAP_IMAGE
+                  value: quay.io/jhrozek/openscap-ocp:remediations_demo
+                - name: LOG_COLLECTOR_IMAGE
+                  value: quay.io/compliance-operator/resultscollector:latest
+                - name: RESULT_SERVER_IMAGE
+                  value: quay.io/compliance-operator/resultserver:latest
+                - name: REMEDIATION_AGGREGATOR_IMAGE
+                  value: quay.io/compliance-operator/remediation-aggregator:latest
+                image: quay.io/compliance-operator/compliance-operator
+                imagePullPolicy: Always
+                name: compliance-operator
+                resources: {}
+              nodeSelector:
+                node-role.kubernetes.io/master: ""
+              serviceAccountName: compliance-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+                operator: Exists
+              - effect: NoExecute
+                key: node.kubernetes.io/unreachable
+                operator: Exists
+                tolerationSeconds: 120
+              - effect: NoExecute
+                key: node.kubernetes.io/not-ready
+                operator: Exists
+                tolerationSeconds: 120
+      permissions:
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: scc-priv
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - persistentvolumeclaims
+          - persistentvolumes
+          - volumeattachments
+          verbs:
+          - watch
+          - create
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - complianceoperator.compliance.openshift.io
+          resources:
+          - compliancescans
+          verbs:
+          - create
+          - watch
+          - patch
+          - get
+          - list
+        - apiGroups:
+          - complianceoperator.compliance.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resourceNames:
+          - compliance-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - services/finalizers
+          verbs:
+          - create
+          - get
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - compliance-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        serviceAccountName: compliance-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - security
+  - compliance
+  - openscap
+  - audit
+  links:
+  - name: compliance-operator
+    url: https://github.com/openshift/compliance-operator
+  - name: ComplianceAsCode content
+    url: https://github.com/ComplianceAsCode/content
+  - name: OpenSCAP
+    url: https://www.open-scap.org/
+  maintainers:
+  - name: Red Hat Inc.
+  maturity: alpha
+  provider:
+    name: Red Hat, Inc
+  replaces: compliance-operator.v0.1.0
+  version: 0.1.1

--- a/deploy/olm-catalog/compliance-operator/0.1.1/complianceoperator.compliance.openshift.io_complianceremediations_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/0.1.1/complianceoperator.compliance.openshift.io_complianceremediations_crd.yaml
@@ -1,0 +1,379 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: complianceremediations.complianceoperator.compliance.openshift.io
+spec:
+  group: complianceoperator.compliance.openshift.io
+  names:
+    kind: ComplianceRemediation
+    listKind: ComplianceRemediationList
+    plural: complianceremediations
+    singular: complianceremediation
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ComplianceRemediation is the Schema for the complianceremediations
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ComplianceRemediationSpec defines the desired state of ComplianceRemediation
+          properties:
+            apply:
+              description: Whether the remediation should be picked up and applied
+                by the operator
+              type: boolean
+            machineConfigContents:
+              description: The actual remediation payload
+              properties:
+                apiVersion:
+                  description: 'APIVersion defines the versioned schema of this representation
+                    of an object. Servers should convert recognized schemas to the
+                    latest internal value, and may reject unrecognized values. More
+                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                  type: string
+                kind:
+                  description: 'Kind is a string value representing the REST resource
+                    this object represents. Servers may infer this from the endpoint
+                    the client submits requests to. Cannot be updated. In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: MachineConfigSpec defines the desired state of MachineConfig
+                  properties:
+                    config:
+                      description: Config is a Ignition Config object.
+                      properties:
+                        ignition:
+                          properties:
+                            config:
+                              properties:
+                                append:
+                                  items:
+                                    properties:
+                                      source:
+                                        type: string
+                                      verification:
+                                        properties:
+                                          hash:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                                replace:
+                                  properties:
+                                    source:
+                                      type: string
+                                    verification:
+                                      properties:
+                                        hash:
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            security:
+                              properties:
+                                tls:
+                                  properties:
+                                    certificateAuthorities:
+                                      items:
+                                        properties:
+                                          source:
+                                            type: string
+                                          verification:
+                                            properties:
+                                              hash:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            timeouts:
+                              properties:
+                                httpResponseHeaders:
+                                  type: integer
+                                httpTotal:
+                                  type: integer
+                              type: object
+                            version:
+                              type: string
+                          type: object
+                        networkd:
+                          properties:
+                            units:
+                              items:
+                                properties:
+                                  contents:
+                                    type: string
+                                  dropins:
+                                    items:
+                                      properties:
+                                        contents:
+                                          type: string
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        passwd:
+                          properties:
+                            groups:
+                              items:
+                                properties:
+                                  gid:
+                                    type: integer
+                                  name:
+                                    type: string
+                                  passwordHash:
+                                    type: string
+                                  system:
+                                    type: boolean
+                                type: object
+                              type: array
+                            users:
+                              items:
+                                properties:
+                                  create:
+                                    properties:
+                                      gecos:
+                                        type: string
+                                      groups:
+                                        items:
+                                          type: string
+                                        type: array
+                                      homeDir:
+                                        type: string
+                                      noCreateHome:
+                                        type: boolean
+                                      noLogInit:
+                                        type: boolean
+                                      noUserGroup:
+                                        type: boolean
+                                      primaryGroup:
+                                        type: string
+                                      shell:
+                                        type: string
+                                      system:
+                                        type: boolean
+                                      uid:
+                                        type: integer
+                                    type: object
+                                  gecos:
+                                    type: string
+                                  groups:
+                                    items:
+                                      type: string
+                                    type: array
+                                  homeDir:
+                                    type: string
+                                  name:
+                                    type: string
+                                  noCreateHome:
+                                    type: boolean
+                                  noLogInit:
+                                    type: boolean
+                                  noUserGroup:
+                                    type: boolean
+                                  passwordHash:
+                                    type: string
+                                  primaryGroup:
+                                    type: string
+                                  shell:
+                                    type: string
+                                  sshAuthorizedKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                  system:
+                                    type: boolean
+                                  uid:
+                                    type: integer
+                                type: object
+                              type: array
+                          type: object
+                        storage:
+                          properties:
+                            directories:
+                              items:
+                                type: object
+                              type: array
+                            disks:
+                              items:
+                                properties:
+                                  device:
+                                    type: string
+                                  partitions:
+                                    items:
+                                      properties:
+                                        guid:
+                                          type: string
+                                        label:
+                                          type: string
+                                        number:
+                                          type: integer
+                                        size:
+                                          type: integer
+                                        start:
+                                          type: integer
+                                        typeGuid:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  wipeTable:
+                                    type: boolean
+                                type: object
+                              type: array
+                            files:
+                              items:
+                                type: object
+                              type: array
+                            filesystems:
+                              items:
+                                properties:
+                                  mount:
+                                    properties:
+                                      create:
+                                        properties:
+                                          force:
+                                            type: boolean
+                                          options:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      device:
+                                        type: string
+                                      format:
+                                        type: string
+                                      label:
+                                        type: string
+                                      options:
+                                        items:
+                                          type: string
+                                        type: array
+                                      uuid:
+                                        type: string
+                                      wipeFilesystem:
+                                        type: boolean
+                                    type: object
+                                  name:
+                                    type: string
+                                  path:
+                                    type: string
+                                type: object
+                              type: array
+                            links:
+                              items:
+                                type: object
+                              type: array
+                            raid:
+                              items:
+                                properties:
+                                  devices:
+                                    items:
+                                      type: string
+                                    type: array
+                                  level:
+                                    type: string
+                                  name:
+                                    type: string
+                                  options:
+                                    items:
+                                      type: string
+                                    type: array
+                                  spares:
+                                    type: integer
+                                type: object
+                              type: array
+                          type: object
+                        systemd:
+                          properties:
+                            units:
+                              items:
+                                properties:
+                                  contents:
+                                    type: string
+                                  dropins:
+                                    items:
+                                      properties:
+                                        contents:
+                                          type: string
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  enable:
+                                    type: boolean
+                                  enabled:
+                                    type: boolean
+                                  mask:
+                                    type: boolean
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                      required:
+                      - ignition
+                      type: object
+                    fips:
+                      type: boolean
+                    kernelArguments:
+                      items:
+                        type: string
+                      type: array
+                    osImageURL:
+                      description: 'INSERT ADDITIONAL SPEC FIELDS - desired state
+                        of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                        code after modifying this file Add custom validation using
+                        kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+                        OSImageURL specifies the remote location that will be used
+                        to fetch the OS.'
+                      type: string
+                  required:
+                  - config
+                  - fips
+                  - kernelArguments
+                  - osImageURL
+                  type: object
+              type: object
+            type:
+              description: Remediation type specifies the artifact the remediation
+                is based on. For now, only MachineConfig is supported
+              type: string
+          required:
+          - apply
+          type: object
+        status:
+          description: ComplianceRemediationStatus defines the observed state of ComplianceRemediation
+          properties:
+            applicationState:
+              description: Whether the remediation is already applied or not
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/compliance-operator/0.1.1/complianceoperator.compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/0.1.1/complianceoperator.compliance.openshift.io_compliancescans_crd.yaml
@@ -1,0 +1,64 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: compliancescans.complianceoperator.compliance.openshift.io
+spec:
+  group: complianceoperator.compliance.openshift.io
+  names:
+    kind: ComplianceScan
+    listKind: ComplianceScanList
+    plural: compliancescans
+    singular: compliancescan
+  scope: ""
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ComplianceScan is the Schema for the compliancescans API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ComplianceScanSpec defines the desired state of ComplianceScan
+          properties:
+            content:
+              type: string
+            contentImage:
+              type: string
+            nodeSelector:
+              additionalProperties:
+                type: string
+              type: object
+            profile:
+              type: string
+            rule:
+              type: string
+          type: object
+        status:
+          description: ComplianceScanStatus defines the observed state of ComplianceScan
+          properties:
+            errormsg:
+              type: string
+            phase:
+              description: Represents the status of the compliance scan run.
+              type: string
+            result:
+              description: Represents the result of the compliance scan
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/compliance-operator/0.1.1/complianceoperator.compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/0.1.1/complianceoperator.compliance.openshift.io_compliancesuites_crd.yaml
@@ -1,0 +1,110 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: compliancesuites.complianceoperator.compliance.openshift.io
+spec:
+  group: complianceoperator.compliance.openshift.io
+  names:
+    kind: ComplianceSuite
+    listKind: ComplianceSuiteList
+    plural: compliancesuites
+    singular: compliancesuite
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ComplianceSuite is the Schema for the compliancesuites API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ComplianceSuiteSpec defines the desired state of ComplianceSuite
+          properties:
+            autoApplyRemediations:
+              description: Should remediations be applied automatically?
+              type: boolean
+            scans:
+              items:
+                description: ComplianceScanSpecWrapper provides a ComplianceScanSpec
+                  and a Name
+                properties:
+                  content:
+                    type: string
+                  contentImage:
+                    type: string
+                  name:
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  profile:
+                    type: string
+                  rule:
+                    type: string
+                type: object
+              type: array
+          required:
+          - scans
+          type: object
+        status:
+          description: ComplianceSuiteStatus defines the observed state of ComplianceSuite
+          properties:
+            remediationOverview:
+              items:
+                properties:
+                  apply:
+                    description: Whether the remediation should be picked up and applied
+                      by the operator
+                    type: boolean
+                  remediationName:
+                    type: string
+                  scanName:
+                    type: string
+                  type:
+                    description: Remediation type specifies the artifact the remediation
+                      is based on. For now, only MachineConfig is supported
+                    type: string
+                required:
+                - apply
+                - remediationName
+                - scanName
+                type: object
+              type: array
+            scanStatuses:
+              items:
+                description: ComplianceScanStatusWrapper provides a ComplianceScanStatus
+                  and a Name
+                properties:
+                  errormsg:
+                    type: string
+                  name:
+                    type: string
+                  phase:
+                    description: Represents the status of the compliance scan run.
+                    type: string
+                  result:
+                    description: Represents the result of the compliance scan
+                    type: string
+                type: object
+              type: array
+          required:
+          - scanStatuses
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true


### PR DESCRIPTION
This releases version v0.1.1, which takes into use the new quay.io organization for the operator, as well as the latest code.

This also enhances the publish workflow to also generate the csv for the desired release. Note that the relevant versions need to be set up in the Makefile.