### PR TITLE
complianceremediation: Don't reuse loop variable

### DIFF
--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -224,25 +224,25 @@ func getAppliedMcRemediations(r *ReconcileComplianceRemediation, rem *compliance
 	}
 
 	appliedRemediations := make([]*mcfgv1.MachineConfig, 0, len(scanSuiteRemediations.Items))
-	for _, candidate := range scanSuiteRemediations.Items {
-		if candidate.Spec.Type != complianceoperatorv1alpha1.McRemediation {
+	for i := range scanSuiteRemediations.Items {
+		if scanSuiteRemediations.Items[i].Spec.Type != complianceoperatorv1alpha1.McRemediation {
 			// We'll only merge MachineConfigs
 			continue
 		}
-		if candidate.Status.ApplicationState != complianceoperatorv1alpha1.RemediationApplied {
+		if scanSuiteRemediations.Items[i].Status.ApplicationState != complianceoperatorv1alpha1.RemediationApplied {
 			// We'll only merge the one that is being reconciled with those that are already
 			// applied
 			continue
 		}
 
-		if candidate.Name == rem.Name {
+		if scanSuiteRemediations.Items[i].Name == rem.Name {
 			// Won't add the one being reconciled to the list, it might be that we're de-selecting
 			// it, so the one being reconciled is handled separately
 			continue
 		}
 
 		// OK, we've got an applied MC, add it to the list
-		appliedRemediations = append(appliedRemediations, &candidate.Spec.MachineConfigContents)
+		appliedRemediations = append(appliedRemediations, &scanSuiteRemediations.Items[i].Spec.MachineConfigContents)
 	}
 
 	return appliedRemediations, nil

--- a/pkg/controller/complianceremediation/complianceremediation_controller_test.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller_test.go
@@ -1,0 +1,171 @@
+package complianceremediation
+
+import (
+	"context"
+	"fmt"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	complianceoperatorv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/complianceoperator/v1alpha1"
+)
+
+func isRemInList(mcList []*mcfgv1.MachineConfig, rem *complianceoperatorv1alpha1.ComplianceRemediation) bool {
+	for _, mc := range mcList {
+		if same := reflect.DeepEqual(mc.Spec, rem.Spec.MachineConfigContents.Spec); same == true {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getMockedRemediation(name string, labels map[string]string, applied bool, status complianceoperatorv1alpha1.RemediationApplicationState) *complianceoperatorv1alpha1.ComplianceRemediation {
+	files := []igntypes.File{
+		{
+			Node: igntypes.Node{
+				Path: "/" + name,
+			},
+		},
+	}
+
+	return &complianceoperatorv1alpha1.ComplianceRemediation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: labels,
+		},
+		Spec:complianceoperatorv1alpha1.ComplianceRemediationSpec{
+			ComplianceRemediationSpecMeta: complianceoperatorv1alpha1.ComplianceRemediationSpecMeta{
+				Type:complianceoperatorv1alpha1.McRemediation,
+				Apply:applied,
+			},
+			MachineConfigContents:         mcfgv1.MachineConfig{
+				TypeMeta:   metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       mcfgv1.MachineConfigSpec{
+					Config: igntypes.Config{
+						Ignition: igntypes.Ignition{
+							Version: igntypes.MaxVersion.String(),
+						},
+						Storage: igntypes.Storage{
+							Files: files,
+						},
+					},
+				},
+			},
+		},
+		Status:complianceoperatorv1alpha1.ComplianceRemediationStatus{
+			ApplicationState: status,
+		},
+	}
+}
+
+var _ = Describe("Testing complianceremediation controller", func() {
+
+	var (
+		complianceremediationinstance *complianceoperatorv1alpha1.ComplianceRemediation
+		reconciler             ReconcileComplianceRemediation
+		testRemLabels			map[string]string
+	)
+
+	BeforeEach(func() {
+		objs := []runtime.Object{}
+
+		testRemLabels = make(map[string]string)
+		testRemLabels[complianceoperatorv1alpha1.SuiteLabel] = "mySuite"
+		testRemLabels[complianceoperatorv1alpha1.ScanLabel] = "myScan"
+		testRemLabels[mcfgv1.MachineConfigRoleLabelKey] = "myRole"
+
+		// test instance
+		complianceremediationinstance = &complianceoperatorv1alpha1.ComplianceRemediation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "testRem",
+				Labels: testRemLabels,
+			},
+		}
+		objs = append(objs, complianceremediationinstance)
+
+		scheme := scheme.Scheme
+		scheme.AddKnownTypes(complianceoperatorv1alpha1.SchemeGroupVersion, complianceremediationinstance)
+		scheme.AddKnownTypes(complianceoperatorv1alpha1.SchemeGroupVersion, &complianceoperatorv1alpha1.ComplianceRemediationList{})
+
+		client := fake.NewFakeClientWithScheme(scheme, objs...)
+		reconciler = ReconcileComplianceRemediation{client: client, scheme: scheme}
+	})
+
+	Context("Only a single remediation", func() {
+		It("should return an empty list if nothing matches", func() {
+			machineConfigs, err := getAppliedMcRemediations(&reconciler, complianceremediationinstance)
+			Expect(len(machineConfigs)).To(BeZero())
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("Multiple matching remediations", func() {
+		existingRemediations := make([]*complianceoperatorv1alpha1.ComplianceRemediation, 0)
+		const numExisting = 10
+
+		BeforeEach(func() {
+			fmt.Println("creating")
+			for i := 0; i < numExisting; i++ {
+				name := fmt.Sprintf("existingRemediation-%02d", i)
+				rem := getMockedRemediation(name, testRemLabels, true, complianceoperatorv1alpha1.RemediationApplied)
+				err := reconciler.client.Create(context.TODO(), rem)
+				Expect(err).To(BeNil())
+				existingRemediations = append(existingRemediations, rem)
+			}
+		})
+
+		AfterEach(func() {
+			for i := 0; i < numExisting; i++ {
+				name := fmt.Sprintf("existingRemediation-%02d", i)
+
+				toDelete := complianceoperatorv1alpha1.ComplianceRemediation{}
+				err := reconciler.client.Get(context.TODO(), types.NamespacedName{Name:name}, &toDelete)
+				Expect(err).To(BeNil())
+
+				err = reconciler.client.Delete(context.TODO(), &toDelete)
+				Expect(err).To(BeNil())
+			}
+		})
+
+		It("should find them all them all", func() {
+			machineConfigs, err := getAppliedMcRemediations(&reconciler, complianceremediationinstance)
+			Expect(len(machineConfigs)).To(Equal(numExisting))
+			Expect(err).To(BeNil())
+
+			for _, rem := range existingRemediations {
+				ok := isRemInList(machineConfigs, rem)
+				Expect(ok).To(BeTrue())
+			}
+		})
+
+		It("should skip those that are not applied", func() {
+			notApplied := existingRemediations[1]
+			notApplied.Status.ApplicationState = complianceoperatorv1alpha1.RemediationNotSelected
+			err := reconciler.client.Update(context.TODO(), notApplied)
+			Expect(err).To(BeNil())
+
+			machineConfigs, err := getAppliedMcRemediations(&reconciler, complianceremediationinstance)
+			Expect(len(machineConfigs)).To(Equal(numExisting-1))
+			Expect(err).To(BeNil())
+
+			for _, rem := range existingRemediations {
+				ok := isRemInList(machineConfigs, rem)
+				if rem.Name == notApplied.Name {
+					Expect(ok).To(BeFalse())
+				} else {
+					Expect(ok).To(BeTrue())
+				}
+			}
+		})
+	})
+})
+

--- a/pkg/controller/complianceremediation/complianceremediation_suite_test.go
+++ b/pkg/controller/complianceremediation/complianceremediation_suite_test.go
@@ -1,0 +1,13 @@
+package complianceremediation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestComplianceRemediation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ComplianceRemediation Suite")
+}


### PR DESCRIPTION
The go spec says in:
    https://golang.org/ref/spec#For_range
that:
    The iteration variables may be declared by the "range" clause using a
    form of short variable declaration (:=). In this case their types are
    set to the types of the respective iteration values and their scope is
    the block of the "for" statement; they are re-used in each iteration.

What was unclear to me when I wrote the original code was that also the
address of the range variable is reused. This lead to the
appliedRemediations slice being populated with copies of the last
iteration of the range variable.