### PR TITLE
Display more metadata about complianceremediations

### DIFF
--- a/deploy/crds/compliance.openshift.io_complianceremediations_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_complianceremediations_crd.yaml
@@ -40,6 +40,9 @@ spec:
               description: Whether the remediation should be picked up and applied
                 by the operator
               type: boolean
+            id:
+              description: A unique identifier of the remediation
+              type: string
             machineConfigContents:
               description: The actual remediation payload
               properties:
@@ -448,6 +451,12 @@ spec:
               required:
               - spec
               type: object
+            rationale:
+              description: Rationale describes why should the remediation be applied
+              type: string
+            title:
+              description: A single-sentence title that sums up the remediation
+              type: string
             type:
               description: Remediation type specifies the artifact the remediation
                 is based on. For now, only MachineConfig is supported

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -104,12 +104,22 @@ spec:
                     description: Whether the remediation should be picked up and applied
                       by the operator
                     type: boolean
+                  id:
+                    description: A unique identifier of the remediation
+                    type: string
+                  rationale:
+                    description: Rationale describes why should the remediation be
+                      applied
+                    type: string
                   remediationName:
                     description: Contains a human readable name for the remediation.
                     type: string
                   scanName:
                     description: Contains the name of the scan that generated the
                       remediation
+                    type: string
+                  title:
+                    description: A single-sentence title that sums up the remediation
                     type: string
                   type:
                     description: Remediation type specifies the artifact the remediation

--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -34,6 +34,12 @@ type ComplianceRemediationSpecMeta struct {
 	Type RemediationType `json:"type,omitempty"`
 	// Whether the remediation should be picked up and applied by the operator
 	Apply bool `json:"apply"`
+	// A unique identifier of the remediation
+	ID string `json:"id,omitempty"`
+	// A single-sentence title that sums up the remediation
+	Title string `json:"title,omitempty"`
+	// Rationale describes why should the remediation be applied
+	Rationale string `json:"rationale,omitempty"`
 }
 
 // ComplianceRemediationSpec defines the desired state of ComplianceRemediation

--- a/pkg/utils/parse_arf_result_test.go
+++ b/pkg/utils/parse_arf_result_test.go
@@ -72,6 +72,21 @@ var _ = Describe("XCCDF parser", func() {
 				Expect(rem.Spec.Type).To(Equal(compv1alpha1.McRemediation))
 			})
 
+			Context("MC metadata", func() {
+				It("Should have an ID", func() {
+					Expect(rem.Spec.ID).ToNot(BeEmpty())
+					Expect(rem.Spec.ID).To(Equal("xccdf_org.ssgproject.content_rule_no_direct_root_logins"))
+				})
+				It("Should have a title", func() {
+					Expect(rem.Spec.Title).ToNot(BeEmpty())
+					Expect(rem.Spec.Title).To(Equal("Direct root Logins Not Allowed"))
+				})
+				It("Should have a rationale", func() {
+					Expect(rem.Spec.Rationale).ToNot(BeEmpty())
+					Expect(rem.Spec.Rationale).To(HavePrefix("Disabling direct root logins ensures"))
+				})
+			})
+
 			Context("MC files", func() {
 				var (
 					mcFiles []igntypes.File

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -261,6 +261,42 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
+
+				// Check that one of the remediations has the expected attributes
+				remCheck := &compv1alpha1.ComplianceRemediation{}
+				expRemSpec := &compv1alpha1.ComplianceRemediationSpecMeta{
+					ID:        "xccdf_org.ssgproject.content_rule_no_empty_passwords",
+					Title:     "Prevent Login to Accounts With Empty Password",
+					Rationale: `If an account has an empty password, anyone could log in and
+run commands with the privileges of that account. Accounts with
+empty passwords should never be used in operational environments.`,
+				}
+
+				err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: workerRemediations[0], Namespace: namespace}, remCheck)
+				if err != nil {
+					t.Errorf("Unexpected error %v", err)
+					return err
+				}
+
+				if expRemSpec.ID != remCheck.Spec.ID {
+					err := fmt.Errorf("unexpected remediation ID, expected '%s' got '%s'", expRemSpec.ID, remCheck.Spec.ID)
+					t.Error(err)
+					return err
+				}
+
+				if expRemSpec.Title != remCheck.Spec.Title {
+					err := fmt.Errorf("unexpected remediation title, expected '%s' got '%s'", expRemSpec.Title, remCheck.Spec.Title)
+					t.Error(err)
+					return err
+				}
+
+				if expRemSpec.Rationale != remCheck.Spec.Rationale {
+					err := fmt.Errorf("unexpected remediation rationale, expected '%s' got '%s'", expRemSpec.Rationale, remCheck.Spec.Rationale)
+					t.Error(err)
+					return err
+				}
+
+				t.Log(remCheck.Spec.ID, remCheck.Spec.Title, remCheck.Spec.Rationale)
 				return nil
 			},
 		},


### PR DESCRIPTION
It was currently quite hard for an administrator to know what a
remediation is doing and why. This patch extends the
complianceremediation CR with a unique ID, a title and a description.

The ID is typically the identifier of the openscap rule. The title is a
one-sentence summary of the remediation and the rationale is a longer,
free-form text.

With this enhancement, the admin can inspect the complianceremediation
object to see what would applying the remediation do to their system and
why.