### PR TITLE
hardening: Drop usage of privileged scc and containers

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -98,14 +98,6 @@ rules:
   - compliance-operator
   verbs:
   - "update"
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - privileged
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -152,7 +144,7 @@ rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
-  - privileged
+  - node-exporter
   resources:
   - securitycontextconstraints
   verbs:
@@ -189,11 +181,3 @@ rules:
   - complianceremediations
   verbs:
   - create
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - privileged
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -61,9 +61,6 @@ func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Log
 						"--scan=" + scanInstance.Name,
 						"--namespace=" + scanInstance.Namespace,
 					},
-					SecurityContext: &corev1.SecurityContext{
-						Privileged: &trueVal,
-					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "content-dir",

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -62,6 +62,9 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 			Name:      podName,
 			Namespace: scanInstance.Namespace,
 			Labels:    podLabels,
+			Annotations: map[string]string{
+				"openshift.io/scc": "node-exporter",
+			},
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: resultscollectorSA,
@@ -99,9 +102,6 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 						"--tls-client-cert=/etc/pki/tls/tls.crt",
 						"--tls-client-key=/etc/pki/tls/tls.key",
 						"--tls-ca=/etc/pki/tls/ca.crt",
-					},
-					SecurityContext: &corev1.SecurityContext{
-						Privileged: &trueVal,
 					},
 					ImagePullPolicy: corev1.PullAlways,
 					VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
This removes the usage of the privileged scc in favor of the
node-exporter scc which is more restrictive. On the other hand, this
drops the usage of "privileged" for containers that didn't need it.