### PR TITLE
Always prepend "/content/" to content path when using it

### DIFF
--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -3,6 +3,7 @@ package compliancescan
 import (
 	"context"
 	"fmt"
+	"path"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -781,7 +782,7 @@ func newScanPodForNode(scanInstance *complianceoperatorv1alpha1.ComplianceScan, 
 					Command: []string{
 						"sh",
 						"-c",
-						"cp /*.xml /content",
+						fmt.Sprintf("cp %s /content | /bin/true", path.Join("/", scanInstance.Spec.Content)),
 					},
 					ImagePullPolicy: corev1.PullAlways,
 					VolumeMounts: []corev1.VolumeMount{
@@ -1083,7 +1084,7 @@ func newAggregatorPod(scanInstance *complianceoperatorv1alpha1.ComplianceScan, l
 					Command: []string{
 						"sh",
 						"-c",
-						"cp /*.xml /content",
+						fmt.Sprintf("cp %s /content | /bin/true", path.Join("/", scanInstance.Spec.Content)),
 					},
 					ImagePullPolicy: corev1.PullAlways,
 					VolumeMounts: []corev1.VolumeMount{

--- a/pkg/controller/compliancescan/utils.go
+++ b/pkg/controller/compliancescan/utils.go
@@ -2,6 +2,7 @@ package compliancescan
 
 import (
 	"context"
+	"path"
 	// we can suppress the gosec warning about sha1 here because we don't use sha1 for crypto
 	// purposes, but only as a string shortener
 	// #nosec G505
@@ -9,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -84,10 +84,7 @@ func dnsLengthName(hashPrefix string, format string, a ...interface{}) string {
 }
 
 func absContentPath(relContentPath string) string {
-	if !strings.HasPrefix(relContentPath, "/") {
-		return "/content/" + relContentPath
-	}
-	return relContentPath
+	return path.Join("/content/", relContentPath)
 }
 
 // Issue a server cert using the instance Root CA (it needs to be created prior to calling this function).


### PR DESCRIPTION
This used to only prepend "/content" if a relative path was being used.
This remove this "feature" with the intent that "/content" should stay
as an implementation detail and is not something the user needs to know
or care about.

Instead, lets always prepend the "/content" directory, since that's what
we use as a volume mount anyway. The content path will always be
relative to "/", so both relative and absolute paths should keep
working.