### PR TITLE
Additional print columns

### DIFF
--- a/deploy/crds/compliance.openshift.io_complianceremediations_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_complianceremediations_crd.yaml
@@ -3,6 +3,10 @@ kind: CustomResourceDefinition
 metadata:
   name: complianceremediations.compliance.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.applicationState
+    name: State
+    type: string
   group: compliance.openshift.io
   names:
     kind: ComplianceRemediation

--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -3,6 +3,13 @@ kind: CustomResourceDefinition
 metadata:
   name: compliancescans.compliance.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  - JSONPath: .status.result
+    name: Result
+    type: string
   group: compliance.openshift.io
   names:
     kind: ComplianceScan

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -84,6 +84,12 @@ spec:
         status:
           description: Contains the current state of the suite
           properties:
+            aggregatedPhase:
+              description: Represents the status of the compliance scan run.
+              type: string
+            aggregatedResult:
+              description: Represents the result of the compliance scan
+              type: string
             remediationOverview:
               items:
                 properties:

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -3,6 +3,13 @@ kind: CustomResourceDefinition
 metadata:
   name: compliancesuites.compliance.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.aggregatedPhase
+    name: Phase
+    type: string
+  - JSONPath: .status.aggregatedResult
+    name: Result
+    type: string
   group: compliance.openshift.io
   names:
     kind: ComplianceSuite

