### PR TITLE
e2e: Speed up the e2e tests by pausing the pool and creating a sub-pool

### DIFF
--- a/pkg/apis/machineconfiguration/v1/register.go
+++ b/pkg/apis/machineconfiguration/v1/register.go
@@ -28,6 +28,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&MachineConfig{},
 		&MachineConfigList{},
+		&MachineConfigPool{},
+		&MachineConfigPoolList{},
 	)
 
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/utils/nodeutils.go
+++ b/pkg/utils/nodeutils.go
@@ -1,0 +1,38 @@
+/*
+Copyright © 2020 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package utils
+
+import "strings"
+
+const (
+	nodeRolePrefix = "node-role.kubernetes.io/"
+)
+
+func GetFirstNodeRole(nodeSelector map[string]string) string {
+	if nodeSelector == nil {
+		return ""
+	}
+
+	// FIXME: should we protect against multiple labels and return
+	// an empty string if there are multiple?
+	for k := range nodeSelector {
+		if strings.HasPrefix(k, nodeRolePrefix) {
+			return strings.TrimPrefix(k, nodeRolePrefix)
+		}
+	}
+
+	return ""
+}

--- a/pkg/utils/nodeutils.go
+++ b/pkg/utils/nodeutils.go
@@ -15,11 +15,29 @@ limitations under the License.
 */
 package utils
 
-import "strings"
+import (
+	"strings"
+)
 
 const (
 	nodeRolePrefix = "node-role.kubernetes.io/"
 )
