### PR TITLE
Fixes to complianceSuite remediations handling

### DIFF
--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -289,6 +289,10 @@ func mergeMachineConfigs(configs []*mcfgv1.MachineConfig, name string, roleLabel
 		}
 		outIgn = ign.Append(outIgn, configs[idx].Spec.Config)
 	}
+	// NOTE(jaosorior): If no version was set (for some reason) lets just add a default
+	if outIgn.Ignition.Version == "" {
+		outIgn.Ignition.Version = "2.2.0"
+	}
 	kargs := []string{}
 	for _, cfg := range configs {
 		kargs = append(kargs, cfg.Spec.KernelArguments...)

--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -60,15 +60,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// Watch for changes to secondary resource ComplianceRemediation and requeue the owner ComplianceSuite
-	err = c.Watch(&source.Kind{Type: &compv1alpha1.ComplianceRemediation{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &compv1alpha1.ComplianceSuite{},
-	})
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -102,11 +102,12 @@ func (r *ReconcileComplianceSuite) Reconcile(request reconcile.Request) (reconci
 		return common.ReturnWithRetriableError(reqLogger, err)
 	}
 
-	if err := r.reconcileRemediations(suiteCopy, reqLogger); err != nil {
+	var res reconcile.Result
+	if res, err = r.reconcileRemediations(suiteCopy, reqLogger); err != nil {
 		return common.ReturnWithRetriableError(reqLogger, err)
 	}
 
-	return reconcile.Result{}, nil
+	return res, nil
 }
 
 func (r *ReconcileComplianceSuite) reconcileScans(suite *compv1alpha1.ComplianceSuite, logger logr.Logger) error {
@@ -225,7 +226,7 @@ func newScanForSuite(suite *compv1alpha1.ComplianceSuite, scanWrap *compv1alpha1
 
 // Reconcile the remediation statuses in the suite. Note that the suite that this takes is already
 // a copy, so it's safe to modify.
-func (r *ReconcileComplianceSuite) reconcileRemediations(suite *compv1alpha1.ComplianceSuite, logger logr.Logger) error {
+func (r *ReconcileComplianceSuite) reconcileRemediations(suite *compv1alpha1.ComplianceSuite, logger logr.Logger) (reconcile.Result, error) {
 	// Get all the remediations
 	var remList compv1alpha1.ComplianceRemediationList
 	mcfgpools := &mcfgv1.MachineConfigPoolList{}
@@ -236,12 +237,12 @@ func (r *ReconcileComplianceSuite) reconcileRemediations(suite *compv1alpha1.Com
 
 	if err := r.client.List(context.TODO(), &remList, &listOpts); err != nil {
 		log.Error(err, "Failed to list remediations")
-		return err
+		return reconcile.Result{}, err
 	}
 
 	if err := r.client.List(context.TODO(), mcfgpools); err != nil {
 		log.Error(err, "Failed to list pools")
-		return err
+		return reconcile.Result{}, err
 	}
 
 	// Construct the list of the statuses
@@ -251,8 +252,30 @@ func (r *ReconcileComplianceSuite) reconcileRemediations(suite *compv1alpha1.Com
 		if suite.Spec.AutoApplyRemediations {
 			switch rem.Spec.Type {
 			case compv1alpha1.McRemediation:
-				if err := r.applyMcfgRemediationAndPausePool(rem, mcfgpools, affectedMcfgPools, logger); err != nil {
-					return err
+				// get relevant scan
+				scan := &compv1alpha1.ComplianceScan{}
+				scanKey := types.NamespacedName{Name: rem.Labels[compv1alpha1.ScanLabel], Namespace: rem.Namespace}
+				if err := r.client.Get(context.TODO(), scanKey, scan); err != nil {
+					return reconcile.Result{}, err
+				}
+				// get affected pool
+				pool, affectedPoolExists := r.getAffectedMcfgPool(scan, mcfgpools)
+				// we only ned to operate on pools that are affected
+				if affectedPoolExists {
+					foundPool, poolIsTracked := affectedMcfgPools[pool.Name]
+					if !poolIsTracked {
+						foundPool = pool.DeepCopy()
+						affectedMcfgPools[pool.Name] = foundPool
+					}
+					// Only apply remediations once the scan is done. This hopefully ensures
+					// that we already have all the relevant remediations in place.
+					// We only care for remediations that haven't been applied
+					if scan.Status.Phase == compv1alpha1.PhaseDone &&
+						rem.Status.ApplicationState != compv1alpha1.RemediationApplied {
+						if err := r.applyMcfgRemediationAndPausePool(rem, foundPool, logger); err != nil {
+							return reconcile.Result{}, err
+						}
+					}
 				}
 			default:
 				logger.Info("Found remediation without applicable type. Not doing anything.", "ComplianceRemediation.Name", rem.Name)
@@ -273,53 +296,69 @@ func (r *ReconcileComplianceSuite) reconcileRemediations(suite *compv1alpha1.Com
 
 	if err := r.client.Status().Update(context.TODO(), suite); err != nil {
 		logger.Error(err, "Could not update suite status with remediations ", "ComplianceSuite.Name", suite.Name)
-		return err
+		return reconcile.Result{}, err
 	}
 
-	for _, pool := range affectedMcfgPools {
-		logger.Info("Unpausing pool", "MachineConfigPool.Name", pool.Name)
-		poolCopy := pool.DeepCopy()
-		poolCopy.Spec.Paused = false
-		if err := r.client.Update(context.TODO(), poolCopy); err != nil {
-			logger.Error(err, "Could not unpause pool", "MachineConfigPool.Name", pool.Name)
-			return err
+	// We don't need to do anything else unless we gotta enabled auto-apply
+	if !suite.Spec.AutoApplyRemediations {
+		return reconcile.Result{}, nil
+	}
+
+	// We only post-process when everything is done. This avoids unnecessary
+	// "unpauses" for MachineConfigPools
+	if suite.Status.AggregatedPhase != compv1alpha1.PhaseDone {
+		logger.Info("Waiting until all scans are in Done phase before post-procesing remediations")
+		return reconcile.Result{}, nil
+	}
+
+	// refresh remediationList
+	if err := r.client.List(context.TODO(), &remList, &listOpts); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Check that all remediations have been applied yet. If not, cause an error
+	// and requeue.
+	for _, rem := range remList.Items {
+		if rem.Status.ApplicationState != compv1alpha1.RemediationApplied {
+			logger.Info("Remediation not applied yet. Skipping post-processing", "ComplianceRemediation.Name", rem.Name)
+			return reconcile.Result{}, nil
 		}
 	}
-	return nil
+
+	// Only un-pause MachineConfigPools once the remediations have been applied
+	for _, pool := range affectedMcfgPools {
+		if pool.Spec.Paused {
+			logger.Info("Unpausing pool", "MachineConfigPool.Name", pool.Name)
+			poolCopy := pool.DeepCopy()
+			poolCopy.Spec.Paused = false
+			if err := r.client.Update(context.TODO(), poolCopy); err != nil {
+				logger.Error(err, "Could not unpause pool", "MachineConfigPool.Name", pool.Name)
+				return reconcile.Result{}, err
+			}
+		}
+	}
+	return reconcile.Result{}, nil
 }
 
 // This gets the remediation to be applied. Note that before being able to do that, the machineConfigPool is
 // paused in order to reduce restarts of nodes.
 func (r *ReconcileComplianceSuite) applyMcfgRemediationAndPausePool(rem compv1alpha1.ComplianceRemediation,
-	mcfgpools *mcfgv1.MachineConfigPoolList, affectedPools map[string]*mcfgv1.MachineConfigPool,
-	logger logr.Logger) error {
-
+	pool *mcfgv1.MachineConfigPool, logger logr.Logger) error {
 	remCopy := rem.DeepCopy()
-	scan := &compv1alpha1.ComplianceScan{}
-	scanKey := types.NamespacedName{Name: rem.Labels[compv1alpha1.ScanLabel], Namespace: rem.Namespace}
-	if err := r.client.Get(context.TODO(), scanKey, scan); err != nil {
-		return err
-	}
-	pool, found := r.getAffectedMcfgPool(scan, mcfgpools)
-
-	// Only apply remediations once the scan is done. This hopefully ensures
-	// that we already have all the relevant remediations in place.
-	if found && scan.Status.Phase == compv1alpha1.PhaseDone {
-		// Only update pool once
-		if _, ok := affectedPools[pool.Name]; !ok {
-			logger.Info("Pausing pool", "MachineConfigPool.Name", pool.Name)
-			poolCopy := pool.DeepCopy()
-			affectedPools[poolCopy.Name] = poolCopy
-			poolCopy.Spec.Paused = true
-			if err := r.client.Update(context.TODO(), poolCopy); err != nil {
-				logger.Error(err, "Could not pause pool", "MachineConfigPool.Name", pool.Name)
-				return err
-			}
-		}
-		remCopy.Spec.Apply = true
-		if err := r.client.Update(context.TODO(), remCopy); err != nil {
+	// Only pause pools where the pool wasn't paused before and
+	// the remediation hasn't been applied
+	if !pool.Spec.Paused {
+		logger.Info("Pausing pool", "MachineConfigPool.Name", pool.Name)
+		pool.Spec.Paused = true
+		if err := r.client.Update(context.TODO(), pool); err != nil {
+			logger.Error(err, "Could not pause pool", "MachineConfigPool.Name", pool.Name)
 			return err
 		}
+	}
+
+	remCopy.Spec.Apply = true
+	if err := r.client.Update(context.TODO(), remCopy); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
* Remove watch for remediations: The suite doesn't create them, so it can't really track them. That code is just confusing folks.
* Don't un-pause the pool if the remediation isn't in an "applied" state: Let's wait until it is before un-pausing.
* This also fixes the e2e test to check that the remediation was applied using a pre-fetched machineconfigpool, instead of fetching it in-place. The issue was that we had a race-condition, since the controller had already started applying the remediation when we checked.