### PR TITLE
Do creator functions for wrapper-types

### DIFF
--- a/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
@@ -82,3 +82,36 @@ type ComplianceSuiteList struct {
 func init() {
 	SchemeBuilder.Register(&ComplianceSuite{}, &ComplianceSuiteList{})
 }
+
+// ScanStatusWrapperFromScan returns a ComplianceScanStatusWrapper object
+// (used by the ComplianceSuite object) in order to display the status of
+// a scan
+func ScanStatusWrapperFromScan(s *ComplianceScan) ComplianceScanStatusWrapper {
+	return ComplianceScanStatusWrapper{
+		Name:                 s.Name,
+		ComplianceScanStatus: s.Status,
+	}
+}
+
+// RemediationNameStatusFromRemediation returns a ComplianceRemediationNameStatus
+// object (used by the ComplianceSuite object) in order to display a
+// remediation
+func RemediationNameStatusFromRemediation(r *ComplianceRemediation) ComplianceRemediationNameStatus {
+	return ComplianceRemediationNameStatus{
+		RemediationName:               r.Name,
+		ScanName:                      r.Labels[ScanLabel],
+		ComplianceRemediationSpecMeta: r.Spec.ComplianceRemediationSpecMeta,
+	}
+}
+
+// ComplianceScanFromWrapper returns a ComplianceScan from the wrapper that's given
+// to a ComplianceSuite. This will return all the values that are derivable from the
+// wrapper in order to build a scan. Anything missing must be added separately.
+func ComplianceScanFromWrapper(sw *ComplianceScanSpecWrapper) *ComplianceScan {
+	return &ComplianceScan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: sw.Name,
+		},
+		Spec: sw.ComplianceScanSpec,
+	}
+}


### PR DESCRIPTION
Currently, there are two ways of handling wrapper types (which are used
in the complianceSuite):

* From object to wrapper
* From wrapper to object

The way that this is done currently is by setting each value from an
object to another.

This is error prone as it can lead to us forgetting to set some
attribute, specially as the types evolve.

This patch instead creates functions to transform between objects and
their wrappers, and attempts to do it in a way that includes bigger
pieces of the object, e.g. setting the whole ComplianceScan Spec, from
the wrapper's Spec. In the aforementioned example, every time we include
new parameters in the ComplianceScan's spec, the function will
automatically take it into account, so we'll have less code changes
there.