### PR TITLE
Shorten log component names

### DIFF
--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -25,7 +25,7 @@ import (
 	mcfgClient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1"
 )
 
-var log = logf.Log.WithName("controller_complianceremediation")
+var log = logf.Log.WithName("remediationctrl")
 
 // Add creates a new ComplianceRemediation Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -24,7 +24,7 @@ import (
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
 )
 
-var log = logf.Log.WithName("controller_compliancescan")
+var log = logf.Log.WithName("scanctrl")
 
 var oneReplica int32 = 1
 

--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -26,7 +26,7 @@ import (
 	"github.com/openshift/compliance-operator/pkg/utils"
 )
 
-var log = logf.Log.WithName("controller_compliancesuite")
+var log = logf.Log.WithName("suitectrl")
 
 // Add creates a new ComplianceSuite Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.


### PR DESCRIPTION
Instead of having the full name "controller_complianceremediation" this
changes the names to be in the following format: "<object>ctrl".

This should shorten the log lines a little.