### PR TITLE
Use quay.io/jhrozek/openscap-ocp:latest in the deployment

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -31,7 +31,7 @@ spec:
             - name: OPERATOR_NAME
               value: "compliance-operator"
             - name: OPENSCAP_IMAGE
-              value: "quay.io/jhrozek/openscap-ocp:remediations_demo"
+              value: "quay.io/jhrozek/openscap-ocp:latest"
             - name: LOG_COLLECTOR_IMAGE
               value: "quay.io/compliance-operator/resultscollector:latest"
             - name: RESULT_SERVER_IMAGE


### PR DESCRIPTION
We used to point `quay.io/jhrozek/openscap-ocp:remediations_demo` for some reason.
This image was outdated (1.3.1 based) while some fixes already made it to the RHEL-8.2 branch
which is based on upstream 1.3.2.

This patch uses the `:latest` tag which was also synced with RHEL-8.2 rhpkg
branch. To highlight one of the fixes, sysctl checks for network-related sysctls
are now evaluated correctly.