### PR TITLE
Makefile: Use `oc apply` instead of `oc create`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ endif
 .PHONY: namespace
 namespace:
 	@echo "Creating '$(NAMESPACE)' namespace/project"
-	@oc create -f deploy/ns.yaml || true
+	@oc apply -f deploy/ns.yaml
 
 .PHONY: openshift-user
 openshift-user:


### PR DESCRIPTION
This makes the logic easier, by always ensuring that the resource is in
the cluster, instead of trying to create it and ignoring errors. This
way we'll see less noise in the logs as well as better error handling
(not real errors will make this fail, instead of always ignoring it).