### PR TITLE
Use predictable names for pods and configmaps

### DIFF
--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -36,8 +36,6 @@ var (
 const (
 	// OpenSCAPScanContainerName defines the name of the contianer that will run OpenSCAP
 	OpenSCAPScanContainerName = "openscap-ocp"
-	OpenSCAPScriptCmLabel     = "cm-script"
-	OpenSCAPScriptEnvLabel    = "cm-env"
 	NodeHostnameLabel         = "kubernetes.io/hostname"
 	AggregatorPodAnnotation   = "scan-aggregator"
 	// The default time we should wait before requeuing
@@ -144,27 +142,9 @@ func (r *ReconcileComplianceScan) Reconcile(request reconcile.Request) (reconcil
 func (r *ReconcileComplianceScan) phasePendingHandler(instance *complianceoperatorv1alpha1.ComplianceScan, logger logr.Logger) (reconcile.Result, error) {
 	logger.Info("Phase: Pending", "ComplianceScan", instance.ObjectMeta.Name)
 
-	if instance.Labels == nil {
-		instance.Labels = make(map[string]string)
-	}
-
-	if instance.Labels[OpenSCAPScriptCmLabel] == "" {
-		instance.Labels[OpenSCAPScriptCmLabel] = scriptCmForScan(instance)
-	}
-
-	if instance.Labels[OpenSCAPScriptEnvLabel] == "" {
-		instance.Labels[OpenSCAPScriptEnvLabel] = envCmForScan(instance)
-	}
-
-	err := createConfigMaps(r, instance.Labels[OpenSCAPScriptCmLabel], instance.Labels[OpenSCAPScriptEnvLabel], instance)
+	err := createConfigMaps(r, scriptCmForScan(instance), envCmForScan(instance), instance)
 	if err != nil {
 		logger.Error(err, "Cannot create the configmaps")
-		return reconcile.Result{}, err
-	}
-
-	// Update the labels that hold the name of the configMaps
-	err = r.client.Update(context.TODO(), instance)
-	if err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -38,7 +38,6 @@ const (
 	OpenSCAPScanContainerName = "openscap-ocp"
 	OpenSCAPScriptCmLabel     = "cm-script"
 	OpenSCAPScriptEnvLabel    = "cm-env"
-	OpenSCAPNodePodLabel      = "node-scan/"
 	NodeHostnameLabel         = "kubernetes.io/hostname"
 	AggregatorPodAnnotation   = "scan-aggregator"
 	// The default time we should wait before requeuing
@@ -401,7 +400,7 @@ func (r *ReconcileComplianceScan) createPVCForScan(instance *complianceoperatorv
 func isPodRunningInNode(r *ReconcileComplianceScan, scanInstance *complianceoperatorv1alpha1.ComplianceScan, node *corev1.Node, logger logr.Logger) (bool, error) {
 	logger.Info("Retrieving a pod for node", "node", node.Name)
 
-	podName := getPodForNodeName(scanInstance, node.Name)
+	podName := getPodForNodeName(scanInstance.Name, node.Name)
 	return isPodRunning(r, podName, scanInstance.Namespace, logger)
 }
 
@@ -496,30 +495,12 @@ func getPVCForScan(instance *complianceoperatorv1alpha1.ComplianceScan) *corev1.
 
 // pod names are limited to 63 chars, inclusive. Try to use a friendly name, if that can't be done,
 // just use a hash. Either way, the node would be present in a label of the pod.
-func createPodForNodeName(scanName, nodeName string) string {
+func getPodForNodeName(scanName, nodeName string) string {
 	return dnsLengthName("openscap-pod-", "%s-%s-pod", scanName, nodeName)
 }
 
 func getConfigMapForNodeName(scanName, nodeName string) string {
 	return dnsLengthName("openscap-pod-", "%s-%s-pod", scanName, nodeName)
-}
-
-func getPodForNodeName(scanInstance *complianceoperatorv1alpha1.ComplianceScan, nodeName string) string {
-	return scanInstance.Labels[nodePodLabel(nodeName)]
-}
-
-func setPodForNodeName(scanInstance *complianceoperatorv1alpha1.ComplianceScan, nodeName, podName string) {
-	if scanInstance.Labels == nil {
-		scanInstance.Labels = make(map[string]string)
-	}
-
-	// TODO(jaosorior): Figure out if we still need this after deleting the pods
-	// This might be more appropraite as an annotation.
-	scanInstance.Labels[nodePodLabel(nodeName)] = podName
-}
-
-func nodePodLabel(nodeName string) string {
-	return OpenSCAPNodePodLabel + nodeName
 }
 
 func getPVCForScanName(instance *complianceoperatorv1alpha1.ComplianceScan) string {

--- a/pkg/controller/compliancescan/compliancescan_controller_test.go
+++ b/pkg/controller/compliancescan/compliancescan_controller_test.go
@@ -102,23 +102,20 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 		Context("With two pods in the cluster", func() {
 			BeforeEach(func() {
 				// Create the pods for the test
-				podName1 := fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance1.Name)
+				podName1 := getPodForNodeName(compliancescaninstance.Name, nodeinstance1.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: podName1,
 					},
 				})
 
-				podName2 := fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance2.Name)
+				podName2 := getPodForNodeName(compliancescaninstance.Name, nodeinstance2.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: podName2,
 					},
 				})
 
-				// Set the pod-node mappings in labels
-				setPodForNodeName(compliancescaninstance, nodeinstance1.Name, podName1)
-				setPodForNodeName(compliancescaninstance, nodeinstance2.Name, podName2)
 				reconciler.client.Update(context.TODO(), compliancescaninstance)
 
 				// Set state to RUNNING
@@ -137,7 +134,7 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 		Context("With two pods that succeeded in the cluster", func() {
 			BeforeEach(func() {
 				// Create the pods for the test
-				podName1 := fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance1.Name)
+				podName1 := getPodForNodeName(compliancescaninstance.Name, nodeinstance1.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: podName1,
@@ -147,7 +144,7 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 					},
 				})
 
-				podName2 := fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance2.Name)
+				podName2 := getPodForNodeName(compliancescaninstance.Name, nodeinstance2.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: podName2,
@@ -157,9 +154,6 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 					},
 				})
 
-				// Set the pod-node mappings in labels
-				setPodForNodeName(compliancescaninstance, nodeinstance1.Name, podName1)
-				setPodForNodeName(compliancescaninstance, nodeinstance2.Name, podName2)
 				reconciler.client.Update(context.TODO(), compliancescaninstance)
 
 				// Set state to RUNNING

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -135,7 +135,7 @@ func newScanPodForNode(scanInstance *complianceoperatorv1alpha1.ComplianceScan, 
 							MountPath: "/content",
 						},
 						{
-							Name:      scanInstance.Labels[OpenSCAPScriptCmLabel],
+							Name:      scriptCmForScan(scanInstance),
 							MountPath: "/scripts",
 						},
 					},
@@ -143,7 +143,7 @@ func newScanPodForNode(scanInstance *complianceoperatorv1alpha1.ComplianceScan, 
 						{
 							ConfigMapRef: &corev1.ConfigMapEnvSource{
 								LocalObjectReference: corev1.LocalObjectReference{
-									Name: scanInstance.Labels[OpenSCAPScriptEnvLabel],
+									Name: envCmForScan(scanInstance),
 								},
 							},
 						},
@@ -184,11 +184,11 @@ func newScanPodForNode(scanInstance *complianceoperatorv1alpha1.ComplianceScan, 
 					},
 				},
 				{
-					Name: scanInstance.Labels[OpenSCAPScriptCmLabel],
+					Name: scriptCmForScan(scanInstance),
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: scanInstance.Labels[OpenSCAPScriptCmLabel],
+								Name: scriptCmForScan(scanInstance),
 							},
 							DefaultMode: &mode,
 						},

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -34,8 +34,6 @@ func (r *ReconcileComplianceScan) createScanPods(instance *complianceoperatorv1a
 			return err
 		} else {
 			logger.Info("Launched a pod", "pod", pod)
-			// ..since the pod name can be random, store it in a label
-			setPodForNodeName(instance, node.Name, pod.Name)
 		}
 	}
 
@@ -50,7 +48,7 @@ func newScanPodForNode(scanInstance *complianceoperatorv1alpha1.ComplianceScan, 
 
 	mode := int32(0744)
 
-	podName := createPodForNodeName(scanInstance.Name, node.Name)
+	podName := getPodForNodeName(scanInstance.Name, node.Name)
 	cmName := getConfigMapForNodeName(scanInstance.Name, node.Name)
 	podLabels := map[string]string{
 		"complianceScan": scanInstance.Name,


### PR DESCRIPTION
This removes the usage of labels to get the pods and configmaps needed for the compliancescans.

Labels are user-facing attributes, and it's a better experience to hide these detalis from the user. Instead, we just rely on the usage of predtictable names to fetch these things.