### PR TITLE
Rely on predictable pod names instead of labels

### DIFF
--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -401,7 +401,7 @@ func (r *ReconcileComplianceScan) createPVCForScan(instance *complianceoperatorv
 func isPodRunningInNode(r *ReconcileComplianceScan, scanInstance *complianceoperatorv1alpha1.ComplianceScan, node *corev1.Node, logger logr.Logger) (bool, error) {
 	logger.Info("Retrieving a pod for node", "node", node.Name)
 
-	podName := getPodForNodeName(scanInstance, node.Name)
+	podName := getPodForNodeName(scanInstance.Name, node.Name)
 	return isPodRunning(r, podName, scanInstance.Namespace, logger)
 }
 
@@ -496,30 +496,12 @@ func getPVCForScan(instance *complianceoperatorv1alpha1.ComplianceScan) *corev1.
 
 // pod names are limited to 63 chars, inclusive. Try to use a friendly name, if that can't be done,
 // just use a hash. Either way, the node would be present in a label of the pod.
-func createPodForNodeName(scanName, nodeName string) string {
+func getPodForNodeName(scanName, nodeName string) string {
 	return dnsLengthName("openscap-pod-", "%s-%s-pod", scanName, nodeName)
 }
 
 func getConfigMapForNodeName(scanName, nodeName string) string {
 	return dnsLengthName("openscap-pod-", "%s-%s-pod", scanName, nodeName)
-}
-
-func getPodForNodeName(scanInstance *complianceoperatorv1alpha1.ComplianceScan, nodeName string) string {
-	return scanInstance.Labels[nodePodLabel(nodeName)]
-}
-
-func setPodForNodeName(scanInstance *complianceoperatorv1alpha1.ComplianceScan, nodeName, podName string) {
-	if scanInstance.Labels == nil {
-		scanInstance.Labels = make(map[string]string)
-	}
-
-	// TODO(jaosorior): Figure out if we still need this after deleting the pods
-	// This might be more appropraite as an annotation.
-	scanInstance.Labels[nodePodLabel(nodeName)] = podName
-}
-
-func nodePodLabel(nodeName string) string {
-	return OpenSCAPNodePodLabel + nodeName
 }
 
 func getPVCForScanName(instance *complianceoperatorv1alpha1.ComplianceScan) string {

--- a/pkg/controller/compliancescan/compliancescan_controller_test.go
+++ b/pkg/controller/compliancescan/compliancescan_controller_test.go
@@ -102,23 +102,20 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 		Context("With two pods in the cluster", func() {
 			BeforeEach(func() {
 				// Create the pods for the test
-				podName1 := fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance1.Name)
+				podName1 := getPodForNodeName(compliancescaninstance.Name, nodeinstance1.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: podName1,
 					},
 				})
 
-				podName2 := fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance2.Name)
+				podName2 := getPodForNodeName(compliancescaninstance.Name, nodeinstance2.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: podName2,
 					},
 				})
 
-				// Set the pod-node mappings in labels
-				setPodForNodeName(compliancescaninstance, nodeinstance1.Name, podName1)
-				setPodForNodeName(compliancescaninstance, nodeinstance2.Name, podName2)
 				reconciler.client.Update(context.TODO(), compliancescaninstance)
 
 				// Set state to RUNNING
@@ -137,7 +134,7 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 		Context("With two pods that succeeded in the cluster", func() {
 			BeforeEach(func() {
 				// Create the pods for the test
-				podName1 := fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance1.Name)
+				podName1 := getPodForNodeName(compliancescaninstance.Name, nodeinstance1.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: podName1,
@@ -147,7 +144,7 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 					},
 				})
 
-				podName2 := fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance2.Name)
+				podName2 := getPodForNodeName(compliancescaninstance.Name, nodeinstance2.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: podName2,
@@ -157,9 +154,6 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 					},
 				})
 
-				// Set the pod-node mappings in labels
-				setPodForNodeName(compliancescaninstance, nodeinstance1.Name, podName1)
-				setPodForNodeName(compliancescaninstance, nodeinstance2.Name, podName2)
 				reconciler.client.Update(context.TODO(), compliancescaninstance)
 
 				// Set state to RUNNING

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -34,8 +34,6 @@ func (r *ReconcileComplianceScan) createScanPods(instance *complianceoperatorv1a
 			return err
 		} else {
 			logger.Info("Launched a pod", "pod", pod)
-			// ..since the pod name can be random, store it in a label
-			setPodForNodeName(instance, node.Name, pod.Name)
 		}
 	}
 
@@ -50,7 +48,7 @@ func newScanPodForNode(scanInstance *complianceoperatorv1alpha1.ComplianceScan, 
 
 	mode := int32(0744)
 
-	podName := createPodForNodeName(scanInstance.Name, node.Name)
+	podName := getPodForNodeName(scanInstance.Name, node.Name)
 	cmName := getConfigMapForNodeName(scanInstance.Name, node.Name)
 	podLabels := map[string]string{
 		"complianceScan": scanInstance.Name,


### PR DESCRIPTION
Given that we're using sha-1 to generate unique pod names for the scan
instances, we can rely on the pod name to be predictable. So we don't
need to store this in a label as we used to.