### PR TITLE
e2e: Test for errormsg being set in the scan status

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -201,6 +201,11 @@ func scanResultIsExpected(f *framework.Framework, namespace, name string, expect
 	if cs.Status.Result != expectedResult {
 		return fmt.Errorf("The ComplianceScan Result wasn't what we expected. Got '%s', expected '%s'", cs.Status.Result, expectedResult)
 	}
+	if expectedResult == complianceoperatorv1alpha1.ResultError {
+		if cs.Status.ErrorMessage == "" {
+			return fmt.Errorf("The ComplianceScan 'errormsg' wasn't set (it was empty). Even if we expected an error.")
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
We were just testing for the error result, but never noticed if the
errormsg was being set or not. This simply checks if the errormsg is
empty or not, and if it isn't (and we were expecting an error), it'll
fail the test.