### PR TITLE
Don't persist the ConfigMaps in labels

### DIFF
--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -36,8 +36,6 @@ var (
 const (
 	// OpenSCAPScanContainerName defines the name of the contianer that will run OpenSCAP
 	OpenSCAPScanContainerName = "openscap-ocp"
-	OpenSCAPScriptCmLabel     = "cm-script"
-	OpenSCAPScriptEnvLabel    = "cm-env"
 	OpenSCAPNodePodLabel      = "node-scan/"
 	NodeHostnameLabel         = "kubernetes.io/hostname"
 	AggregatorPodAnnotation   = "scan-aggregator"
@@ -145,27 +143,9 @@ func (r *ReconcileComplianceScan) Reconcile(request reconcile.Request) (reconcil
 func (r *ReconcileComplianceScan) phasePendingHandler(instance *complianceoperatorv1alpha1.ComplianceScan, logger logr.Logger) (reconcile.Result, error) {
 	logger.Info("Phase: Pending", "ComplianceScan", instance.ObjectMeta.Name)
 
-	if instance.Labels == nil {
-		instance.Labels = make(map[string]string)
-	}
-
-	if instance.Labels[OpenSCAPScriptCmLabel] == "" {
-		instance.Labels[OpenSCAPScriptCmLabel] = scriptCmForScan(instance)
-	}
-
-	if instance.Labels[OpenSCAPScriptEnvLabel] == "" {
-		instance.Labels[OpenSCAPScriptEnvLabel] = envCmForScan(instance)
-	}
-
-	err := createConfigMaps(r, instance.Labels[OpenSCAPScriptCmLabel], instance.Labels[OpenSCAPScriptEnvLabel], instance)
+	err := createConfigMaps(r, scriptCmForScan(instance), envCmForScan(instance), instance)
 	if err != nil {
 		logger.Error(err, "Cannot create the configmaps")
-		return reconcile.Result{}, err
-	}
-
-	// Update the labels that hold the name of the configMaps
-	err = r.client.Update(context.TODO(), instance)
-	if err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -137,7 +137,7 @@ func newScanPodForNode(scanInstance *complianceoperatorv1alpha1.ComplianceScan, 
 							MountPath: "/content",
 						},
 						{
-							Name:      scanInstance.Labels[OpenSCAPScriptCmLabel],
+							Name:      scriptCmForScan(scanInstance),
 							MountPath: "/scripts",
 						},
 					},
@@ -145,7 +145,7 @@ func newScanPodForNode(scanInstance *complianceoperatorv1alpha1.ComplianceScan, 
 						{
 							ConfigMapRef: &corev1.ConfigMapEnvSource{
 								LocalObjectReference: corev1.LocalObjectReference{
-									Name: scanInstance.Labels[OpenSCAPScriptEnvLabel],
+									Name: envCmForScan(scanInstance),
 								},
 							},
 						},
@@ -186,11 +186,11 @@ func newScanPodForNode(scanInstance *complianceoperatorv1alpha1.ComplianceScan, 
 					},
 				},
 				{
-					Name: scanInstance.Labels[OpenSCAPScriptCmLabel],
+					Name: scriptCmForScan(scanInstance),
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: scanInstance.Labels[OpenSCAPScriptCmLabel],
+								Name: scriptCmForScan(scanInstance),
 							},
 							DefaultMode: &mode,
 						},


### PR DESCRIPTION
We are using predictable names, so we don't need to store these values
in labels. The downside of doing this is that labels are user-facing
parameters, and we don't want to expose inner functionality here.