--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -11,8 +11,8 @@ import (
 type RemediationApplicationState string
 
 const (
-	RemediationNotSelected RemediationApplicationState = "NotSelected"
-	RemediationApplied     RemediationApplicationState = "Applied"
+	RemediationNotApplied RemediationApplicationState = "NotApplied"
+	RemediationApplied    RemediationApplicationState = "Applied"
 )
 
 type RemediationType string

--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -58,6 +58,7 @@ type ComplianceRemediationStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=complianceremediations,scope=Namespaced
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=`.status.applicationState`
 type ComplianceRemediation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -27,6 +27,8 @@ type ComplianceScanStatusResult string
 
 const (
 	// ResultCompliant represents the compliance scan having succeeded
+	ResultNotAvailable ComplianceScanStatusResult = "NOT-AVAILABLE"
+	// ResultCompliant represents the compliance scan having succeeded
 	ResultCompliant ComplianceScanStatusResult = "COMPLIANT"
 	// ResultError represents a compliance scan pod having failed to run the scan or encountered an error
 	ResultError ComplianceScanStatusResult = "ERROR"

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -112,6 +112,8 @@ type ComplianceScanStatus struct {
 // that apply to a certain nodeSelector, or the cluster itself.
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Result",type="string",JSONPath=`.status.result`
 type ComplianceScan struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -22,6 +22,20 @@ const (
 	PhaseDone ComplianceScanStatusPhase = "DONE"
 )
 
+func stateCompare(lowPhase ComplianceScanStatusPhase, scanPhase ComplianceScanStatusPhase) ComplianceScanStatusPhase {
+	orderedStates := make(map[ComplianceScanStatusPhase]int)
+	orderedStates[PhasePending] = 0
+	orderedStates[PhaseLaunching] = 1
+	orderedStates[PhaseRunning] = 2
+	orderedStates[PhaseAggregating] = 3
+	orderedStates[PhaseDone] = 4
+
+	if orderedStates[lowPhase] > orderedStates[scanPhase] {
+		return scanPhase
+	}
+	return lowPhase
+}
+
 // Represents the result of the compliance scan
 type ComplianceScanStatusResult string
 
@@ -35,6 +49,19 @@ const (
 	// ResultNonCompliant represents the compliance scan having found a gap
 	ResultNonCompliant ComplianceScanStatusResult = "NON-COMPLIANT"
 )
+
+func resultCompare(lowResult ComplianceScanStatusResult, scanResult ComplianceScanStatusResult) ComplianceScanStatusResult {
+	orderedResults := make(map[ComplianceScanStatusResult]int)
+	orderedResults[ResultNotAvailable] = 0
+	orderedResults[ResultError] = 1
+	orderedResults[ResultNonCompliant] = 2
+	orderedResults[ResultCompliant] = 3
+
+	if orderedResults[lowResult] > orderedResults[scanResult] {
+		return scanResult
+	}
+	return lowResult
+}
 
 // ComplianceScanSpec defines the desired state of ComplianceScan
 // +k8s:openapi-gen=true

--- a/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
@@ -51,6 +51,8 @@ type ComplianceSuiteStatus struct {
 	// +listType=atomic
 	// +optional
 	RemediationOverview []ComplianceRemediationNameStatus `json:"remediationOverview,omitempty"`
+	AggregatedPhase     ComplianceScanStatusPhase         `json:"aggregatedPhase,omitempty"`
+	AggregatedResult    ComplianceScanStatusResult        `json:"aggregatedResult,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -114,4 +116,24 @@ func ComplianceScanFromWrapper(sw *ComplianceScanSpecWrapper) *ComplianceScan {
 		},
 		Spec: sw.ComplianceScanSpec,
 	}
+}
+
+func (s *ComplianceSuite) LowestCommonState() ComplianceScanStatusPhase {
+	lowestCommonState := PhaseDone
+
+	for _, scanStatusWrap := range s.Status.ScanStatuses {
+		lowestCommonState = stateCompare(lowestCommonState, scanStatusWrap.Phase)
+	}
+
+	return lowestCommonState
+}
+
+func (s *ComplianceSuite) LowestCommonResult() ComplianceScanStatusResult {
+	lowestCommonResult := ResultCompliant
+
+	for _, scanStatusWrap := range s.Status.ScanStatuses {
+		lowestCommonResult = resultCompare(lowestCommonResult, scanStatusWrap.Result)
+	}
+
+	return lowestCommonResult
 }

--- a/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
@@ -62,6 +62,8 @@ type ComplianceSuiteStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=compliancesuites,scope=Namespaced
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=`.status.aggregatedPhase`
+// +kubebuilder:printcolumn:name="Result",type="string",JSONPath=`.status.aggregatedResult`
 type ComplianceSuite struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -168,7 +168,7 @@ func (r *ReconcileComplianceRemediation) reconcileRemediationStatus(instance *co
 	if instance.Spec.Apply {
 		instanceCopy.Status.ApplicationState = compv1alpha1.RemediationApplied
 	} else {
-		instanceCopy.Status.ApplicationState = compv1alpha1.RemediationNotSelected
+		instanceCopy.Status.ApplicationState = compv1alpha1.RemediationNotApplied
 	}
 
 	if err := r.client.Status().Update(context.TODO(), instanceCopy); err != nil {

--- a/pkg/controller/complianceremediation/complianceremediation_controller_test.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Testing complianceremediation controller", func() {
 
 		It("should skip those that are not applied", func() {
 			notApplied := existingRemediations[1]
-			notApplied.Status.ApplicationState = compv1alpha1.RemediationNotSelected
+			notApplied.Status.ApplicationState = compv1alpha1.RemediationNotApplied
 			err := reconciler.client.Update(context.TODO(), notApplied)
 			Expect(err).To(BeNil())
 

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -150,6 +150,7 @@ func (r *ReconcileComplianceScan) phasePendingHandler(instance *compv1alpha1.Com
 
 	// Update the scan instance, the next phase is running
 	instance.Status.Phase = compv1alpha1.PhaseLaunching
+	instance.Status.Result = compv1alpha1.ResultNotAvailable
 	err = r.client.Status().Update(context.TODO(), instance)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/compliancescan/compliancescan_controller_test.go
+++ b/pkg/controller/compliancescan/compliancescan_controller_test.go
@@ -71,6 +71,7 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 			Expect(result).NotTo(BeNil())
 			Expect(err).To(BeNil())
 			Expect(compliancescaninstance.Status.Phase).To(Equal(compv1alpha1.PhaseLaunching))
+			Expect(compliancescaninstance.Status.Result).To(Equal(compv1alpha1.ResultNotAvailable))
 		})
 	})
 

--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -164,6 +164,7 @@ func (r *ReconcileComplianceSuite) reconcileScanStatus(suite *compv1alpha1.Compl
 		logger.Error(err, "Could not add scan status")
 		return err
 	}
+
 	return nil
 }
 
@@ -180,6 +181,8 @@ func (r *ReconcileComplianceSuite) updateScanStatus(suite *compv1alpha1.Complian
 	// Replace the copy so we use fresh metadata
 	suite = suite.DeepCopy()
 	suite.Status.ScanStatuses[idx] = modScanStatus
+	suite.Status.AggregatedPhase = suite.LowestCommonState()
+	suite.Status.AggregatedResult = suite.LowestCommonResult()
 	logger.Info("Updating scan status", "scan", modScanStatus.Name, "phase", modScanStatus.Phase)
 
 	return r.client.Status().Update(context.TODO(), suite)
@@ -193,6 +196,8 @@ func (r *ReconcileComplianceSuite) addScanStatus(suite *compv1alpha1.ComplianceS
 	suite = suite.DeepCopy()
 	suite.Status.ScanStatuses = append(suite.Status.ScanStatuses, newScanStatus)
 	logger.Info("Adding scan status", "scan", newScanStatus.Name, "phase", newScanStatus.Phase)
+	suite.Status.AggregatedPhase = suite.LowestCommonState()
+	suite.Status.AggregatedResult = suite.LowestCommonResult()
 	return r.client.Status().Update(context.TODO(), suite)
 }
 

--- a/pkg/utils/parse_arf_result.go
+++ b/pkg/utils/parse_arf_result.go
@@ -126,7 +126,7 @@ func remediationFromString(scheme *runtime.Scheme, name string, namespace string
 			MachineConfigContents: *mcObject,
 		},
 		Status: compv1alpha1.ComplianceRemediationStatus{
-			ApplicationState: compv1alpha1.RemediationNotSelected,
+			ApplicationState: compv1alpha1.RemediationNotApplied,
 		},
 	}
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -228,7 +228,7 @@ func TestE2E(t *testing.T) {
 				}
 
 				// Ensure that all the scans in the suite have finished and are marked as Done
-				err = waitForSuiteScansStatus(t, f, namespace, suiteName, compv1alpha1.PhaseDone)
+				err = waitForSuiteScansStatus(t, f, namespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultNonCompliant)
 				if err != nil {
 					return err
 				}
@@ -305,7 +305,7 @@ func TestE2E(t *testing.T) {
 				}
 
 				// Ensure that all the scans in the suite have finished and are marked as Done
-				err = waitForSuiteScansStatus(t, f, namespace, suiteName, compv1alpha1.PhaseDone)
+				err = waitForSuiteScansStatus(t, f, namespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultNonCompliant)
 				if err != nil {
 					return err
 				}
@@ -352,7 +352,7 @@ func TestE2E(t *testing.T) {
 				t.Logf("Second scan launched")
 
 				// Ensure that all the scans in the suite have finished and are marked as Done
-				err = waitForSuiteScansStatus(t, f, namespace, secondSuiteName, compv1alpha1.PhaseDone)
+				err = waitForSuiteScansStatus(t, f, namespace, secondSuiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultCompliant)
 				if err != nil {
 					return err
 				}
@@ -459,7 +459,7 @@ func TestE2E(t *testing.T) {
 				}
 
 				// Ensure that all the scans in the suite have finished and are marked as Done
-				err = waitForSuiteScansStatus(t, f, namespace, suiteName, compv1alpha1.PhaseDone)
+				err = waitForSuiteScansStatus(t, f, namespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultNonCompliant)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Makes use of a kubebuilder feature to print additional status columns for
our CRs.

For Remediations, we display whether a remediation was applied or not. For
Suites and Scans, we display the status and result.

More info on the server side columns can be found here:
   https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html or
here:
    https://medium.com/@xcoulon/customizing-the-server-side-printing-of-your-kubernetes-custom-resources-1c84b7631686

Even more details can be found in the commit messages.