### PR TITLE
Add a debug message when no nodes match a scan

### DIFF
--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -219,6 +219,10 @@ func (r *ReconcileComplianceScan) phaseRunningHandler(instance *compv1alpha1.Com
 		return reconcile.Result{}, err
 	}
 
+	if len(nodes.Items) == 0 {
+		log.Info("Warning: No eligible nodes. Check the nodeSelector.")
+	}
+
 	// On each eligible node..
 	for _, node := range nodes.Items {
 		running, err := isPodRunningInNode(r, instance, &node, logger)


### PR DESCRIPTION
I ran a Scan (not a suite) with a wrong pool and was wondering for a bit
why is nothing being scheduled. This message would have helped.