### PR TITLE
Add services delete permission to role

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -72,6 +72,7 @@ rules:
   - create      # The operator needs to create a service to expose the metrics and resultserver
   - get
   - update
+  - delete
 - apiGroups:
   - monitoring.coreos.com
   resources:


### PR DESCRIPTION
The ComplianceScan controller has to delete the resultserver services, but did not have permission.

Seen in CI: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_compliance-operator/124/pull-ci-openshift-compliance-operator-master-e2e-aws/620/artifacts/e2e-aws/pods/openshift-compliance_compliance-operator-6fbfbb9989-pvdjl_compliance-operator.log
```
{"level":"error","ts":1583261458.9643643,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"compliancescan-controller","request":"openshift-compliance/test-recheck-remediations-workers-scan","error":"services \"test-recheck-remediations-workers-scan-rs\" is forbidden: User \"system:serviceaccount:openshift-compliance:compliance-operator\" cannot delete resource \"services\" in API group \"\" in the namespace \"openshift-compliance\"","stacktrace":"github.com/openshift/compliance-operator/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/src/github.com/openshift/compliance-operator/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:258\ngithub.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232\ngithub.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/src/github.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211\ngithub.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/src/github.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152\ngithub.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/src/github.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153\ngithub.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait.Until\n\t/go/src/github.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```