### PR TITLE
Delete scan/logcollector pods & PKI secrets when the scan is done

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -38,6 +38,7 @@ rules:
   - list
   - update
   - watch
+  - delete
 - apiGroups:
   - apps
   resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -16,6 +16,7 @@ rules:
   - create      # The operator needs to spawn the containers
   - get
   - list
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -381,13 +381,13 @@ func (r *ReconcileComplianceScan) handleRootCASecret(instance *complianceoperato
 		return err
 	}
 
-	// Create the CA secret.
-	err = r.client.Create(context.TODO(), secret)
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if err = controllerutil.SetControllerReference(instance, secret, r.scheme); err != nil {
 		return err
 	}
 
-	if err = controllerutil.SetControllerReference(instance, secret, r.scheme); err != nil {
+	// Create the CA secret.
+	err = r.client.Create(context.TODO(), secret)
+	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
 
@@ -409,16 +409,15 @@ func (r *ReconcileComplianceScan) handleResultServerSecret(instance *complianceo
 		return err
 	}
 
+	if err = controllerutil.SetControllerReference(instance, secret, r.scheme); err != nil {
+		return err
+	}
+
 	// Create the server cert secret.
 	err = r.client.Create(context.TODO(), secret)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
-
-	if err = controllerutil.SetControllerReference(instance, secret, r.scheme); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -437,13 +436,13 @@ func (r *ReconcileComplianceScan) handleResultClientSecret(instance *complianceo
 		return err
 	}
 
-	// Create the client cert secret.
-	err = r.client.Create(context.TODO(), secret)
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if err = controllerutil.SetControllerReference(instance, secret, r.scheme); err != nil {
 		return err
 	}
 
-	if err = controllerutil.SetControllerReference(instance, secret, r.scheme); err != nil {
+	// Create the client cert secret.
+	err = r.client.Create(context.TODO(), secret)
+	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
 

--- a/pkg/controller/compliancescan/compliancescan_controller_test.go
+++ b/pkg/controller/compliancescan/compliancescan_controller_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	. "github.com/onsi/ginkgo"
@@ -55,11 +54,8 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 		}
 
 		caSecret, _ := makeCASecret(compliancescaninstance, common.GetComplianceOperatorNamespace())
-		spew.Dump(caSecret)
 		serverSecret, _ := serverCertSecret(compliancescaninstance, caSecret.Data[corev1.TLSCertKey], caSecret.Data[corev1.TLSPrivateKeyKey], common.GetComplianceOperatorNamespace())
-		spew.Dump(serverSecret)
 		clientSecret, _ := clientCertSecret(compliancescaninstance, caSecret.Data[corev1.TLSCertKey], caSecret.Data[corev1.TLSPrivateKeyKey], common.GetComplianceOperatorNamespace())
-		spew.Dump(clientSecret)
 
 		objs = append(objs, nodeinstance1, nodeinstance2, caSecret, serverSecret, clientSecret)
 		scheme := scheme.Scheme

--- a/pkg/controller/compliancescan/utils.go
+++ b/pkg/controller/compliancescan/utils.go
@@ -2,9 +2,6 @@ package compliancescan
 
 import (
 	"context"
-
-	"k8s.io/apimachinery/pkg/api/errors"
-
 	// we can suppress the gosec warning about sha1 here because we don't use sha1 for crypto
 	// purposes, but only as a string shortener
 	// #nosec G505
@@ -16,6 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -111,7 +109,7 @@ func serverCertSecret(instance *complianceoperatorv1alpha1.ComplianceScan, ca, c
 		return nil, err
 	}
 
-	return certSecret(ServerCertPrefix+instance.Name, namespace, cert, key, ca), nil
+	return certSecret(getServerCertSecretName(instance), namespace, cert, key, ca), nil
 }
 
 // Issue a client cert using the instance Root CA (it needs to be created prior to calling this function).
@@ -133,7 +131,7 @@ func clientCertSecret(instance *complianceoperatorv1alpha1.ComplianceScan, ca, c
 		return nil, err
 	}
 
-	return certSecret(ClientCertPrefix+instance.Name, namespace, cert, key, ca), nil
+	return certSecret(getClientCertSecretName(instance), namespace, cert, key, ca), nil
 }
 
 func makeCASecret(instance *complianceoperatorv1alpha1.ComplianceScan, namespace string) (*v1.Secret, error) {
@@ -142,7 +140,19 @@ func makeCASecret(instance *complianceoperatorv1alpha1.ComplianceScan, namespace
 		return nil, err
 	}
 
-	return certSecret(RootCAPrefix+instance.Name, namespace, cert, key, []byte{}), nil
+	return certSecret(getCASecretName(instance), namespace, cert, key, []byte{}), nil
+}
+
+func getServerCertSecretName(instance *complianceoperatorv1alpha1.ComplianceScan) string {
+	return ServerCertPrefix + instance.Name
+}
+
+func getClientCertSecretName(instance *complianceoperatorv1alpha1.ComplianceScan) string {
+	return ClientCertPrefix + instance.Name
+}
+
+func getCASecretName(instance *complianceoperatorv1alpha1.ComplianceScan) string {
+	return RootCAPrefix + instance.Name
 }
 
 func certSecret(name, namespace string, cert, key, ca []byte) *corev1.Secret {


### PR DESCRIPTION
This removes the pods & secrets to clean up the namespace once the scan is done.

As a side-effect of deleting the PKI secrets, it means that we don't have to deal with cert-rotation, given that we generate a new PKI per-scan.