### PR TITLE
Fix getting previous csv version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ COURIER_PACKAGE_NAME=compliance-operator-bundle
 COURIER_OPERATOR_DIR=deploy/olm-catalog/compliance-operator
 COURIER_QUAY_NAMESPACE=compliance-operator
 COURIER_PACKAGE_VERSION?=
-OLD_COURIER_PACKAGE_VERSION=$(shell ls -t deploy/olm-catalog/compliance-operator/ | grep -v package.yaml | head -1)
+OLD_COURIER_PACKAGE_VERSION=$(shell find deploy/olm-catalog/compliance-operator/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -r | head -1)
 COURIER_QUAY_TOKEN?= $(shell cat ~/.quay)
 PACKAGE_CHANNEL?=alpha
 


### PR DESCRIPTION
It used to base the previous version on the last touched file in the
CSV versions directory... This might very between people's computers (I
might have temporarily modified a CSV) so this is not reliable. Instead,
lets just use alphabetical order.