### PR TITLE
Improve operator logging

### DIFF
--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -116,7 +116,7 @@ func (r *ReconcileComplianceScan) deleteAggregator(instance *compv1alpha1.Compli
 }
 
 func isAggregatorRunning(r *ReconcileComplianceScan, scanInstance *compv1alpha1.ComplianceScan, logger logr.Logger) (bool, error) {
-	logger.Info("Checking aggregator pod for scan", "scan", scanInstance.Name)
+	logger.Info("Checking aggregator pod for scan", "ComplianceScan.Name", scanInstance.Name)
 
 	podName := scanInstance.Annotations[AggregatorPodAnnotation]
 	return isPodRunning(r, podName, scanInstance.Namespace, logger)

--- a/pkg/controller/compliancescan/pki.go
+++ b/pkg/controller/compliancescan/pki.go
@@ -21,7 +21,7 @@ func (r *ReconcileComplianceScan) handleRootCASecret(instance *compv1alpha1.Comp
 		return nil
 	}
 
-	logger.Info("creating CA", "instance", instance.Name)
+	logger.Info("creating CA", "ComplianceScan.Name", instance.Name)
 	secret, err := makeCASecret(instance, common.GetComplianceOperatorNamespace())
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func (r *ReconcileComplianceScan) handleResultServerSecret(instance *compv1alpha
 		return nil
 	}
 
-	logger.Info("creating server cert", "instance", instance.Name)
+	logger.Info("creating server cert", "ComplianceScan.Name", instance.Name)
 	secret, err := makeServerCertSecret(r.client, instance, common.GetComplianceOperatorNamespace())
 	if err != nil {
 		return err
@@ -76,7 +76,7 @@ func (r *ReconcileComplianceScan) handleResultClientSecret(instance *compv1alpha
 		return nil
 	}
 
-	logger.Info("creating client cert", "instance", instance.Name)
+	logger.Info("creating client cert", "ComplianceScan.Name", instance.Name)
 	secret, err := makeClientCertSecret(r.client, instance, common.GetComplianceOperatorNamespace())
 	if err != nil {
 		return err
@@ -96,21 +96,21 @@ func (r *ReconcileComplianceScan) handleResultClientSecret(instance *compv1alpha
 }
 
 func (r *ReconcileComplianceScan) deleteRootCASecret(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
-	logger.Info("deleting CA", "instance", instance.Name)
+	logger.Info("deleting CA", "ComplianceScan.Name", instance.Name)
 	ns := common.GetComplianceOperatorNamespace()
 	secret := certSecret(getCASecretName(instance), ns, []byte{}, []byte{}, []byte{})
 	return r.deleteSecret(secret)
 }
 
 func (r *ReconcileComplianceScan) deleteResultServerSecret(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
-	logger.Info("deleting server cert", "instance", instance.Name)
+	logger.Info("deleting server cert", "ComplianceScan.Name", instance.Name)
 	ns := common.GetComplianceOperatorNamespace()
 	secret := certSecret(getServerCertSecretName(instance), ns, []byte{}, []byte{}, []byte{})
 	return r.deleteSecret(secret)
 }
 
 func (r *ReconcileComplianceScan) deleteResultClientSecret(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
-	logger.Info("deleting client cert", "instance", instance.Name)
+	logger.Info("deleting client cert", "ComplianceScan.Name", instance.Name)
 	ns := common.GetComplianceOperatorNamespace()
 	secret := certSecret(getClientCertSecretName(instance), ns, []byte{}, []byte{}, []byte{})
 	return r.deleteSecret(secret)

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -43,7 +43,7 @@ func (r *ReconcileComplianceScan) createResultServer(instance *compv1alpha1.Comp
 		logger.Error(err, "Cannot create deployment", "deployment", deployment)
 		return err
 	}
-	logger.Info("ResultServer Deployment launched", "name", deployment.Name)
+	logger.Info("ResultServer Deployment launched", "Deployment.Name", deployment.Name)
 
 	service := resultServerService(instance, resultServerLabels)
 	if err = controllerutil.SetControllerReference(instance, service, r.scheme); err != nil {
@@ -56,7 +56,7 @@ func (r *ReconcileComplianceScan) createResultServer(instance *compv1alpha1.Comp
 		logger.Error(err, "Cannot create service", "service", service)
 		return err
 	}
-	logger.Info("ResultServer Service launched", "name", service.Name)
+	logger.Info("ResultServer Service launched", "Service.Name", service.Name)
 	return nil
 }
 
@@ -75,7 +75,7 @@ func (r *ReconcileComplianceScan) deleteResultServer(instance *compv1alpha1.Comp
 		logger.Error(err, "Cannot delete deployment", "deployment", deployment)
 		return err
 	}
-	logger.Info("ResultServer Deployment deleted", "name", deployment.Name)
+	logger.Info("ResultServer Deployment deleted", "Deployment.Name", deployment.Name)
 	logger.Info("Deleting scan result server service")
 
 	service := resultServerService(instance, resultServerLabels)
@@ -84,7 +84,7 @@ func (r *ReconcileComplianceScan) deleteResultServer(instance *compv1alpha1.Comp
 		logger.Error(err, "Cannot delete service", "service", service)
 		return err
 	}
-	logger.Info("ResultServer Service deleted", "name", service.Name)
+	logger.Info("ResultServer Service deleted", "Service.Name", service.Name)
 	return nil
 }
 

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -20,34 +20,34 @@ func (r *ReconcileComplianceScan) createScanPods(instance *compv1alpha1.Complian
 	// On each eligible node..
 	for _, node := range nodes.Items {
 		// ..schedule a pod..
-		logger.Info("Creating a pod for node", "node", node.Name)
+		logger.Info("Creating a pod for node", "Pod.Name", node.Name)
 		pod := newScanPodForNode(instance, &node, logger)
 		if err := controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
-			log.Error(err, "Failed to set pod ownership", "pod", pod)
+			log.Error(err, "Failed to set pod ownership", "Pod.Name", pod)
 			return err
 		}
 
 		// ..and launch it..
 		err := r.client.Create(context.TODO(), pod)
 		if errors.IsAlreadyExists(err) {
-			logger.Info("Pod already exists. This is fine.", "pod", pod)
+			logger.Info("Pod already exists. This is fine.", "Pod.Name", pod)
 		} else if err != nil {
-			log.Error(err, "Failed to launch a pod", "pod", pod)
+			log.Error(err, "Failed to launch a pod", "Pod.Name", pod)
 			return err
 		} else {
-			logger.Info("Launched a pod", "pod", pod)
+			logger.Info("Launched a pod", "Pod.Name", pod)
 		}
 	}
 
 	// make sure the instance is updated with the node-pod labels
 	if err := r.client.Update(context.TODO(), instance); err != nil {
+		log.Error(err, "Failed to update a scan")
 		return err
 	}
 	return nil
 }
 
 func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.Node, logger logr.Logger) *corev1.Pod {
-
 	mode := int32(0744)
 
 	podName := getPodForNodeName(scanInstance.Name, node.Name)
@@ -217,18 +217,18 @@ func (r *ReconcileComplianceScan) deleteScanPods(instance *compv1alpha1.Complian
 	// On each eligible node..
 	for _, node := range nodes.Items {
 		// ..schedule a pod..
-		logger.Info("Creating a pod for node", "node", node.Name)
+		logger.Info("Creating a pod for node", "Node.Name", node.Name)
 		pod := newScanPodForNode(instance, &node, logger)
 
 		// ..and launch it..
 		err := r.client.Delete(context.TODO(), pod)
 		if errors.IsNotFound(err) {
-			logger.Info("Pod is already gone. This is fine.", "pod", pod)
+			logger.Info("Pod is already gone. This is fine.", "Pod.Name", pod)
 		} else if err != nil {
-			log.Error(err, "Failed to delete a pod", "pod", pod)
+			log.Error(err, "Failed to delete a pod", "Pod.Name", pod)
 			return err
 		} else {
-			logger.Info("deleted pod", "pod", pod)
+			logger.Info("deleted pod", "Pod.Name", pod)
 		}
 	}
 


### PR DESCRIPTION
The operator was sometimes logging too much and sometimes too little.
This patch adds more log messages to error conditions as well as
branches that were not decorated with logging at all such as pausing or
unpausing the pools.

In addition, some log messages are not completely removed but instead
commented out for when we introduce log levels that let us fine-tune the
verbosity.