### PR TITLE
Update description of API types

### DIFF
--- a/deploy/crds/complianceoperator.compliance.openshift.io_complianceremediations_crd.yaml
+++ b/deploy/crds/complianceoperator.compliance.openshift.io_complianceremediations_crd.yaml
@@ -14,8 +14,8 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: ComplianceRemediation is the Schema for the complianceremediations
-        API
+      description: ComplianceRemediation represents a remediation that can be applied
+        to the cluster to fix the found issues.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -30,7 +30,7 @@ spec:
         metadata:
           type: object
         spec:
-          description: ComplianceRemediationSpec defines the desired state of ComplianceRemediation
+          description: Contains the definition of what the remediation should be
           properties:
             apply:
               description: Whether the remediation should be picked up and applied
@@ -452,7 +452,8 @@ spec:
           - apply
           type: object
         status:
-          description: ComplianceRemediationStatus defines the observed state of ComplianceRemediation
+          description: Contains information on the remediation (whether it's applied
+            or not)
           properties:
             applicationState:
               description: Whether the remediation is already applied or not

--- a/deploy/crds/complianceoperator.compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/complianceoperator.compliance.openshift.io_compliancescans_crd.yaml
@@ -14,7 +14,9 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: ComplianceScan is the Schema for the compliancescans API
+      description: ComplianceScan represents a scan with a certain configuration that
+        will be applied to objects of a certain entity in the host. These could be
+        nodes that apply to a certain nodeSelector, or the cluster itself.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -29,11 +31,16 @@ spec:
         metadata:
           type: object
         spec:
-          description: ComplianceScanSpec defines the desired state of ComplianceScan
+          description: The spec is the configuration for the compliance scan.
           properties:
             content:
+              description: Is the path to the file that contains the content (the
+                data stream). Note that the path needs to be relative to the `/` (root)
+                directory, as it is in the ContentImage
               type: string
             contentImage:
+              description: Is the image with the content (Data Stream), that will
+                be used to run OpenSCAP.
               type: string
             debug:
               description: Disables cleaning up resources in the DONE phase, this
@@ -42,22 +49,39 @@ spec:
             nodeSelector:
               additionalProperties:
                 type: string
+              description: By setting this, it's possible to only run the scan on
+                certain nodes in the cluster. Note that when applying remediations
+                generated from the scan, this should match the selector of the MachineConfigPool
+                you want to apply the remediations to.
               type: object
             profile:
+              description: Is the profile in the data stream to be used. This is the
+                collection of rules that will be checked for.
               type: string
             rule:
+              description: A Rule can be specified if the scan should check only for
+                a specific rule. Note that when leaving this empty, the scan will
+                check for all the rules for a specific profile.
               type: string
           type: object
         status:
-          description: ComplianceScanStatus defines the observed state of ComplianceScan
+          description: The status will give valuable information on what's going on
+            with the scan; and, more importantly, if the scan is successful (compliant)
+            or not (non-compliant)
           properties:
             errormsg:
+              description: If there are issues on the scan, this will be filled up
+                with an error message.
               type: string
             phase:
-              description: Represents the status of the compliance scan run.
+              description: Is the phase where the scan is at. Normally, one must wait
+                for the scan to reach the phase DONE.
               type: string
             result:
-              description: Represents the result of the compliance scan
+              description: Once the scan reaches the phase DONE, this will contain
+                the result of the scan. Where COMPLIANT means that the scan succeeded;
+                NON-COMPLIANT means that there were rule violations; and ERROR means
+                that the scan couldn't complete due to an issue.
               type: string
           type: object
       type: object

--- a/deploy/crds/complianceoperator.compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/complianceoperator.compliance.openshift.io_compliancesuites_crd.yaml
@@ -14,7 +14,8 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: ComplianceSuite is the Schema for the compliancesuites API
+      description: ComplianceSuite represents a set of scans that will be applied
+        to the cluster. These should help deployers achieve a certain compliance target.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -29,33 +30,51 @@ spec:
         metadata:
           type: object
         spec:
-          description: ComplianceSuiteSpec defines the desired state of ComplianceSuite
+          description: Contains the definition of the suite
           properties:
             autoApplyRemediations:
-              description: Should remediations be applied automatically?
+              description: Defines whether or not the remediations should be applied
+                automatically
               type: boolean
             scans:
+              description: Contains a list of the scans to execute on the cluster
               items:
                 description: ComplianceScanSpecWrapper provides a ComplianceScanSpec
                   and a Name
                 properties:
                   content:
+                    description: Is the path to the file that contains the content
+                      (the data stream). Note that the path needs to be relative to
+                      the `/` (root) directory, as it is in the ContentImage
                     type: string
                   contentImage:
