### PR TITLE
Enable updating channel in package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ COURIER_QUAY_NAMESPACE=compliance-operator
 COURIER_PACKAGE_VERSION?=
 OLD_COURIER_PACKAGE_VERSION=$(shell ls -t deploy/olm-catalog/compliance-operator/ | grep -v package.yaml | head -1)
 COURIER_QUAY_TOKEN?= $(shell cat ~/.quay)
+PACKAGE_CHANNEL?=alpha
 
 .PHONY: all
 all: build ## Test and Build the compliance-operator
@@ -329,7 +330,7 @@ endif
 
 .PHONY: csv
 csv: check-package-version
-	$(GOPATH)/bin/operator-sdk generate csv --csv-version "$(COURIER_PACKAGE_VERSION)" --from-version "$(OLD_COURIER_PACKAGE_VERSION)" --update-crds
+	$(GOPATH)/bin/operator-sdk generate csv --csv-channel $(PACKAGE_CHANNEL) --csv-version "$(COURIER_PACKAGE_VERSION)" --from-version "$(OLD_COURIER_PACKAGE_VERSION)" --update-crds
 
 .PHONY: publish-bundle
 publish-bundle: check-package-version
@@ -357,6 +358,7 @@ undo-deploy-tag-image: package-version-to-tag
 .PHONY: git-release
 git-release: package-version-to-tag
 	git add "deploy/olm-catalog/compliance-operator/$(TAG)"
+	git add "deploy/olm-catalog/compliance-operator/compliance-operator.package.yaml"
 	git commit -m "Release v$(TAG)"
 	git tag "v$(TAG)"
 	git push origin "v$(TAG)"

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ COURIER_PACKAGE_NAME=compliance-operator-bundle
 COURIER_OPERATOR_DIR=deploy/olm-catalog/compliance-operator
 COURIER_QUAY_NAMESPACE=compliance-operator
 COURIER_PACKAGE_VERSION?=
-OLD_COURIER_PACKAGE_VERSION=$(shell ls -t deploy/olm-catalog/compliance-operator/ | head -1)
+OLD_COURIER_PACKAGE_VERSION=$(shell ls -t deploy/olm-catalog/compliance-operator/ | grep -v package.yaml | head -1)
 COURIER_QUAY_TOKEN?= $(shell cat ~/.quay)
 
 .PHONY: all


### PR DESCRIPTION
This takes into account the package channel in the `generate csv` command,
which enables us to keep that file up to date.
    
The default channel we update is the `alpha` channel, and we can change
that when doing a stable release.

Also, the automatic fetching of the previous version could accidentally take the
package yaml file as the previous version... which is not desired. This fixes that