### PR TITLE
hardening: Make resultscollector use its own service account

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -132,3 +132,29 @@ rules:
   - watch
   - update
   - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: resultscollector
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - compliance.openshift.io
+  resources:
+  - compliancescans
+  verbs:
+  - get
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -22,3 +22,15 @@ roleRef:
   kind: ClusterRole
   name: compliance-operator
   apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: resultscollector
+subjects:
+- kind: ServiceAccount
+  name: resultscollector
+roleRef:
+  kind: Role
+  name: resultscollector
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: compliance-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: resultscollector

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -14,6 +14,8 @@ import (
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
 )
 
+const resultscollectorSA = "resultscollector"
+
 func (r *ReconcileComplianceScan) createScanPods(instance *compv1alpha1.ComplianceScan, nodes corev1.NodeList, logger logr.Logger) error {
 	// On each eligible node..
 	for _, node := range nodes.Items {
@@ -62,7 +64,7 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 			Labels:    podLabels,
 		},
 		Spec: corev1.PodSpec{
-			ServiceAccountName: "compliance-operator",
+			ServiceAccountName: resultscollectorSA,
 			InitContainers: []corev1.Container{
 				{
 					Name:  "content-container",


### PR DESCRIPTION
Instead of having a pod that runs with the operator's privileges, lets
make it use its owna service account. This way, it will only run with a
subset of privileges.