### PR TITLE
Optimization: Only parse DS XML once in the aggregator

### DIFF
--- a/pkg/utils/parse_arf_result_test.go
+++ b/pkg/utils/parse_arf_result_test.go
@@ -40,8 +40,9 @@ var _ = Describe("XCCDF parser", func() {
 
 			ds, err = os.Open(dsFilename)
 			Expect(err).NotTo(HaveOccurred())
-
-			remList, err = ParseRemediationFromContentAndResults(schema, "testScan", "testNamespace", ds, xccdf)
+			dsDom, err := ParseContent(ds)
+			Expect(err).NotTo(HaveOccurred())
+			remList, err = ParseRemediationFromContentAndResults(schema, "testScan", "testNamespace", dsDom, xccdf)
 		})
 
 		Context("Valid XCCDF", func() {
@@ -111,7 +112,9 @@ var _ = Describe("XCCDF parser", func() {
 		Context("Valid XCCDF and DS with remediations", func() {
 			Measure("Should parse the XCCDF and DS without errors", func(b Benchmarker) {
 				runtime := b.Time("runtime", func() {
-					remList, err = ParseRemediationFromContentAndResults(schema, "testScan", "testNamespace", ds, xccdf)
+					dsDom, err := ParseContent(ds)
+					Expect(err).NotTo(HaveOccurred())
+					remList, err = ParseRemediationFromContentAndResults(schema, "testScan", "testNamespace", dsDom, xccdf)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(remList).To(HaveLen(5))
 				})


### PR DESCRIPTION
For each ConfigMap, we were parsing the DS file's XML... Which was quite
costly. Instead, lets parse it once, and reuse the xmldom.Document file
for each configMap, as that file's not modified.