### PR TITLE
Up default number of replicas

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: compliance-operator
   namespace: openshift-compliance
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: compliance-operator


### PR DESCRIPTION
The operator by default uses only 1 replica for the Deployment... Let's
use 3 replicas to have a more resilient deployment.

This will eventually be used in the csv once we release again.