### PR TITLE
Implement remediation auto-apply

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/openshift/compliance-operator/pkg/apis"
 	"github.com/openshift/compliance-operator/pkg/controller"
+	mcfgapi "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
@@ -101,8 +102,13 @@ func main() {
 
 	log.Info("Registering Components.")
 
+	mgrscheme := mgr.GetScheme()
 	// Setup Scheme for all resources
-	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+	if err := apis.AddToScheme(mgrscheme); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+	if err := mcfgapi.Install(mgrscheme); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -115,6 +115,7 @@ rules:
   - machineconfiguration.openshift.io
   resources:
   - machineconfigs  # The compliance remediation controller operates on MachineConfigs
+  - machineconfigpools
   verbs:
   - list
   - get

--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -120,16 +121,6 @@ func (r *ReconcileComplianceSuite) Reconcile(request reconcile.Request) (reconci
 
 func (r *ReconcileComplianceSuite) reconcileScans(suite *compv1alpha1.ComplianceSuite, logger logr.Logger) error {
 	for _, scanWrap := range suite.Spec.Scans {
-		// The scans contain a nodeSelector that ultimately must match a machineConfigPool. The only way we can
-		// ensure it does is by checking if the nodeSelector contains a label with the key
-		//"node-role.kubernetes.io/XXX". Then the matching Pool would be labeled with
-		//"machineconfiguration.openshift.io/role: XXX".
-		//See also: https://github.com/openshift/machine-config-operator/blob/master/docs/custom-pools.md
-		if utils.GetFirstNodeRole(scanWrap.NodeSelector) == "" {
-			logger.Info("Not scheduling scan without a role label", "scan", scanWrap.Name)
-			continue
-		}
-
 		scan := &compv1alpha1.ComplianceScan{}
 		err := r.client.Get(context.TODO(), types.NamespacedName{Name: scanWrap.Name, Namespace: suite.Namespace}, scan)
 		if err != nil && errors.IsNotFound(err) {
@@ -271,11 +262,17 @@ func newScanForSuite(suite *compv1alpha1.ComplianceSuite, scanWrap *compv1alpha1
 func (r *ReconcileComplianceSuite) reconcileRemediations(suite *compv1alpha1.ComplianceSuite, logger logr.Logger) error {
 	// Get all the remediations
 	var remList compv1alpha1.ComplianceRemediationList
+	mcfgpools := &mcfgv1.MachineConfigPoolList{}
+	affectedMcfgPools := map[string]*mcfgv1.MachineConfigPool{}
 	listOpts := client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set{"complianceoperator.openshift.io/suite": suite.Name}),
 	}
 
 	if err := r.client.List(context.TODO(), &remList, &listOpts); err != nil {
+		return err
+	}
+
+	if err := r.client.List(context.TODO(), mcfgpools); err != nil {
 		return err
 	}
 
@@ -285,7 +282,19 @@ func (r *ReconcileComplianceSuite) reconcileRemediations(suite *compv1alpha1.Com
 		remOverview[idx].ScanName = rem.Labels[compv1alpha1.ScanLabel]
 		remOverview[idx].RemediationName = rem.Name
 		remOverview[idx].Type = rem.Spec.Type
-		remOverview[idx].Apply = rem.Spec.Apply
+		if suite.Spec.AutoApplyRemediations {
+			switch rem.Spec.Type {
+			case compv1alpha1.McRemediation:
+				if err := r.applyMcfgRemediationAndPausePool(rem, mcfgpools, affectedMcfgPools); err != nil {
+					return err
+				}
+			default:
+				logger.Info("Found remediation without applicable type. Not doing anything.", "name", rem.Name)
+			}
+			remOverview[idx].Apply = true
+		} else {
+			remOverview[idx].Apply = rem.Spec.Apply
+		}
 	}
 
 	// Replace the copy so we use fresh metadata
@@ -296,5 +305,58 @@ func (r *ReconcileComplianceSuite) reconcileRemediations(suite *compv1alpha1.Com
 	}
 	suite.Status.RemediationOverview = remOverview
 	logger.Info("Remediations", "remOverview", remOverview)
-	return r.client.Status().Update(context.TODO(), suite)
+
+	if err := r.client.Status().Update(context.TODO(), suite); err != nil {
+		return err
+	}
+
+	for _, pool := range affectedMcfgPools {
+		poolCopy := pool.DeepCopy()
+		poolCopy.Spec.Paused = false
+		if err := r.client.Update(context.TODO(), poolCopy); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// This gets the remediation to be applied. Note that before being able to do that, the machineConfigPool is
+// paused in order to reduce restarts of nodes.
+func (r *ReconcileComplianceSuite) applyMcfgRemediationAndPausePool(rem compv1alpha1.ComplianceRemediation,
+	mcfgpools *mcfgv1.MachineConfigPoolList, affectedPools map[string]*mcfgv1.MachineConfigPool) error {
+	remCopy := rem.DeepCopy()
+	scan := &compv1alpha1.ComplianceScan{}
+	scanKey := types.NamespacedName{Name: rem.Labels[compv1alpha1.ScanLabel], Namespace: rem.Namespace}
+	if err := r.client.Get(context.TODO(), scanKey, scan); err != nil {
+		return err
+	}
+	pool, found := r.getAffectedMcfgPool(scan, mcfgpools)
+
+	// Only apply remediations once the scan is done. This hopefully ensures
+	// that we already have all the relevant remediations in place.
+	if found && scan.Status.Phase == compv1alpha1.PhaseDone {
+		// Only update pool once
+		if _, ok := affectedPools[pool.Name]; !ok {
+			poolCopy := pool.DeepCopy()
+			affectedPools[poolCopy.Name] = poolCopy
+			poolCopy.Spec.Paused = true
+			if err := r.client.Update(context.TODO(), poolCopy); err != nil {
+				return err
+			}
+		}
+		remCopy.Spec.Apply = true
+		if err := r.client.Update(context.TODO(), remCopy); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileComplianceSuite) getAffectedMcfgPool(scan *compv1alpha1.ComplianceScan, mcfgpools *mcfgv1.MachineConfigPoolList) (mcfgv1.MachineConfigPool, bool) {
+	for _, pool := range mcfgpools.Items {
+		if utils.McfgPoolLabelMatches(scan.Spec.NodeSelector, &pool) {
+			return pool, true
+		}
+	}
+	return mcfgv1.MachineConfigPool{}, false
 }

--- a/pkg/utils/nodeutils.go
+++ b/pkg/utils/nodeutils.go
@@ -16,7 +16,10 @@ limitations under the License.
 package utils
 
 import (
+	"reflect"
 	"strings"
+
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
 const (
@@ -53,6 +56,26 @@ func GetFirstNodeRole(nodeSelector map[string]string) string {
 	}
 
 	return ""
+}
+
+// AnyMcfgPoolLabelMatches verifies if the given nodeSelector matches the nodeSelector
+// in any of the given MachineConfigPools
+func AnyMcfgPoolLabelMatches(nodeSelector map[string]string, poolList *mcfgv1.MachineConfigPoolList) bool {
+	for _, pool := range poolList.Items {
+		if McfgPoolLabelMatches(nodeSelector, &pool) {
+			return true
+		}
+	}
+	return false
+}
+
+// McfgPoolLabelMatches verifies if the given nodeSelector matches the given MachineConfigPool's nodeSelector
+func McfgPoolLabelMatches(nodeSelector map[string]string, pool *mcfgv1.MachineConfigPool) bool {
+	if nodeSelector == nil {
+		return false
+	}
+	// TODO(jaosorior): Make this work with MatchExpression
+	return reflect.DeepEqual(nodeSelector, pool.Spec.NodeSelector.MatchLabels)
 }
 
 func GetNodeRoleSelector(role string) map[string]string {

--- a/vendor/github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/install.go
+++ b/vendor/github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/install.go
@@ -1,0 +1,15 @@
+package machineconfiguration
+
+import (
+	machineconfigurationv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// GroupName defines the API group for machineconfiguration.
+const GroupName = "machineconfiguration.openshift.io"
+
+var (
+	SchemeBuilder = runtime.NewSchemeBuilder(machineconfigurationv1.Install)
+	// Install is a function which adds every version of this group to a scheme
+	Install = SchemeBuilder.AddToScheme
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -196,6 +196,7 @@ github.com/openshift/api/config/v1
 # github.com/openshift/library-go v0.0.0-20200303185131-81598fff9efa
 github.com/openshift/library-go/pkg/crypto
 # github.com/openshift/machine-config-operator v4.2.0-alpha.0.0.20190917115525-033375cbe820+incompatible => github.com/openshift/machine-config-operator v0.0.1-0.20200305103412-b9fa5093eb95
+github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io
 github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1
 github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/scheme
 github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1


### PR DESCRIPTION
This implements the feature to auto apply remediations by checking if
the scans are all done and then starting to set the "apply" for all of
the remediations belonging to the suite.

Before applying, this actually gets the MachineConfigPool that the
remediation will apply to, and it pauses it. Once all of the "apply"
have been set, it unpauses the pool.

Note that this is only done for Remediations that are of type
MachineConfig.

This also removes the check for nodeSelectors in the suite. This is
instead done on the remediation controller and only for MachineConfig
remediation types