+                    description: Is the image with the content (Data Stream), that
+                      will be used to run OpenSCAP.
                     type: string
                   debug:
                     description: Disables cleaning up resources in the DONE phase,
                       this might be useful for debugging.
                     type: boolean
                   name:
+                    description: Contains a human readable name for the scan. This
+                      is to identify the objects that it creates.
                     type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
+                    description: By setting this, it's possible to only run the scan
+                      on certain nodes in the cluster. Note that when applying remediations
+                      generated from the scan, this should match the selector of the
+                      MachineConfigPool you want to apply the remediations to.
                     type: object
                   profile:
+                    description: Is the profile in the data stream to be used. This
+                      is the collection of rules that will be checked for.
                     type: string
                   rule:
+                    description: A Rule can be specified if the scan should check
+                      only for a specific rule. Note that when leaving this empty,
+                      the scan will check for all the rules for a specific profile.
                     type: string
                 type: object
               type: array
@@ -63,7 +82,7 @@ spec:
           - scans
           type: object
         status:
-          description: ComplianceSuiteStatus defines the observed state of ComplianceSuite
+          description: Contains the current state of the suite
           properties:
             remediationOverview:
               items:
@@ -73,8 +92,11 @@ spec:
                       by the operator
                     type: boolean
                   remediationName:
+                    description: Contains a human readable name for the remediation.
                     type: string
                   scanName:
+                    description: Contains the name of the scan that generated the
+                      remediation
                     type: string
                   type:
                     description: Remediation type specifies the artifact the remediation
@@ -92,14 +114,22 @@ spec:
                   and a Name
                 properties:
                   errormsg:
+                    description: If there are issues on the scan, this will be filled
+                      up with an error message.
                     type: string
                   name:
+                    description: Contains a human readable name for the scan. This
+                      is to identify the objects that it creates.
                     type: string
                   phase:
-                    description: Represents the status of the compliance scan run.
+                    description: Is the phase where the scan is at. Normally, one
+                      must wait for the scan to reach the phase DONE.
                     type: string
                   result:
-                    description: Represents the result of the compliance scan
+                    description: Once the scan reaches the phase DONE, this will contain
+                      the result of the scan. Where COMPLIANT means that the scan
+                      succeeded; NON-COMPLIANT means that there were rule violations;
+                      and ERROR means that the scan couldn't complete due to an issue.
                     type: string
                 type: object
               type: array

--- a/pkg/apis/complianceoperator/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/complianceoperator/v1alpha1/complianceremediation_types.go
@@ -53,7 +53,8 @@ type ComplianceRemediationStatus struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ComplianceRemediation is the Schema for the complianceremediations API
+// ComplianceRemediation represents a remediation that can be applied to the
+// cluster to fix the found issues.
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=complianceremediations,scope=Namespaced
@@ -61,7 +62,9 @@ type ComplianceRemediation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ComplianceRemediationSpec   `json:"spec,omitempty"`
+	// Contains the definition of what the remediation should be
+	Spec ComplianceRemediationSpec `json:"spec,omitempty"`
+	// Contains information on the remediation (whether it's applied or not)
 	Status ComplianceRemediationStatus `json:"status,omitempty"`
 }
 

