### PR TITLE
Add build directories to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,6 @@
 *_test.go
 tests/
 .git/
+build/_output
+build/_test
+_output


### PR DESCRIPTION
This ensures that we don't copy any binaries that we might have
previously built. Thus making the COPY operation lighter.