+
+func GetFirstNodeRoleLabel(nodeSelector map[string]string) string {
+	if nodeSelector == nil {
+		return ""
+	}
+
+	// FIXME: should we protect against multiple labels and return
+	// an empty string if there are multiple?
+	for k := range nodeSelector {
+		if strings.HasPrefix(k, nodeRolePrefix) {
+			return k
+		}
+	}
+
+	return ""
+}
 
 func GetFirstNodeRole(nodeSelector map[string]string) string {
 	if nodeSelector == nil {
@@ -35,4 +53,10 @@ func GetFirstNodeRole(nodeSelector map[string]string) string {
 	}
 
 	return ""
+}
+
+func GetNodeRoleSelector(role string) map[string]string {
+	return map[string]string{
+		nodeRolePrefix + role: "",
+	}
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -14,14 +14,13 @@ import (
 
 	complianceoperatorv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/complianceoperator/v1alpha1"
 	mcfgv1 "github.com/openshift/compliance-operator/pkg/apis/machineconfiguration/v1"
-	mcfgClient "github.com/openshift/compliance-operator/pkg/generated/clientset/versioned/typed/machineconfiguration/v1"
 )
 
 func TestE2E(t *testing.T) {
 	executeTests(t,
 		testExecution{
 			Name: "TestSingleScanSucceeds",
-			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, mcTctx *mcTestCtx, namespace string) error {
 				exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-single-scan",
@@ -48,7 +47,7 @@ func TestE2E(t *testing.T) {
 		},
 		testExecution{
 			Name: "TestScanWithNodeSelectorFiltersCorrectly",
-			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, mcTctx *mcTestCtx, namespace string) error {
 				selectWorkers := map[string]string{
 					"node-role.kubernetes.io/worker": "",
 				}
@@ -85,7 +84,7 @@ func TestE2E(t *testing.T) {
 		},
 		testExecution{
 			Name: "TestScanWithInvalidContentFails",
-			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, mcTctx *mcTestCtx, namespace string) error {
 				exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-scan-w-invalid-content",
@@ -110,7 +109,7 @@ func TestE2E(t *testing.T) {
 		},
 		testExecution{
 			Name: "TestScanWithInvalidProfileFails",
-			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, mcTctx *mcTestCtx, namespace string) error {
 				exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-scan-w-invalid-profile",
@@ -135,7 +134,7 @@ func TestE2E(t *testing.T) {
 		},
 		testExecution{
 			Name: "TestMissingPodInRunningState",
-			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, mcTctx *mcTestCtx, namespace string) error {
 				exampleComplianceScan := &complianceoperatorv1alpha1.ComplianceScan{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-missing-pod-scan",
@@ -180,7 +179,7 @@ func TestE2E(t *testing.T) {
 		},
 		testExecution{
 			Name: "TestSuiteScan",
-			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, mcTctx *mcTestCtx, namespace string) error {
 				suiteName := "test-suite-two-scans"
 
 				workerScanName := fmt.Sprintf("%s-workers-scan", suiteName)
@@ -267,14 +266,10 @@ func TestE2E(t *testing.T) {
 		},
 		testExecution{
 			Name: "TestRemediate",
-			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, mcTctx *mcTestCtx, namespace string) error {
 				// FIXME, maybe have a func that returns a struct with suite name and scan names?
 				suiteName := "test-remediate"
-
 				workerScanName := fmt.Sprintf("%s-workers-scan", suiteName)
-				selectWorkers := map[string]string{
-					"node-role.kubernetes.io/worker": "",
-				}
 
 				exampleComplianceSuite := &complianceoperatorv1alpha1.ComplianceSuite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -289,7 +284,7 @@ func TestE2E(t *testing.T) {
 									ContentImage: "quay.io/jhrozek/ocp4-openscap-content:ignition_remediation",
 									Profile:      "xccdf_org.ssgproject.content_profile_coreos-ncp",
 									Content:      "ssg-ocp4-ds.xml",
-									NodeSelector: selectWorkers,
+									NodeSelector: E2EPoolNodeRoleSelector(),
 								},
 								Name: workerScanName,
 							},
@@ -297,8 +292,11 @@ func TestE2E(t *testing.T) {
 					},
 				}
 
-				// Should this be part of some utility function?
-				mcClient, err := mcfgClient.NewForConfig(f.KubeConfig)
+				err := mcTctx.createE2EPool()
+				if err != nil {
+					t.Errorf("Cannot create subpool for this test")
+					return err
+				}
 
 				err = f.Client.Create(goctx.TODO(), exampleComplianceSuite, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 				if err != nil {
@@ -313,7 +311,7 @@ func TestE2E(t *testing.T) {
 
 				// - Get the no-root-logins remediation for workers
 				workersNoRootLoginsRemName := fmt.Sprintf("%s-no-direct-root-logins", workerScanName)
-				err = applyRemediationAndWaitForReboot(t, f, mcClient, namespace, workersNoRootLoginsRemName, "worker")
+				err = applyRemediationAndWaitForReboot(t, f, mcTctx.mcClient, namespace, workersNoRootLoginsRemName, testPoolName)
 
 				// Also get the remediation so that we can delete it later
 				rem := &complianceoperatorv1alpha1.ComplianceRemediation{}
@@ -339,7 +337,7 @@ func TestE2E(t *testing.T) {
 									ContentImage: "quay.io/jhrozek/ocp4-openscap-content:ignition_remediation",
 									Profile:      "xccdf_org.ssgproject.content_profile_coreos-ncp",
 									Content:      "ssg-ocp4-ds.xml",
-									NodeSelector: selectWorkers,
+									NodeSelector: E2EPoolNodeRoleSelector(),
 								},
 								Name: secondWorkerScanName,
 							},
@@ -374,7 +372,7 @@ func TestE2E(t *testing.T) {
 				// The test should not leave junk around, let's remove the MC and wait for the nodes to stabilize
 				// again
 				t.Logf("Remediation found")
-				err = mcClient.MachineConfigs().Delete(rem.GetMcName(), &metav1.DeleteOptions{})
+				err = mcTctx.mcClient.MachineConfigs().Delete(rem.GetMcName(), &metav1.DeleteOptions{})
 				if err != nil {
 					return err
 				}
@@ -395,7 +393,7 @@ func TestE2E(t *testing.T) {
 				}
 
 				// We need to wait for both the pool to update..
-				err = waitForMachinePoolUpdate(t, mcClient, "worker", dummyAction, poolHasNoMc)
+				err = waitForMachinePoolUpdate(t, mcTctx.mcClient, testPoolName, dummyAction, poolHasNoMc)
 				if err != nil {
 					t.Errorf("Failed to wait for workers to come back up after deleting MC")
 					return err
@@ -414,14 +412,11 @@ func TestE2E(t *testing.T) {
 		},
 		testExecution{
 			Name: "TestUnapplyRemediation",
-			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, mcTctx *mcTestCtx, namespace string) error {
 				// FIXME, maybe have a func that returns a struct with suite name and scan names?
 				suiteName := "test-unapply-remediation"
 
 				workerScanName := fmt.Sprintf("%s-workers-scan", suiteName)
-				selectWorkers := map[string]string{
-					"node-role.kubernetes.io/worker": "",
-				}
 
 				exampleComplianceSuite := &complianceoperatorv1alpha1.ComplianceSuite{
 					ObjectMeta: metav1.ObjectMeta{
@@ -436,7 +431,7 @@ func TestE2E(t *testing.T) {
 									ContentImage: "quay.io/jhrozek/ocp4-openscap-content:ignition_remediation",
 									Profile:      "xccdf_org.ssgproject.content_profile_coreos-ncp",
 									Content:      "ssg-ocp4-ds.xml",
-									NodeSelector: selectWorkers,
+									NodeSelector: E2EPoolNodeRoleSelector(),
 								},
 								Name: workerScanName,
 							},
@@ -444,8 +439,11 @@ func TestE2E(t *testing.T) {
 					},
 				}
 
-				// Should this be part of some utility function?
-				mcClient, err := mcfgClient.NewForConfig(f.KubeConfig)
+				err := mcTctx.createE2EPool()
+				if err != nil {
+					t.Errorf("Cannot create subpool for this test")
+					return err
+				}
 
 				err = f.Client.Create(goctx.TODO(), exampleComplianceSuite, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 				if err != nil {
@@ -459,28 +457,28 @@ func TestE2E(t *testing.T) {
 				}
 
 				// Pause the MC so that we have only one reboot
-				err = pauseMachinePool(t, mcClient, "worker")
+				err = pauseMachinePool(t, mcTctx.mcClient, testPoolName)
 				if err != nil {
 					return err
 				}
 
 				// Apply both remediations
 				workersNoRootLoginsRemName := fmt.Sprintf("%s-no-direct-root-logins", workerScanName)
-				err = applyRemediationAndCheck(t, f, mcClient, namespace, workersNoRootLoginsRemName, "worker")
+				err = applyRemediationAndCheck(t, f, mcTctx.mcClient, namespace, workersNoRootLoginsRemName, testPoolName)
 				if err != nil {
 					t.Logf("WARNING: Got an error while applying remediation '%s': %v", workersNoRootLoginsRemName, err)
 				}
 				t.Logf("Remediation %s applied", workersNoRootLoginsRemName)
 
 				workersNoEmptyPassRemName := fmt.Sprintf("%s-no-empty-passwords", workerScanName)
-				err = applyRemediationAndCheck(t, f, mcClient, namespace, workersNoEmptyPassRemName, "worker")
+				err = applyRemediationAndCheck(t, f, mcTctx.mcClient, namespace, workersNoEmptyPassRemName, testPoolName)
 				if err != nil {
 					t.Logf("WARNING: Got an error while applying remediation '%s': %v", workersNoEmptyPassRemName, err)
 				}
 				t.Logf("Remediation %s applied", workersNoEmptyPassRemName)
 
 				// unpause the MCP so that the remediation gets applied
-				err = unPauseMachinePoolAndWait(t, mcClient, "worker")
+				err = unPauseMachinePoolAndWait(t, mcTctx.mcClient, testPoolName)
 				if err != nil {
 					return err
 				}
@@ -493,17 +491,17 @@ func TestE2E(t *testing.T) {
 
 				// Get the resulting MC
 				mcName := fmt.Sprintf("75-%s-%s", workerScanName, suiteName)
-				mcBoth, err := mcClient.MachineConfigs().Get(mcName, metav1.GetOptions{})
+				mcBoth, err := mcTctx.mcClient.MachineConfigs().Get(mcName, metav1.GetOptions{})
 				t.Logf("MC %s exists", mcName)
 
 				// Revert one remediation. The MC should stay, but its generation should bump
 				t.Logf("Will revert remediation %s", workersNoEmptyPassRemName)
-				err = unApplyRemediationAndCheck(t, f, mcClient, namespace, workersNoEmptyPassRemName, "worker", false)
+				err = unApplyRemediationAndCheck(t, f, mcTctx.mcClient, namespace, workersNoEmptyPassRemName, testPoolName, false)
 				if err != nil {
 					t.Logf("WARNING: Got an error while unapplying remediation '%s': %v", workersNoEmptyPassRemName, err)
 				}
 				t.Logf("Remediation %s reverted", workersNoEmptyPassRemName)
-				mcOne, err := mcClient.MachineConfigs().Get(mcName, metav1.GetOptions{})
+				mcOne, err := mcTctx.mcClient.MachineConfigs().Get(mcName, metav1.GetOptions{})
 
 				if mcOne.Generation == mcBoth.Generation {
 					t.Errorf("Expected that the MC generation changes. Got: %d, Expected: %d", mcOne.Generation, mcBoth.Generation)
@@ -511,11 +509,11 @@ func TestE2E(t *testing.T) {
 
 				// When we unapply the second remediation, the MC should be deleted, too
 				t.Logf("Will revert remediation %s", workersNoRootLoginsRemName)
-				err = unApplyRemediationAndCheck(t, f, mcClient, namespace, workersNoRootLoginsRemName, "worker", true)
+				err = unApplyRemediationAndCheck(t, f, mcTctx.mcClient, namespace, workersNoRootLoginsRemName, testPoolName, true)
 				t.Logf("Remediation %s reverted", workersNoEmptyPassRemName)
 
 				t.Logf("No remediation-based MCs should exist now")
-				_, err = mcClient.MachineConfigs().Get(mcName, metav1.GetOptions{})
+				_, err = mcTctx.mcClient.MachineConfigs().Get(mcName, metav1.GetOptions{})
 				if err == nil {
 					t.Errorf("MC %s unexpectedly found", mcName)
 				}

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -2,7 +2,9 @@ package e2e
 
 import (
 	goctx "context"
+	"errors"
 	"fmt"
+	"github.com/openshift/compliance-operator/pkg/utils"
 	"testing"
 	"time"
 
@@ -23,9 +25,88 @@ import (
 	mcfgClient "github.com/openshift/compliance-operator/pkg/generated/clientset/versioned/typed/machineconfiguration/v1"
 )
 
+const (
+	workerPoolName = "worker"
+	testPoolName   = "e2e"
+)
+
 type testExecution struct {
 	Name   string
-	TestFn func(*testing.T, *framework.Framework, *framework.TestCtx, string) error
+	TestFn func(*testing.T, *framework.Framework, *framework.TestCtx, *mcTestCtx, string) error
+}
+
+type mcTestCtx struct {
+	mcClient *mcfgClient.MachineconfigurationV1Client
+
+	f     *framework.Framework
+	t     *testing.T
+	pools []*mcfgv1.MachineConfigPool
+}
+
+func NewMcTestCtx(f *framework.Framework, t *testing.T) (*mcTestCtx, error) {
+	mcClient, err := mcfgClient.NewForConfig(f.KubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcTestCtx{mcClient: mcClient, f: f, t: t}, nil
+}
+
+func (c *mcTestCtx) cleanupTrackedPools() {
+	for _, p := range c.pools {
+		// Then find all nodes that are labeled with this pool and remove the label
+		// Search the nodes with this label
+		poolNodes := getNodesWithSelector(c.f, p.Spec.NodeSelector.MatchLabels)
+		rmPoolLabel := utils.GetFirstNodeRoleLabel(p.Spec.NodeSelector.MatchLabels)
+
+		err := unLabelNodes(c.t, c.f, rmPoolLabel, poolNodes)
+		if err != nil {
+			c.t.Errorf("Could not unlabel nodes from pool %s: %v\n", rmPoolLabel, err)
+		}
+
+		// Unlabeling the nodes triggers an update of the affected nodes because the nodes
+		// will then start using a different rendered pool. e.g a node that used to be labeled
+		// with "e2e,worker" and becomes labeled with "worker" switches from "rendered-e2e-*"
+		// to "rendered-worker-*". If we didn't wait, the node might have tried to use the
+		// e2e pool that would be gone when we remove it with the next call
+		err = waitForNodesToHaveARenderedPool(c.t, c.f, c.mcClient, poolNodes, workerPoolName)
+		if err != nil {
+			c.t.Errorf("Error waiting for nodes to reach the worker pool again: %v\n", err)
+		}
+
+		err = waitForPoolCondition(c.t, c.mcClient, mcfgv1.MachineConfigPoolUpdated, p.Name)
+		if err != nil {
+			c.t.Errorf("Error waiting for reboot after nodes were unlabeled: %v\n", err)
+		}
+
+		// Then delete the pool itself
+		c.t.Logf("Removing pool %s\n", p.Name)
+		err = c.mcClient.MachineConfigPools().Delete(p.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			c.t.Errorf("Could not remove pool %s: %v\n", p.Name, err)
+		}
+	}
+}
+
+func (c *mcTestCtx) trackPool(pool *mcfgv1.MachineConfigPool) {
+	for _, p := range c.pools {
+		if p.Name == pool.Name {
+			return
+		}
+	}
+	c.pools = append(c.pools, pool)
+	c.t.Logf("Tracking pool %s\n", pool.Name)
+}
+
+func (c *mcTestCtx) createE2EPool() error {
+	pool, err := createReadyMachineConfigPoolSubset(c.t, c.f, c.mcClient, workerPoolName, testPoolName)
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	c.trackPool(pool)
+	return nil
 }
 
 // executeTest sets up everything that a e2e test needs to run, and executes the test.
@@ -43,9 +124,15 @@ func executeTests(t *testing.T, tests ...testExecution) {
 		t.Fatalf("could not get namespace: %v", err)
 	}
 
+	mcTctx, err := NewMcTestCtx(f, t)
+	if err != nil {
+		t.Fatalf("could not create the MC test context: %v", err)
+	}
+	defer mcTctx.cleanupTrackedPools()
+
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			if err := test.TestFn(t, f, ctx, ns); err != nil {
+			if err := test.TestFn(t, f, ctx, mcTctx, ns); err != nil {
 				t.Error(err)
 			}
 		})
@@ -400,6 +487,46 @@ func waitForNodesToBeReady(t *testing.T, f *framework.Framework) error {
 	return nil
 }
 
+// waitForNodesToHaveARenderedPool wait until all nodes passed through a parameter transition to a rendered
+// config from a pool that is passed through a parameter as well. A typical use-case is when a node is unlabeled
+// from a pool, in that case we need to wait until MCO makes the node use the other available pool. Only then it
+// is safe to remove the pool the node was labeled with, otherwise the node might still on next reboot use the
+// pool that was removed and this would mean the node transitions into Degraded state
+func waitForNodesToHaveARenderedPool(t *testing.T, f *framework.Framework, mcClient *mcfgClient.MachineconfigurationV1Client, nodes []corev1.Node, poolName string) error {
+	pool, err := mcClient.MachineConfigPools().Get(poolName, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Could not find pool %s\n", poolName)
+		return err
+	}
+
+	t.Logf("We'll wait for the nodes to reach %s\n", pool.Spec.Configuration.Name)
+	return wait.PollImmediate(10*time.Second, timeout, func() (bool, error) {
+		for _, loopNode := range nodes {
+			node := &corev1.Node{}
+			err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: loopNode.Name}, node)
+			if err != nil {
+				return false, err
+			}
+
+			t.Logf("Node %s has config %s, desired config %s state %s",
+				node.Name,
+				node.Annotations["machineconfiguration.openshift.io/currentConfig"],
+				node.Annotations["machineconfiguration.openshift.io/desiredConfig"],
+				node.Annotations["machineconfiguration.openshift.io/state"])
+
+			if node.Annotations["machineconfiguration.openshift.io/desiredConfig"] != pool.Spec.Configuration.Name ||
+				node.Annotations["machineconfiguration.openshift.io/currentConfig"] != node.Annotations["machineconfiguration.openshift.io/desiredConfig"] {
+				t.Logf("Node %s still updating", node.Name)
+				return false, nil
+			}
+			t.Logf("Node %s was updated", node.Name)
+		}
+
+		t.Logf("All machines updated")
+		return true, nil
+	})
+}
+
 func applyRemediationAndCheck(t *testing.T, f *framework.Framework, mcClient *mcfgClient.MachineconfigurationV1Client, namespace, name, pool string) error {
 	rem := &complianceoperatorv1alpha1.ComplianceRemediation{}
 	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, rem)
@@ -549,7 +676,7 @@ func unPauseMachinePoolAndWait(t *testing.T, mcClient *mcfgClient.Machineconfigu
 		return false, nil
 	})
 
-	return nil
+	return err
 }
 
 func pauseMachinePool(t *testing.T, mcClient *mcfgClient.MachineconfigurationV1Client, poolName string) error {
@@ -576,4 +703,142 @@ func modMachinePoolPause(t *testing.T, mcClient *mcfgClient.Machineconfiguration
 	}
 
 	return nil
+}
+
+func createReadyMachineConfigPoolSubset(t *testing.T, f *framework.Framework, mcClient *mcfgClient.MachineconfigurationV1Client, oldPoolName, newPoolName string) (*mcfgv1.MachineConfigPool, error) {
+	pool, err := createMachineConfigPoolSubset(t, f, mcClient, oldPoolName, newPoolName)
+	if err != nil {
+		return nil, err
+	}
+
+	err = waitForPoolCondition(t, mcClient, mcfgv1.MachineConfigPoolUpdated, newPoolName)
+	if err != nil {
+		return nil, err
+	}
+	return pool, nil
+}
+
+// picks a random machine from an existing pool and creates a subset of the pool with
+// one machine
+func createMachineConfigPoolSubset(t *testing.T, f *framework.Framework, mcClient *mcfgClient.MachineconfigurationV1Client, oldPoolName, newPoolName string) (*mcfgv1.MachineConfigPool, error) {
+	// retrieve the old pool
+	oldPool, err := mcClient.MachineConfigPools().Get(oldPoolName, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Could not find the pool to modify")
+		return nil, err
+	}
+
+	// list the nodes matching the node selector
+	poolNodes := getNodesWithSelector(f, oldPool.Spec.NodeSelector.MatchLabels)
+	if len(poolNodes) == 0 {
+		return nil, errors.New("no nodes found with the old pool selector")
+	}
+
+	// just pick one of them and create the new pool out of that one-item node slice
+	return createMachineConfigPool(t, f, mcClient, oldPoolName, newPoolName, poolNodes[:1])
+}
+
+// creates a new pool named newPoolName from a list of nodes
+func createMachineConfigPool(t *testing.T, f *framework.Framework, mcClient *mcfgClient.MachineconfigurationV1Client, oldPoolName, newPoolName string, nodes []corev1.Node) (*mcfgv1.MachineConfigPool, error) {
+	newPoolNodeLabel := fmt.Sprintf("node-role.kubernetes.io/%s", newPoolName)
+
+	err := labelNodes(t, f, newPoolNodeLabel, nodes)
+	if err != nil {
+		return nil, err
+	}
+
+	return createMCPObject(mcClient, newPoolNodeLabel, oldPoolName, newPoolName)
+}
+
+func labelNodes(t *testing.T, f *framework.Framework, newPoolNodeLabel string, nodes []corev1.Node) error {
+	for _, node := range nodes {
+		nodeCopy := node.DeepCopy()
+		nodeCopy.Labels[newPoolNodeLabel] = ""
+
+		t.Logf("Adding label %s to node %s\n", newPoolNodeLabel, nodeCopy.Name)
+		err := f.Client.Update(goctx.TODO(), nodeCopy)
+		if err != nil {
+			t.Logf("Could not label node %s with %s\n", nodeCopy.Name, newPoolNodeLabel)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func unLabelNodes(t *testing.T, f *framework.Framework, rmPoolNodeLabel string, nodes []corev1.Node) error {
+	for _, node := range nodes {
+		nodeCopy := node.DeepCopy()
+		delete(nodeCopy.Labels, rmPoolNodeLabel)
+
+		t.Logf("Removing label %s from node %s\n", rmPoolNodeLabel, nodeCopy.Name)
+		err := f.Client.Update(goctx.TODO(), nodeCopy)
+		if err != nil {
+			t.Logf("Could not label node %s with %s\n", nodeCopy.Name, rmPoolNodeLabel)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createMCPObject(mcClient *mcfgClient.MachineconfigurationV1Client, newPoolNodeLabel, oldPoolName, newPoolName string) (*mcfgv1.MachineConfigPool, error) {
+	nodeSelectorMatchLabel := make(map[string]string)
+	nodeSelectorMatchLabel[newPoolNodeLabel] = ""
+
+	newPool := mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{Name: newPoolName},
+		Spec: mcfgv1.MachineConfigPoolSpec{
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: nodeSelectorMatchLabel,
+			},
+			MachineConfigSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      mcfgv1.MachineConfigRoleLabelKey,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{oldPoolName, newPoolName},
+					},
+				},
+			},
+		},
+	}
+
+	return mcClient.MachineConfigPools().Create(&newPool)
+}
+
+func waitForPoolCondition(t *testing.T, mcClient *mcfgClient.MachineconfigurationV1Client, conditionType mcfgv1.MachineConfigPoolConditionType, newPoolName string) error {
+	return wait.PollImmediate(10*time.Second, 20*time.Minute, func() (bool, error) {
+		pool, err := mcClient.MachineConfigPools().Get(newPoolName, metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("Could not find the pool post update")
+			return false, err
+		}
+
+		if isMachineConfigPoolConditionTrue(pool.Status.Conditions, conditionType) {
+			return true, nil
+		}
+
+		t.Logf("The pool has not updated yet\n")
+		return false, nil
+	})
+}
+
+// isMachineConfigPoolConditionTrue returns true when the conditionType is present and set to `ConditionTrue`
+func isMachineConfigPoolConditionTrue(conditions []mcfgv1.MachineConfigPoolCondition, conditionType mcfgv1.MachineConfigPoolConditionType) bool {
+	return IsMachineConfigPoolConditionPresentAndEqual(conditions, conditionType, corev1.ConditionTrue)
+}
+
+// IsMachineConfigPoolConditionPresentAndEqual returns true when conditionType is present and equal to status.
+func IsMachineConfigPoolConditionPresentAndEqual(conditions []mcfgv1.MachineConfigPoolCondition, conditionType mcfgv1.MachineConfigPoolConditionType, status corev1.ConditionStatus) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == status
+		}
+	}
+	return false
+}
+
+func E2EPoolNodeRoleSelector() map[string]string {
+	return utils.GetNodeRoleSelector(testPoolName)
 }

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -423,9 +423,8 @@ func applyRemediationAndCheck(t *testing.T, f *framework.Framework, mcClient *mc
 			}
 		}
 
-		// When applying a remediation, check that the MC *is not* in the pool
 		t.Logf("Remediation %s not present in pool %s, returning false", rem.GetMcName(), pool.Name)
-		return true, nil
+		return false, nil
 	}
 
 	err = waitForMachinePoolUpdate(t, mcClient, pool, applyRemediation, predicate)


### PR DESCRIPTION
There are two optimizations in the patchset: Pause a pool when we work with
multiple remediations and creating a sub-pool. There are some other optimizations
we could do to speed up the tests, namely:
    * We could only remove the MC created through our aggregated remediations
      when the custom pool is deleted. This would shave off one more reboot
      from the TestRemediate testcase.
    * We could use a slimmed-down content with only one rule or a handful of rules
      needed for the test. This would speed up every Scan by about a minute, but
      on the other hand, we've already seen issues triggered by the full scan earlier
      like the CM size overflowing, so I'm not sure this is a good idea in the
      general case.

Please see the commit messages for a detailed explanation of each change. The two
most important commits are highlighted below.

e2e: Speed up tests by pausing a MachineConfigPool before modifying it
----------------------------------------------------------------------

Some tests need to apply multiple MachineConfigs during their run. Because
normally, applying a MC means the cluster gets rebooted, applying N MCs
meant N reboots. If we pause a cluster by setting paused=true prior to
applying a MC and then unpause after all the MCs are updated, we can only
reboot the cluster once during the whole test.

Required a little refactoring of the functions that wait for the different
state changes in the cluster as some of the conditions are different when a
pool is paused, for example we can't check that a MC is present in a pool's
status, but only in its spec.

e2e: Use sub-pool to speed up the e2e test
----------------------------------------------------------------------

It is possible to label a node with several pools, creating a sub-pool:
    https://github.com/openshift/machine-config-operator/blob/master/docs/custom-pools.md

We leverage this in our e2e tests in order to create a pool with a single
machine only. This has the benefit of rebooting only one node when applying
or unapplying a remediation.

In my testing with an AWS cluster with three workers, running the tests 
that actually touch remediations is about twice as fast using this 
optimization.

Because creating or removing a pool also triggers a reboot of the node that
we label, we also add a new structure mcTestCtx that is instantiated and
torn down together with the whole suite. Any pool created for the e2e test
run is tracked by this structure and when the suite is torn down, the nodes
are unlabeled and then the pool is removed, therefore we only incur the
overhead of creating and removing the pool once per suite run.