### PR TITLE
Add Dockerfiles for openscap yaml-probe testing

### DIFF
--- a/images/openscap/Dockerfile.maint-1.3
+++ b/images/openscap/Dockerfile.maint-1.3
@@ -1,0 +1,18 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+LABEL \
+    name="openscap-ocp" \
+    run="podman run --privileged -v /:/host  -eHOSTROOT=/host -ePROFILE=xccdf_org.ssgproject.content_profile_coreos-fedramp -eCONTENT=ssg-ocp4-ds.xml -eREPORT_DIR=/reports -eRULE=xccdf_org.ssgproject.content_rule_selinux_state" \
+    io.k8s.display-name="OpenSCAP container for OCP4 node scans" \
+    io.k8s.description="OpenSCAP security scanner for scanning hosts through a host mount - test version" \
+    io.openshift.tags="compliance openscap scan" \
+    io.openshift.wants="scap-content"
+
+# The repo is only for testing. Used to create quay.io/mrogers950/openscap-ocp:yamlprobe
+COPY \
+    mrogers-openscap-with-yaml-epel-8.repo /etc/yum.repos.d/
+
+RUN true \
+    && microdnf install -y openscap-scanner \
+    && microdnf clean all \
+    && true

--- a/images/openscap/mrogers-openscap-with-yaml-epel-8.repo
+++ b/images/openscap/mrogers-openscap-with-yaml-epel-8.repo
@@ -1,0 +1,10 @@
+[copr:copr.fedorainfracloud.org:mrogers:openscap]
+name=Copr repo for openscap owned by mrogers
+baseurl=https://download.copr.fedorainfracloud.org/results/mrogers/openscap/epel-8-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/mrogers/openscap/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1


### PR DESCRIPTION
I figured I would share this in the repo. It's for manually building an openscap image with the github.com/OpenSCAP maint-1.3 branch, which contains the yaml OVAL probe code.