### PR TITLE
hardening: Make remediation-aggregator use its own Service Account

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -158,3 +158,43 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: remediation-aggregator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - update
+- apiGroups:
+  - compliance.openshift.io
+  resources:
+  - compliancescans
+  verbs:
+  - get
+- apiGroups:
+  - compliance.openshift.io
+  resources:
+  - compliancescans/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - compliance.openshift.io
+  resources:
+  - complianceremediations
+  verbs:
+  - create
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -34,3 +34,15 @@ roleRef:
   kind: Role
   name: resultscollector
   apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: remediation-aggregator
+subjects:
+- kind: ServiceAccount
+  name: remediation-aggregator
+roleRef:
+  kind: Role
+  name: remediation-aggregator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -7,3 +7,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: resultscollector
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: remediation-aggregator

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -13,6 +13,8 @@ import (
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
 )
 
+const aggregatorSA = "remediation-aggregator"
+
 func createAggregatorPodName(scanName string) string {
 	return dnsLengthName("aggregator-pod-", "aggregator-pod-%s", scanName)
 }
@@ -31,7 +33,7 @@ func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Log
 			Labels:    podLabels,
 		},
 		Spec: corev1.PodSpec{
-			ServiceAccountName: "compliance-operator",
+			ServiceAccountName: aggregatorSA,
 			InitContainers: []corev1.Container{
 				{
 					Name:  "content-container",


### PR DESCRIPTION
Instead of having a pod that runs with the operator's privileges, lets
make it use its own service account. This way, it will only run with a
subset of privileges