### PR TITLE
Add `debug` flag to compliancescan

### DIFF
--- a/deploy/crds/complianceoperator.compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/complianceoperator.compliance.openshift.io_compliancescans_crd.yaml
@@ -35,6 +35,10 @@ spec:
               type: string
             contentImage:
               type: string
+            debug:
+              description: Disables cleaning up resources in the DONE phase, this
+                might be useful for debugging.
+              type: boolean
             nodeSelector:
               additionalProperties:
                 type: string

--- a/deploy/crds/complianceoperator.compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/complianceoperator.compliance.openshift.io_compliancesuites_crd.yaml
@@ -43,6 +43,10 @@ spec:
                     type: string
                   contentImage:
                     type: string
+                  debug:
+                    description: Disables cleaning up resources in the DONE phase,
+                      this might be useful for debugging.
+                    type: boolean
                   name:
                     type: string
                   nodeSelector:

--- a/pkg/apis/complianceoperator/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/complianceoperator/v1alpha1/compliancescan_types.go
@@ -42,6 +42,8 @@ type ComplianceScanSpec struct {
 	Rule         string            `json:"rule,omitempty"`
 	Content      string            `json:"content,omitempty"`
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	// Disables cleaning up resources in the DONE phase, this might be useful for debugging.
+	Debug bool `json:"debug,omitempty"`
 }
 
 // ComplianceScanStatus defines the observed state of ComplianceScan

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -334,39 +334,41 @@ func (r *ReconcileComplianceScan) phaseDoneHandler(instance *complianceoperatorv
 	var nodes corev1.NodeList
 	var err error
 	logger.Info("Phase: Done", "ComplianceScan scan", instance.ObjectMeta.Name)
-	if nodes, err = getTargetNodes(r, instance); err != nil {
-		log.Error(err, "Cannot get nodes")
-		return reconcile.Result{}, err
-	}
+	if !instance.Spec.Debug {
+		if nodes, err = getTargetNodes(r, instance); err != nil {
+			log.Error(err, "Cannot get nodes")
+			return reconcile.Result{}, err
+		}
 
-	if err := r.deleteScanPods(instance, nodes, logger); err != nil {
-		log.Error(err, "Cannot delete scan pods")
-		return reconcile.Result{}, err
-	}
+		if err := r.deleteScanPods(instance, nodes, logger); err != nil {
+			log.Error(err, "Cannot delete scan pods")
+			return reconcile.Result{}, err
+		}
 
-	if err := r.deleteResultServer(instance, logger); err != nil {
-		log.Error(err, "Cannot delete result server")
-		return reconcile.Result{}, err
-	}
+		if err := r.deleteResultServer(instance, logger); err != nil {
+			log.Error(err, "Cannot delete result server")
+			return reconcile.Result{}, err
+		}
 
-	if err := r.deleteAggregator(instance, logger); err != nil {
-		log.Error(err, "Cannot delete aggregator")
-		return reconcile.Result{}, err
-	}
+		if err := r.deleteAggregator(instance, logger); err != nil {
+			log.Error(err, "Cannot delete aggregator")
+			return reconcile.Result{}, err
+		}
 
-	if err = r.deleteResultServerSecret(instance, logger); err != nil {
-		log.Error(err, "Cannot delete result server cert secret")
-		return reconcile.Result{}, err
-	}
+		if err = r.deleteResultServerSecret(instance, logger); err != nil {
+			log.Error(err, "Cannot delete result server cert secret")
+			return reconcile.Result{}, err
+		}
 
-	if err = r.deleteResultClientSecret(instance, logger); err != nil {
-		log.Error(err, "Cannot delete result client cert secret")
-		return reconcile.Result{}, err
-	}
+		if err = r.deleteResultClientSecret(instance, logger); err != nil {
+			log.Error(err, "Cannot delete result client cert secret")
+			return reconcile.Result{}, err
+		}
 
-	if err = r.deleteRootCASecret(instance, logger); err != nil {
-		log.Error(err, "Cannot delete CA secret")
-		return reconcile.Result{}, err
+		if err = r.deleteRootCASecret(instance, logger); err != nil {
+			log.Error(err, "Cannot delete CA secret")
+			return reconcile.Result{}, err
+		}
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -3,14 +3,15 @@ package compliancesuite
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"sort"
+
 	"github.com/go-logr/logr"
-	"github.com/openshift/compliance-operator/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -19,8 +20,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"sort"
 
+	"github.com/openshift/compliance-operator/pkg/utils"
 	complianceoperatorv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/complianceoperator/v1alpha1"
 	"github.com/openshift/compliance-operator/pkg/controller/common"
 )
@@ -253,6 +254,7 @@ func newScanForSuite(suite *complianceoperatorv1alpha1.ComplianceSuite, scanWrap
 			Rule:         scanWrap.Rule,
 			Content:      scanWrap.Content,
 			NodeSelector: scanWrap.NodeSelector,
+			Debug:        scanWrap.Debug,
 		},
 	}
 }


### PR DESCRIPTION
This disables cleanup of resources when in the DONE phase. This way, you
can go back to the pods and check what happened.