### PR TITLE
Remediations: Only update merged MC if remediation isn't there yet

### DIFF
--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -28,6 +28,10 @@ import (
 
 var log = logf.Log.WithName("remediationctrl")
 
+const (
+	remediationNameAnnotationKey = "remediation.compliance.openshift.io/"
+)
+
 // Add creates a new ComplianceRemediation Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -154,7 +158,7 @@ func (r *ReconcileComplianceRemediation) reconcileMcRemediation(instance *compv1
 	// Actually touch the MC, this hands over control to the MCO
 	// TODO: Only log this with a very high log level
 	// logger.Info("Merged MC", "mc", mergedMc)
-	if err := createOrUpdateMachineConfig(r, mergedMc, logger); err != nil {
+	if err := createOrUpdateMachineConfig(r, mergedMc, instance, logger); err != nil {
 		logger.Error(err, "Failed to create or modify the MC")
 		// The err itself is already retriable (or not)
 		return err
@@ -313,18 +317,25 @@ func mergeMachineConfigs(configs []*mcfgv1.MachineConfig, name string, roleLabel
 	return mergedMc
 }
 
-func createOrUpdateMachineConfig(r *ReconcileComplianceRemediation, merged *mcfgv1.MachineConfig, logger logr.Logger) error {
+func createOrUpdateMachineConfig(r *ReconcileComplianceRemediation, merged *mcfgv1.MachineConfig, rem *compv1alpha1.ComplianceRemediation, logger logr.Logger) error {
 	mc := &mcfgv1.MachineConfig{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: merged.Name}, mc)
 	if err != nil && errors.IsNotFound(err) {
-		return createMachineConfig(r, merged, logger)
+		return createMachineConfig(r, merged, rem, logger)
 	} else if err != nil {
 		logger.Error(err, "Cannot retrieve MC", "MachineConfig.Name", merged.Name)
 		// Get error should be retried
 		return err
 	}
 
-	return updateMachineConfig(r, mc, merged, logger)
+	if rem.Spec.Apply && mcHasRemediation(mc, rem) {
+		// If we have already applied this there's nothing to do
+		return nil
+	} else if !rem.Spec.Apply && !mcHasRemediation(mc, rem) {
+		// If we have already un-applied this there's nothing to do
+		return nil
+	}
+	return updateMachineConfig(r, mc, merged, rem, logger)
 }
 
 func deleteMachineConfig(r *ReconcileComplianceRemediation, name string, logger logr.Logger) error {
@@ -345,7 +356,10 @@ func deleteMachineConfig(r *ReconcileComplianceRemediation, name string, logger 
 	return nil
 }
 
-func createMachineConfig(r *ReconcileComplianceRemediation, merged *mcfgv1.MachineConfig, logger logr.Logger) error {
+func createMachineConfig(r *ReconcileComplianceRemediation, merged *mcfgv1.MachineConfig, rem *compv1alpha1.ComplianceRemediation, logger logr.Logger) error {
+	if rem.Spec.Apply {
+		ensureRemediationAnnotationIsSet(merged, rem)
+	}
 	err := r.client.Create(context.TODO(), merged)
 	if err != nil {
 		logger.Error(err, "Cannot create MC", "MachineConfig.Name", merged.Name)
@@ -356,8 +370,13 @@ func createMachineConfig(r *ReconcileComplianceRemediation, merged *mcfgv1.Machi
 	return nil
 }
 
-func updateMachineConfig(r *ReconcileComplianceRemediation, current *mcfgv1.MachineConfig, merged *mcfgv1.MachineConfig, logger logr.Logger) error {
+func updateMachineConfig(r *ReconcileComplianceRemediation, current *mcfgv1.MachineConfig, merged *mcfgv1.MachineConfig, rem *compv1alpha1.ComplianceRemediation, logger logr.Logger) error {
 	mcCopy := current.DeepCopy()
+	if rem.Spec.Apply {
+		ensureRemediationAnnotationIsSet(mcCopy, rem)
+	} else {
+		ensureRemediationAnnotationIsNotSet(mcCopy, rem)
+	}
 	mcCopy.Spec = merged.Spec
 
 	err := r.client.Update(context.TODO(), mcCopy)
@@ -368,4 +387,33 @@ func updateMachineConfig(r *ReconcileComplianceRemediation, current *mcfgv1.Mach
 	}
 	logger.Info("MC updated", "MachineConfig.Name", merged.Name)
 	return nil
+}
+
+func getRemediationAnnotationKey(remName string) string {
+	return remediationNameAnnotationKey + remName
+}
+
+func ensureRemediationAnnotationIsSet(mc *mcfgv1.MachineConfig, rem *compv1alpha1.ComplianceRemediation) {
+	if mc.Annotations == nil {
+		mc.Annotations = make(map[string]string)
+	}
+	mc.Annotations[getRemediationAnnotationKey(rem.Name)] = ""
+}
+
+func ensureRemediationAnnotationIsNotSet(mc *mcfgv1.MachineConfig, rem *compv1alpha1.ComplianceRemediation) {
+	if mc.Annotations == nil {
+		// No need to do anything
+		return
+	}
+	if _, ok := mc.Annotations[getRemediationAnnotationKey(rem.Name)]; ok {
+		delete(mc.Annotations, getRemediationAnnotationKey(rem.Name))
+	}
+}
+
+func mcHasRemediation(mc *mcfgv1.MachineConfig, rem *compv1alpha1.ComplianceRemediation) bool {
+	if mc.Annotations == nil {
+		return false
+	}
+	_, ok := mc.Annotations[getRemediationAnnotationKey(rem.Name)]
+	return ok
 }


### PR DESCRIPTION
We used to always update the merged MC, however, this was resulting in
multiple changes to the MC because the reconciler would be called many
times and the updates aren't ordered (we can't asure that). So, to avoid
this, we only update if the remediation isn't already there.

We detect that by checking a specific entry in the MC's annotations.