### PR TITLE
Make remediation-aggregator more resilient

### DIFF
--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -1044,7 +1044,7 @@ func newAggregatorPod(scanInstance *complianceoperatorv1alpha1.ComplianceScan, l
 					},
 				},
 			},
-			RestartPolicy: corev1.RestartPolicyNever,
+			RestartPolicy: corev1.RestartPolicyOnFailure,
 			Volumes: []corev1.Volume{
 				{
 					Name: "content-dir",


### PR DESCRIPTION
This makes the aggregator resist temporary network failures by using the
retry function from the backoff library on the k8s operations (when
creating a remediation and when updating configmaps).

On the other hand, this moves the configmap updating to the end of the
script, since, if the script fails, we want to try to parse them all
again and make sure we have all the remediations created.

Finally, this changes the policy of the pod to RestartOnFailure.