### PR TITLE
Make csv target idempotent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,9 @@ ifndef COURIER_PACKAGE_VERSION
 endif
 
 .PHONY: csv
-csv: check-package-version operator-sdk
+csv: deploy/olm-catalog/compliance-operator/$(COURIER_PACKAGE_VERSION) check-package-version operator-sdk ## Generate the CSV and packaging for the specific version (NOTE: Gotta specify the version with the COURIER_PACKAGE_VERSION environment variable)
+
+deploy/olm-catalog/compliance-operator/$(COURIER_PACKAGE_VERSION):
 	$(GOPATH)/bin/operator-sdk generate csv --csv-channel $(PACKAGE_CHANNEL) --csv-version "$(COURIER_PACKAGE_VERSION)" --from-version "$(OLD_COURIER_PACKAGE_VERSION)" --update-crds
 
 .PHONY: publish-bundle


### PR DESCRIPTION
As a Makefile would usually have as a good practice... if a directory or
file already exists, you probably don't need to try the command again
and again. So this makes the csv command idempotent by checking that the
directory of the target version already exists.

This also adds docs for the target, so it appears in the help target
too.