### PR TITLE
Remove hardcoded namespace references where possible

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: compliance-operator
-  namespace: openshift-compliance
 spec:
   replicas: 1
   selector:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: openshift-compliance
   name: compliance-operator
 rules:
 - apiGroups:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,15 +1,12 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: openshift-compliance
   name: compliance-operator
 subjects:
 - kind: ServiceAccount
-  namespace: openshift-compliance
   name: compliance-operator
 roleRef:
   kind: Role
-  namespace: openshift-compliance
   name: compliance-operator
   apiGroup: rbac.authorization.k8s.io
 ---

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: openshift-compliance
   name: compliance-operator

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -57,6 +57,7 @@ func newAggregatorPod(scanInstance *complianceoperatorv1alpha1.ComplianceScan, l
 					Args: []string{
 						"--content=" + absContentPath(scanInstance.Spec.Content),
 						"--scan=" + scanInstance.Name,
+						"--namespace=" + scanInstance.Namespace,
 					},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: &trueVal,


### PR DESCRIPTION
This makes it so that we can deploy the compliance operator in any namespace when doing it from a CSV.

Only leaving the one required reference.