--- a/pkg/apis/complianceoperator/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/complianceoperator/v1alpha1/compliancescan_types.go
@@ -37,10 +37,24 @@ const (
 // ComplianceScanSpec defines the desired state of ComplianceScan
 // +k8s:openapi-gen=true
 type ComplianceScanSpec struct {
-	ContentImage string            `json:"contentImage,omitempty"`
-	Profile      string            `json:"profile,omitempty"`
-	Rule         string            `json:"rule,omitempty"`
-	Content      string            `json:"content,omitempty"`
+	// Is the image with the content (Data Stream), that will be used to run
+	// OpenSCAP.
+	ContentImage string `json:"contentImage,omitempty"`
+	// Is the profile in the data stream to be used. This is the collection of
+	// rules that will be checked for.
+	Profile string `json:"profile,omitempty"`
+	// A Rule can be specified if the scan should check only for a specific
+	// rule. Note that when leaving this empty, the scan will check for all the
+	// rules for a specific profile.
+	Rule string `json:"rule,omitempty"`
+	// Is the path to the file that contains the content (the data stream).
+	// Note that the path needs to be relative to the `/` (root) directory, as
+	// it is in the ContentImage
+	Content string `json:"content,omitempty"`
+	// By setting this, it's possible to only run the scan on certain nodes in
+	// the cluster. Note that when applying remediations generated from the
+	// scan, this should match the selector of the MachineConfigPool you want
+	// to apply the remediations to.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Disables cleaning up resources in the DONE phase, this might be useful for debugging.
 	Debug bool `json:"debug,omitempty"`
@@ -49,21 +63,35 @@ type ComplianceScanSpec struct {
 // ComplianceScanStatus defines the observed state of ComplianceScan
 // +k8s:openapi-gen=true
 type ComplianceScanStatus struct {
-	Phase        ComplianceScanStatusPhase  `json:"phase,omitempty"`
-	Result       ComplianceScanStatusResult `json:"result,omitempty"`
-	ErrorMessage string                     `json:"errormsg,omitempty"`
+	// Is the phase where the scan is at. Normally, one must wait for the scan
+	// to reach the phase DONE.
+	Phase ComplianceScanStatusPhase `json:"phase,omitempty"`
+	// Once the scan reaches the phase DONE, this will contain the result of
+	// the scan. Where COMPLIANT means that the scan succeeded; NON-COMPLIANT
+	// means that there were rule violations; and ERROR means that the scan
+	// couldn't complete due to an issue.
+	Result ComplianceScanStatusResult `json:"result,omitempty"`
+	// If there are issues on the scan, this will be filled up with an error
+	// message.
+	ErrorMessage string `json:"errormsg,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ComplianceScan is the Schema for the compliancescans API
+// ComplianceScan represents a scan with a certain configuration that will be
+// applied to objects of a certain entity in the host. These could be nodes
+// that apply to a certain nodeSelector, or the cluster itself.
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 type ComplianceScan struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ComplianceScanSpec   `json:"spec,omitempty"`
+	// The spec is the configuration for the compliance scan.
+	Spec ComplianceScanSpec `json:"spec,omitempty"`
+	// The status will give valuable information on what's going on with the
+	// scan; and, more importantly, if the scan is successful (compliant) or
+	// not (non-compliant)
 	Status ComplianceScanStatus `json:"status,omitempty"`
 }
 

--- a/pkg/apis/complianceoperator/v1alpha1/compliancesuite_types.go
+++ b/pkg/apis/complianceoperator/v1alpha1/compliancesuite_types.go
@@ -9,6 +9,8 @@ import (
 type ComplianceScanSpecWrapper struct {
 	ComplianceScanSpec `json:",inline"`
 
+	// Contains a human readable name for the scan. This is to identify the
+	// objects that it creates.
 	Name string `json:"name,omitempty"`
 }
 
@@ -17,21 +19,26 @@ type ComplianceScanSpecWrapper struct {
 type ComplianceScanStatusWrapper struct {
 	ComplianceScanStatus `json:",inline"`
 
+	// Contains a human readable name for the scan. This is to identify the
+	// objects that it creates.
 	Name string `json:"name,omitempty"`
 }
 
 // +k8s:openapi-gen=true
 type ComplianceRemediationNameStatus struct {
 	ComplianceRemediationSpecMeta `json:",inline"`
-	RemediationName               string `json:"remediationName"`
-	ScanName                      string `json:"scanName"`
+	// Contains a human readable name for the remediation.
+	RemediationName string `json:"remediationName"`
+	// Contains the name of the scan that generated the remediation
+	ScanName string `json:"scanName"`
 }
 
 // ComplianceSuiteSpec defines the desired state of ComplianceSuite
 // +k8s:openapi-gen=true
 type ComplianceSuiteSpec struct {
-	// Should remediations be applied automatically?
+	// Defines whether or not the remediations should be applied automatically
 	AutoApplyRemediations bool `json:"autoApplyRemediations,omitempty"`
+	// Contains a list of the scans to execute on the cluster
 	// +listType=atomic
 	Scans []ComplianceScanSpecWrapper `json:"scans"`
 }
@@ -48,7 +55,8 @@ type ComplianceSuiteStatus struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ComplianceSuite is the Schema for the compliancesuites API
+// ComplianceSuite represents a set of scans that will be applied to the
+// cluster. These should help deployers achieve a certain compliance target.
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=compliancesuites,scope=Namespaced
@@ -56,7 +64,9 @@ type ComplianceSuite struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ComplianceSuiteSpec   `json:"spec,omitempty"`
+	// Contains the definition of the suite
+	Spec ComplianceSuiteSpec `json:"spec,omitempty"`
+	// Contains the current state of the suite
 	Status ComplianceSuiteStatus `json:"status,omitempty"`
 }
 


### PR DESCRIPTION
This makes sure that the appropraite descriptions are set in the CRDs,
and will eventually show up in the `explain` command's output.