### PR TITLE
Enable OCP API scanning

### DIFF
--- a/cmd/api-resource-collector/log.go
+++ b/cmd/api-resource-collector/log.go
@@ -1,0 +1,38 @@
+/*
+Copyright © 2020 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+var debugLog bool
+
+func LOG(format string, a ...interface{}) {
+	fmt.Printf(format+"\n", a...)
+}
+
+func DBG(format string, a ...interface{}) {
+	if debugLog {
+		LOG("debug: "+format, a...)
+	}
+}
+
+func FATAL(format string, a ...interface{}) {
+	fmt.Fprintf(os.Stderr, "FATAL:"+format+"\n", a...)
+	os.Exit(1)
+}

--- a/cmd/api-resource-collector/main.go
+++ b/cmd/api-resource-collector/main.go
@@ -1,0 +1,149 @@
+/*
+Copyright © 2020 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// ResourceFetcher sources content for resource paths to gather, and then saves the path contents.
+// This interface is provided primarily for code organization.
+type ResourceFetcher interface {
+	// Load from a source path, including the decoding step.
+	LoadSource(path string) error
+	// Search the decoded data for the resources we need under a particular profile.
+	FigureResources(profile string) error
+	// Fetch the resources.
+	FetchResources() error
+	// Save the resources.
+	SaveResources(to string) error
+}
+
+type fetcherConfig struct {
+	Content   string
+	ResultDir string
+	Profile   string
+	Local     bool
+}
+
+func defineFlags(cmd *cobra.Command) {
+	cmd.Flags().String("content", "", "The path to the OpenSCAP content file.")
+	cmd.Flags().String("resultdir", "", "The directory to write the collected object files to.")
+	cmd.Flags().String("profile", "", "The scan profile.")
+	cmd.Flags().Bool("local", false, "Uses KUBECONFIG instead of the in-cluster config, for running the program locally.")
+	cmd.Flags().Bool("debug", false, "Print debug messages.")
+}
+
+func parseConfig(cmd *cobra.Command) *fetcherConfig {
+	var conf fetcherConfig
+	conf.Content = getValidStringArg(cmd, "content")
+	conf.ResultDir = getValidStringArg(cmd, "resultdir")
+	conf.Profile = getValidStringArg(cmd, "profile")
+	local, err := cmd.Flags().GetBool("local")
+	if err != nil {
+		fmt.Printf("error fetching local flag")
+		os.Exit(1)
+	}
+	conf.Local = local
+	debugLog, _ = cmd.Flags().GetBool("debug")
+	return &conf
+}
+
+func getValidStringArg(cmd *cobra.Command, name string) string {
+	val, _ := cmd.Flags().GetString(name)
+	if val == "" {
+		fmt.Fprintf(os.Stderr, "The command line argument '%s' is mandatory.\n", name)
+		os.Exit(1)
+	}
+	return val
+}
+
+// getConfig returns the rest config, from KUBECONFIG if local or in-cluster if !local
+func getConfig(local bool) *rest.Config {
+	if local {
+		DBG("Running locally from KUBECONFIG")
+
+		kubeConfigFile := os.Getenv("KUBECONFIG")
+		if len(kubeConfigFile) == 0 {
+			FATAL("Set KUBECONFIG when running locally")
+		}
+
+		conf, err := clientcmd.BuildConfigFromFlags("", kubeConfigFile)
+		if err != nil {
+			FATAL("Error building config: %v", err)
+		}
+		return conf
+	}
+
+	DBG("Running in-cluster")
+	conf, err := rest.InClusterConfig()
+	if err != nil {
+		FATAL("Error getting in-cluster config: %v", err)
+	}
+	return conf
+}
+
+func run(cmd *cobra.Command, args []string) {
+	fetcherConf := parseConfig(cmd)
+	kubeClient, err := kubernetes.NewForConfig(getConfig(fetcherConf.Local))
+	if err != nil {
+		FATAL("Error building kubeClient: %v", err)
+	}
+
+	fetcher := &scapContentDataStream{
+		client: kubeClient,
+	}
+
+	if err := fetcher.LoadSource(fetcherConf.Content); err != nil {
+		FATAL("Error loading source data: %v", err)
+	}
+
+	if err := fetcher.FigureResources(fetcherConf.Profile); err != nil {
+		FATAL("Error finding resources: %v", err)
+	}
+
+	if err := fetcher.FetchResources(); err != nil {
+		FATAL("Error fetching resources: %v", err)
+	}
+
+	if err := fetcher.SaveResources(fetcherConf.ResultDir); err != nil {
+		FATAL("Error saving resources: %v", err)
+	}
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "api-resource-collector",
+	Short: "Stages cluster resources for OpenSCAP scanning.",
+	Long:  "Stages cluster resources for OpenSCAP scanning.",
+	Run:   run,
+}
+
+func main() {
+	defineFlags(rootCmd)
+
+	if err := rootCmd.Execute(); err != nil {
+		FATAL("%v", err)
+	}
+
+	os.Exit(0)
+}

--- a/cmd/api-resource-collector/scap.go
+++ b/cmd/api-resource-collector/scap.go
@@ -1,0 +1,290 @@
+/*
+Copyright © 2020 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/subchen/go-xmldom"
+
+	"github.com/ghodss/yaml"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openshift/compliance-operator/pkg/utils"
+)
+
+const (
+	contentFileTimeout = 3600
+)
+
+// For OpenSCAP content as an XML data stream. Implements ResourceFetcher.
+type scapContentDataStream struct {
+	// Client for Gets
+	client *kubernetes.Clientset
+	// Staging objects
+	dataStream *utils.XMLDocument
+	resources  map[string]string
+	found      map[string][]byte
+}
+
+func (c *scapContentDataStream) LoadSource(path string) error {
+	f, err := openNonEmptyFile(path)
+	if err != nil {
+		return err
+	}
+	// #nosec
+	defer f.Close()
+	xml, err := parseContent(f)
+	if err != nil {
+		return err
+	}
+	c.dataStream = xml
+	return nil
+}
+
+func parseContent(f *os.File) (*utils.XMLDocument, error) {
+	return utils.ParseContent(bufio.NewReader(f))
+}
+
+// Returns the file, but only after it has been created by the other init container.
+// This avoids a race.
+func openNonEmptyFile(filename string) (*os.File, error) {
+	readFileTimeoutChan := make(chan *os.File, 1)
+
+	// gosec complains that the file is passed through an evironment variable. But
+	// this is not a security issue because none of the files are user-provided
+	cleanFileName := filepath.Clean(filename)
+
+	go func() {
+		for {
+			// Note that we're cleaning the filename path above.
+			// #nosec
+			file, err := os.Open(cleanFileName)
+			if err == nil {
+				fileinfo, err := file.Stat()
+				// Only try to use the file if it already has contents.
+				if err == nil && fileinfo.Size() > 0 {
+					readFileTimeoutChan <- file
+				}
+			} else if !os.IsNotExist(err) {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			time.Sleep(1 * time.Second)
+		}
+	}()
+
+	select {
+	case file := <-readFileTimeoutChan:
+		fmt.Printf("File '%s' found, using.\n", filename)
+		return file, nil
+	case <-time.After(time.Duration(contentFileTimeout) * time.Second):
+		fmt.Println("Timeout. Aborting.")
+		os.Exit(1)
+	}
+
+	// We shouldn't get here.
+	return nil, nil
+}
+
+func (c *scapContentDataStream) FigureResources(profile string) error {
+	paths := getResourcePaths(c.dataStream, profile)
+	if len(paths) == 0 {
+		return fmt.Errorf("no checks found in datastream")
+	}
+	c.resources = paths
+	return nil
+}
+
+const (
+	endPointTag    = "ocp-api-endpoint"
+	endPointTagEnd = endPointTag + "\">"
+	dumpTag        = "ocp-dump-location"
+	dumpTagEnd     = dumpTag + "\"><sub idref=\"xccdf_org.ssgproject.content_value_ocp_data_root\" use=\"legacy\" />"
+	codeTag        = "</code>"
+)
+
+// getPathsFromRuleWarning finds the API endpoint and save path from in. The expected structure is:
+//
+//  <warning category="general" lang="en-US"><code class="ocp-api-endpoint">/apis/config.openshift.io/v1/oauths/cluster
+//  </code><code class="ocp-dump-location"><sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy" />
+//  /idp.yml</code>file.</warning>
+//
+// We return both values or none at all.
+func getPathsFromWarningXML(in string) (string, string) {
+	var (
+		apiPathOut  string
+		dumpPathOut string
+	)
+
+	DBG("%s", in)
+	apiIndex := strings.Index(in, endPointTag)
+	if apiIndex == -1 {
+		return "", ""
+	}
+
+	apiValueBeginIndex := apiIndex + len(endPointTagEnd)
+	apiValueEndIndex := strings.Index(in[apiValueBeginIndex:], codeTag)
+	if apiValueEndIndex == -1 {
+		return "", ""
+	}
+
+	apiPathOut = in[apiValueBeginIndex : apiValueBeginIndex+apiValueEndIndex]
+
+	dumpIndex := strings.Index(in, dumpTag)
+	if dumpIndex == -1 {
+		return "", ""
+	}
+
+	dumpValueBeginIndex := dumpIndex + len(dumpTagEnd)
+	dumpValueEndIndex := strings.Index(in[dumpValueBeginIndex:], codeTag)
+	if dumpValueEndIndex == -1 {
+		return "", ""
+	}
+
+	dumpPathOut = in[dumpValueBeginIndex : dumpValueBeginIndex+dumpValueEndIndex]
+
+	return apiPathOut, dumpPathOut
+}
+
+// Collect the resource paths for objects that this scan needs to obtain, and their corresponding file paths based on
+// profile. The profile will have a series of "selected" checks that we grab all of the path info from.
+func getResourcePaths(ds *utils.XMLDocument, profile string) map[string]string {
+	out := map[string]string{}
+	selectedChecks := []string{}
+
+	// First we find the Profile node, to locate the enabled checks.
+	DBG("Using profile %s", profile)
+	nodes := ds.Root.Query("//Profile")
+	for _, node := range nodes {
+		profileID := node.GetAttributeValue("id")
+		if profileID != profile {
+			continue
+		}
+
+		checks := node.GetChildren("select")
+		for _, check := range checks {
+			if check.GetAttributeValue("selected") != "true" {
+				continue
+			}
+
+			if idRef := check.GetAttributeValue("idref"); idRef != "" {
+				DBG("selected: %v", idRef)
+				selectedChecks = append(selectedChecks, idRef)
+			}
+		}
+	}
+
+	checkDefinitions := ds.Root.Query("//Rule")
+	if len(checkDefinitions) == 0 {
+		DBG("WARNING: No rules to query (invalid datastream)")
+		return out
+	}
+
+	// For each of our selected checks, collect the required path info.
+	for _, checkID := range selectedChecks {
+		var found *xmldom.Node
+		for _, rule := range checkDefinitions {
+			if rule.GetAttributeValue("id") == checkID {
+				found = rule
+				break
+			}
+		}
+		if found == nil {
+			DBG("WARNING: Couldn't find a check for id %s", checkID)
+			continue
+		}
+
+		// This node is called "warning" and contains the path info. It's not an actual "warning" for us here.
+		warning := found.GetChild("warning")
+		if warning == nil {
+			DBG("Couldn't find 'warning' child of check %s", checkID)
+			continue
+		}
+
+		apiPath, dumpPath := getPathsFromWarningXML(warning.XML())
+		if len(apiPath) == 0 || len(dumpPath) == 0 {
+			continue
+		}
+		out[apiPath] = dumpPath
+	}
+
+	return out
+}
+
+func (c *scapContentDataStream) FetchResources() error {
+	found, err := fetch(c.client, c.resources)
+	if err != nil {
+		return err
+	}
+	c.found = found
+	return nil
+}
+
+func fetch(client *kubernetes.Clientset, objects map[string]string) (map[string][]byte, error) {
+	results := map[string][]byte{}
+	for uri, file := range objects {
+		err := func() error {
+			LOG("Fetching URI: '%s' File: '%s'", uri, file)
+			req := client.RESTClient().Get().RequestURI(uri)
+			stream, err := req.Stream()
+			if err != nil {
+				return err
+			}
+			defer stream.Close()
+			body, err := ioutil.ReadAll(stream)
+			if err != nil {
+				return err
+			}
+			if len(body) == 0 {
+				DBG("no data in request body")
+				return nil
+			}
+			yaml, err := yaml.JSONToYAML(body)
+			if err != nil {
+				return err
+			}
+			results[file] = yaml
+			return nil
+		}()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return results, nil
+}
+
+func (c *scapContentDataStream) SaveResources(to string) error {
+	return saveResources(to, c.found)
+}
+
+func saveResources(dir string, data map[string][]byte) error {
+	for f, d := range data {
+		err := ioutil.WriteFile(path.Join(dir, f), d, 0600)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/api-resource-collector/scap_test.go
+++ b/cmd/api-resource-collector/scap_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestSCAPContentParsing(t *testing.T) {
+	debugLog = true
+	tests := map[string]struct {
+		profile  string
+		expected map[string]string
+		data     string
+	}{
+		"ssg-ocp4-ds.xml(mocked) new": {
+			profile: "xccdf_org.ssgproject.content_profile_platform-moderate",
+			data:    "../../tests/data/ssg-ocp4-ds-new.xml",
+			expected: map[string]string{
+				"/apis/config.openshift.io/v1/oauths/cluster": "/idp.yml",
+			},
+		},
+	}
+	for n, tc := range tests {
+		t.Run(n, func(t *testing.T) {
+			f, err := os.Open(tc.data)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+			c, err := parseContent(f)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := getResourcePaths(c, tc.profile)
+			if !reflect.DeepEqual(tc.expected, got) {
+				t.Errorf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestParseWarning(t *testing.T) {
+	debugLog = true
+	tests := map[string]struct {
+		input            string
+		expectedAPIPath  string
+		expectedSavePath string
+	}{
+		"first": {
+			input:            `<warning category="general" lang="en-US"><code class="ocp-api-endpoint">/apis/config.openshift.io/v1/oauths/cluster</code><code class="ocp-dump-location"><sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy" />/idp.yml</code>file.</warning>`,
+			expectedAPIPath:  "/apis/config.openshift.io/v1/oauths/cluster",
+			expectedSavePath: "/idp.yml",
+		},
+	}
+	for n, tc := range tests {
+		t.Run(n, func(t *testing.T) {
+			api, save := getPathsFromWarningXML(tc.input)
+			if api != tc.expectedAPIPath {
+				t.Errorf("expected API path %s, got %s", tc.expectedAPIPath, api)
+			}
+			if save != tc.expectedSavePath {
+				t.Errorf("expected save path %s, got %s", tc.expectedSavePath, save)
+			}
+		})
+	}
+}

--- a/cmd/api-resource-collector/scap_test.go
+++ b/cmd/api-resource-collector/scap_test.go
@@ -44,24 +44,62 @@ func TestSCAPContentParsing(t *testing.T) {
 func TestParseWarning(t *testing.T) {
 	debugLog = true
 	tests := map[string]struct {
-		input            string
-		expectedAPIPath  string
-		expectedSavePath string
+		input           string
+		expectedAPIPath string
 	}{
 		"first": {
-			input:            `<warning category="general" lang="en-US"><code class="ocp-api-endpoint">/apis/config.openshift.io/v1/oauths/cluster</code><code class="ocp-dump-location"><sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy" />/idp.yml</code>file.</warning>`,
-			expectedAPIPath:  "/apis/config.openshift.io/v1/oauths/cluster",
-			expectedSavePath: "/idp.yml",
+			input:           `<warning category="general" lang="en-US"><code class="ocp-api-endpoint">/apis/config.openshift.io/v1/oauths/cluster</code><code class="ocp-dump-location"><sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy" />/idp.yml</code>file.</warning>`,
+			expectedAPIPath: "/apis/config.openshift.io/v1/oauths/cluster",
 		},
 	}
 	for n, tc := range tests {
 		t.Run(n, func(t *testing.T) {
-			api, save := getPathsFromWarningXML(tc.input)
+			api := getPathFromWarningXML(tc.input)
 			if api != tc.expectedAPIPath {
 				t.Errorf("expected API path %s, got %s", tc.expectedAPIPath, api)
 			}
-			if save != tc.expectedSavePath {
-				t.Errorf("expected save path %s, got %s", tc.expectedSavePath, save)
+		})
+	}
+}
+
+func TestSaveDirectoryAndFile(t *testing.T) {
+	debugLog = true
+	tests := map[string]struct {
+		root         string
+		path         string
+		expectedDir  string
+		expectedFile string
+	}{
+		"1": {
+			root:         "/tmp",
+			path:         "/apis/foo",
+			expectedDir:  "/tmp/apis",
+			expectedFile: "foo",
+		},
+		"2": {
+			root:         "/",
+			path:         "/apis/foo/bar",
+			expectedDir:  "/apis/foo",
+			expectedFile: "bar",
+		},
+		"3": {
+			root:         "/tmp/foo",
+			path:         "/apis/foo/bar/baz",
+			expectedDir:  "/tmp/foo/apis/foo/bar",
+			expectedFile: "baz",
+		},
+	}
+	for n, tc := range tests {
+		t.Run(n, func(t *testing.T) {
+			dir, file, err := getSaveDirectoryAndFileName(tc.root, tc.path)
+			if err != nil {
+				t.Error(err)
+			}
+			if dir != tc.expectedDir {
+				t.Errorf("expected dir %s, got %s", tc.expectedDir, dir)
+			}
+			if file != tc.expectedFile {
+				t.Errorf("expected file %s, got %s", tc.expectedFile, file)
 			}
 		})
 	}

--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -81,6 +81,9 @@ spec:
               required:
               - name
               type: object
+            scanType:
+              description: The type of Compliance scan.
+              type: string
           type: object
         status:
           description: The status will give valuable information on what's going on

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -94,6 +94,9 @@ spec:
                     required:
                     - name
                     type: object
+                  scanType:
+                    description: The type of Compliance scan.
+                    type: string
                 type: object
               type: array
           required:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -31,13 +31,16 @@ spec:
             - name: OPERATOR_NAME
               value: "compliance-operator"
             - name: OPENSCAP_IMAGE
-              value: "quay.io/jhrozek/openscap-ocp:latest"
+              # Trying hardcoding this temporarily until its propagated to CI
+              value: "quay.io/mrogers950/openscap-ocp:latest"
             - name: LOG_COLLECTOR_IMAGE
               value: "quay.io/compliance-operator/resultscollector:latest"
             - name: RESULT_SERVER_IMAGE
               value: "quay.io/compliance-operator/resultserver:latest"
             - name: REMEDIATION_AGGREGATOR_IMAGE
               value: "quay.io/compliance-operator/remediation-aggregator:latest"
+            - name: API_RESOURCE_COLLECTOR_IMAGE
+              value: "quay.io/compliance-operator/api-resource-collector:latest"
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -46,3 +46,16 @@ roleRef:
   kind: Role
   name: remediation-aggregator
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: api-resource-collector
+subjects:
+- kind: ServiceAccount
+  name: resultscollector
+  namespace: openshift-compliance
+roleRef:
+  kind: ClusterRole
+  name: cluster-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cenkalti/backoff/v3 v3.2.2
 	github.com/coreos/ignition v0.35.0
 	github.com/dsnet/compress v0.0.1
+	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1
 	github.com/onsi/ginkgo v1.12.0

--- a/images/api-resource-collector/Dockerfile
+++ b/images/api-resource-collector/Dockerfile
@@ -1,0 +1,18 @@
+# Step one: build fetcher
+FROM registry.access.redhat.com/ubi8/go-toolset as builder
+
+WORKDIR /go/src/github.com/openshift/compliance-operator
+
+ENV GOFLAGS=-mod=vendor
+COPY . .
+RUN make api-resource-collector
+
+# Step two: containerize fetcher
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+USER root
+
+# build fetcher
+COPY --from=builder /go/src/github.com/openshift/compliance-operator/build/_output/bin/api-resource-collector /usr/local/bin/api-resource-collector
+
+ENTRYPOINT ["/usr/local/bin/api-resource-collector"]

--- a/images/api-resource-collector/Dockerfile.ci
+++ b/images/api-resource-collector/Dockerfile.ci
@@ -1,0 +1,18 @@
+# Step one: build fetcher
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
+
+WORKDIR /go/src/github.com/openshift/compliance-operator
+
+ENV GOFLAGS=-mod=vendor
+COPY . .
+RUN make api-resource-collector
+
+# Step two: containerize fetcher
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+USER root
+
+# build fetcher
+COPY --from=builder /go/src/github.com/openshift/compliance-operator/build/_output/bin/api-resource-collector /usr/local/bin/api-resource-collector
+
+ENTRYPOINT ["/usr/local/bin/api-resource-collector"]

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -56,6 +56,8 @@ const (
 	ResultError ComplianceScanStatusResult = "ERROR"
 	// ResultNonCompliant represents the compliance scan having found a gap
 	ResultNonCompliant ComplianceScanStatusResult = "NON-COMPLIANT"
+	ScanTypeNode       ComplianceScanType         = "Node"
+	ScanTypePlatform   ComplianceScanType         = "Platform"
 )
 
 func resultCompare(lowResult ComplianceScanStatusResult, scanResult ComplianceScanStatusResult) ComplianceScanStatusResult {
@@ -79,9 +81,15 @@ type TailoringConfigMapRef struct {
 	Name string `json:"name"`
 }
 
+// ComplianceScanType
+// +k8s:openapi-gen=true
+type ComplianceScanType string
+
 // ComplianceScanSpec defines the desired state of ComplianceScan
 // +k8s:openapi-gen=true
 type ComplianceScanSpec struct {
+	// The type of Compliance scan.
+	ScanType ComplianceScanType `json:"scanType,omitempty"`
 	// Is the image with the content (Data Stream), that will be used to run
 	// OpenSCAP.
 	ContentImage string `json:"contentImage,omitempty"`

--- a/pkg/controller/compliancescan/compliancescan_controller_test.go
+++ b/pkg/controller/compliancescan/compliancescan_controller_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",
 			},
+			Spec: compv1alpha1.ComplianceScanSpec{},
 		}
 		objs = append(objs, compliancescaninstance)
 

--- a/pkg/controller/compliancescan/utils.go
+++ b/pkg/controller/compliancescan/utils.go
@@ -40,6 +40,7 @@ const (
 	OPENSCAP
 	RESULT_SERVER
 	AGGREGATOR
+	API_RESOURCE_COLLECTOR
 )
 
 var componentDefaults = []struct {
@@ -50,6 +51,7 @@ var componentDefaults = []struct {
 	{"quay.io/jhrozek/openscap-ocp:latest", "OPENSCAP_IMAGE"},
 	{"quay.io/compliance-operator/resultserver:latest", "RESULT_SERVER_IMAGE"},
 	{"quay.io/compliance-operator/remediation-aggregator", "REMEDIATION_AGGREGATOR_IMAGE"},
+	{"quay.io/compliance-operator/api-resource-collector:latest", "API_RESOURCE_COLLECTOR_IMAGE"},
 }
 
 // GetComponentImage returns a full image pull spec for a given component

--- a/tests/data/ssg-ocp4-ds-new.xml
+++ b/tests/data/ssg-ocp4-ds-new.xml
@@ -1,0 +1,4490 @@
+<?xml version="1.0"?>
+<ns0:data-stream-collection xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:ns0="http://scap.nist.gov/schema/scap/source/1.2" xmlns:ns1="http://www.w3.org/1999/xlink" xmlns:ns10="http://checklists.nist.gov/xccdf/1.2" xmlns:ns13="http://cpe.mitre.org/dictionary/2.0" xmlns:ns2="urn:oasis:names:tc:entity:xmlns:xml:catalog" xmlns:ns3="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:ns5="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:ns6="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:ns7="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:ns8="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns:ns9="http://scap.nist.gov/schema/ocil/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_org.open-scap_collection_from_xccdf_ssg-ocp4-xccdf-1.2.xml" schematron-version="1.3">
+  <ns0:data-stream id="scap_org.open-scap_datastream_from_xccdf_ssg-ocp4-xccdf-1.2.xml" scap-version="1.3" use-case="OTHER">
+    <ns0:dictionaries>
+      <ns0:component-ref id="scap_org.open-scap_cref_ssg-ocp4-cpe-dictionary.xml" ns1:href="#scap_org.open-scap_comp_ssg-ocp4-cpe-dictionary.xml">
+        <ns2:catalog>
+          <ns2:uri name="ssg-ocp4-cpe-oval.xml" uri="#scap_org.open-scap_cref_ssg-ocp4-cpe-oval.xml"/>
+        </ns2:catalog>
+      </ns0:component-ref>
+    </ns0:dictionaries>
+    <ns0:checklists>
+      <ns0:component-ref id="scap_org.open-scap_cref_ssg-ocp4-xccdf-1.2.xml" ns1:href="#scap_org.open-scap_comp_ssg-ocp4-xccdf-1.2.xml">
+        <ns2:catalog>
+          <ns2:uri name="ssg-ocp4-oval.xml" uri="#scap_org.open-scap_cref_ssg-ocp4-oval.xml"/>
+          <ns2:uri name="ssg-ocp4-ocil.xml" uri="#scap_org.open-scap_cref_ssg-ocp4-ocil.xml"/>
+        </ns2:catalog>
+      </ns0:component-ref>
+    </ns0:checklists>
+    <ns0:checks>
+      <ns0:component-ref id="scap_org.open-scap_cref_ssg-ocp4-oval.xml" ns1:href="#scap_org.open-scap_comp_ssg-ocp4-oval.xml"/>
+      <ns0:component-ref id="scap_org.open-scap_cref_ssg-ocp4-ocil.xml" ns1:href="#scap_org.open-scap_comp_ssg-ocp4-ocil.xml"/>
+      <ns0:component-ref id="scap_org.open-scap_cref_ssg-ocp4-cpe-oval.xml" ns1:href="#scap_org.open-scap_comp_ssg-ocp4-cpe-oval.xml"/>
+    </ns0:checks>
+  </ns0:data-stream>
+  <ns0:component id="scap_org.open-scap_comp_ssg-ocp4-oval.xml" timestamp="2020-04-20T13:24:48">
+      <ns10:Profile id="xccdf_org.ssgproject.content_profile_platform-moderate">
+        <ns10:title override="true" xml:lang="en-US">NIST 800-53 Moderate-Impact Baseline for Red Hat Enterprise Linux CoreOS</ns10:title>
+        <ns10:description override="true" xml:lang="en-US">This compliance profile reflects the core set of Moderate-Impact Baseline
+configuration settings for deployment of Red Hat Enterprise
+Linux CoreOS into U.S. Defense, Intelligence, and Civilian agencies.
+Development partners and sponsors include the U.S. National Institute
+of Standards and Technology (NIST), U.S. Department of Defense,
+the National Security Agency, and Red Hat.
+
+This baseline implements configuration requirements from the following
+sources:
+
+- NIST 800-53 control selections for Moderate-Impact systems (NIST 800-53)
+
+For any differing configuration requirements, e.g. password lengths, the stricter
+security setting was chosen. Security Requirement Traceability Guides (RTMs) and
+sample System Security Configuration Guides are provided via the
+scap-security-guide-docs package.
+
+This profile reflects U.S. Government consensus content and is developed through
+the ComplianceAsCode initiative, championed by the National
+Security Agency. Except for differences in formatting to accommodate
+publishing processes, this profile mirrors ComplianceAsCode
+content as minor divergences, such as bugfixes, work through the
+consensus and release processes.</ns10:description>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_remediation_functions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_system" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_selinux" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_selinux-booleans" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-firewalld" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_firewalld_activation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ruleset_modifications" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-iptables" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_activation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_ruleset_modifications" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_log_and_drop_suspicious" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_icmp_disabled" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_disable_unused_interfaces" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-wireless" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_wireless_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-ipsec" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-uncommon" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-kernel" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_host_parameters" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_host_and_router_parameters" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-ipv6" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_ipv6" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configuring_ipv6" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_ipv6_limit_requests" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_permissions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_files" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_permissions_within_important_dirs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_permissions_important_account_files" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mounting" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_partitions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_enable_execshield_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_enable_nx" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_coredumps" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_daemon_umask" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_poisoning" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_integrity" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_fips" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_crypto" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_software-integrity" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rpm_verification" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_aide" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_certified-vendor" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_endpoint_security_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mcafee_security_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mcafee_hbss_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_media_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_network_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_login_screen" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_system_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_remote_access_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_system-tools" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_updating" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disk_partitioning" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sap_host" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sudo" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_logging" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_logwatch_on_logserver" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rsyslog_accepting_remote_messages" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ensure_rsyslog_log_file_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rsyslog_sending_messages" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_log_rotation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_bootloader-grub-legacy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_bootloader-grub2" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_auditing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_auditd_configure_rules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_file_modification" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_execution_selinux_commands" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_kernel_module_loading" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_time_rules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_dac_actions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_file_deletion_events" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_privileged_commands" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_login_events" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_auditd_data_retention" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_policy_rules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_entropy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-session" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_user_umask" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_root_paths" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-physical" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smart_card_login" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_console_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-banners" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gui_login_banner" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_account_expiration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_expiration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_storage" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_root_logins" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-pam" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_locking_out_password_attempts" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality_pamcracklib" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality_pwquality" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_set_password_hashing_algorithm" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_services" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_avahi" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_avahi_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disable_avahi_group" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_xwindows" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_xwindows" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_radius" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_deprecated" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_apt" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_protection" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_partition_with_views" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_separate_internal_external" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dns_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_isolation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_dedicated" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_chroot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_cron_and_at" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_restrict_at_cron_users" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rng" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ntp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_routing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_quagga" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sssd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sssd-ldap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_and_rpc" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_clients" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mounting_remote_filesystems" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfsd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_netfs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfs_services" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_all_machines" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configure_fixed_ports" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_client_or_server_not_both" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_servers" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_export_filesystems_read_only" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_use_acl_enforce_auth_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_exports_restrictively" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_use_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_configure_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_restrict_users" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ssh" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ssh_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sshd_strengthen_firewall" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp_server_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp_client_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dhcp_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dhcp_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_imap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dovecot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_dovecot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_enabling_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_support_necessary_protocols" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_allow_imap_access" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_http" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_installing_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimal_modules_installed" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_securing_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_restrict_info_leakage" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_secure_content" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_php_securely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_modules_improve_security" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_deploy_mod_security" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_deploy_mod_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_directory_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_os_protect_web_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_chroot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_restrict_file_dir_access" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_use_dos_protection_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_perl_securely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimize_loadable_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_core_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimize_config_files_included" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_optional_components" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_basic_authentication" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_snmp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_snmp_service" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_snmp_configure_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_samba" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configuring_samba" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb_disable_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb_restrict_file_sharing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_proxy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_squid" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_docker" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mail" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_harden_os" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_cfg" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_mail_smtpd_recipient_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_mail_smtpd_relay_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_smtp_auth_for_untrusted" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_require_tls" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_set_trusted" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_dos" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_configure_ssl_certs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_install_ssl_cert" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_kerberos" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_usbguard" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_obsolete" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nis" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_r_services" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_tftp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_telnet" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_talk" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_inetd_and_xinetd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_fapolicyd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ldap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_openldap_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ldap_server_config_certificate_files" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_openldap_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_base" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_general-principles" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-use-security-tools" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-encrypt-transmitted-data" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-least-privilege" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-separate-servers" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_how-to-use" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-formatting-conventions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-reboot-required" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-root-shell-assumed" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-test-non-production" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-read-sections-completely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_api-server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_etcd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ocp-permissions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ocp-files" selected="false"/>
+      </ns10:Profile>
+      <ns10:Profile id="xccdf_org.ssgproject.content_profile_coreos-ncp">
+        <ns10:title override="true" xml:lang="en-US">NIST National Checklist for Red Hat Enterprise Linux CoreOS</ns10:title>
+        <ns10:description override="true" xml:lang="en-US">This compliance profile reflects the core set of security
+related configuration settings for deployment of Red Hat Enterprise
+Linux CoreOS into U.S. Defense, Intelligence, and Civilian agencies.
+Development partners and sponsors include the U.S. National Institute
+of Standards and Technology (NIST), U.S. Department of Defense,
+the National Security Agency, and Red Hat.
+
+This baseline implements configuration requirements from the following
+sources:
+
+- Committee on National Security Systems Instruction No. 1253 (CNSSI 1253)
+- NIST Controlled Unclassified Information (NIST 800-171)
+- NIST 800-53 control selections for Moderate-Impact systems (NIST 800-53)
+- U.S. Government Configuration Baseline (USGCB)
+- NIAP Protection Profile for General Purpose Operating Systems v4.2.1 (OSPP v4.2.1)
+- DISA Operating System Security Requirements Guide (OS SRG)
+
+For any differing configuration requirements, e.g. password lengths, the stricter
+security setting was chosen. Security Requirement Traceability Guides (RTMs) and
+sample System Security Configuration Guides are provided via the
+scap-security-guide-docs package.
+
+This profile reflects U.S. Government consensus content and is developed through
+the ComplianceAsCode initiative, championed by the National
+Security Agency. Except for differences in formatting to accommodate
+publishing processes, this profile mirrors ComplianceAsCode
+content as minor divergences, such as bugfixes, work through the
+consensus and release processes.</ns10:description>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_accounts_no_uid_except_zero" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_chmod" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_chown" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fchmod" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fchmodat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fchown" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fchownat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fremovexattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fsetxattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_lchown" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_lremovexattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_lsetxattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_removexattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_setxattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_group_open" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_group_open_by_handle_at" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_group_openat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_gshadow_open" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_gshadow_open_by_handle_at" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_gshadow_openat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_passwd_open" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_passwd_open_by_handle_at" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_passwd_openat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_shadow_open" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_shadow_open_by_handle_at" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_shadow_openat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chcon" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_restorecon" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_semanage" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setfiles" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setsebool" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_seunshare" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rename" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_renameat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rmdir" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlink" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlinkat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_immutable" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_finit" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_faillock" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_lastlog" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_tallylog" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_media_export" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_at" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_chage" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_chsh" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_crontab" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_gpasswd" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_mount" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_newgidmap" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_newgrp" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_newuidmap" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_pam_timestamp_check" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_passwd" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_postdrop" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_postqueue" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_pt_chown" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_ssh_keysign" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_su" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_sudo" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_sudoedit" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_umount" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_unix_chkpwd" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_userhelper" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_usernetctl" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_sysadmin_actions" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_time_adjtimex" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_time_stime" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_chmod" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_chown" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_creat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_fchmod" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_fchmodat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_fchown" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_fchownat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_fremovexattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_fsetxattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_ftruncate" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_lchown" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_lremovexattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_lsetxattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_by_handle_at" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_by_handle_at_rule_order" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_o_creat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_o_trunc_write" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_rule_order" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_openat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_openat_o_creat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_openat_o_trunc_write" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_openat_rule_order" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_removexattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_rename" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_renameat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_setxattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_truncate" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_unlink" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_unlinkat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_group" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_gshadow" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_opasswd" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_passwd" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_shadow" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_disk_error_action" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_disk_full_action" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_action_mail_acct" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_admin_space_left_action" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_flush" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_num_logs" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left_action" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_freq" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_local_events" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_log_format" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_name_format" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_write_logs" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_banner_etc_issue" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_bios_disable_usb_boot" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_chronyd_client_only" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_chronyd_no_chronyc_network" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_chronyd_or_ntpd_set_maxpoll" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_chronyd_or_ntpd_specify_multiple_servers" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_chronyd_or_ntpd_specify_remote_server" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_configure_crypto_policy" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_configure_kerberos_crypto_policy" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_configure_openssl_crypto_policy" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_configure_usbguard_auditbackend" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_coredump_disable_backtraces" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_coredump_disable_storage" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_directory_access_var_log_audit" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_directory_permissions_var_log_audit" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_disable_ctrlaltdel_burstaction" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_disable_ctrlaltdel_reboot" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_disable_users_coredumps" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_enable_dracut_fips_module" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_enable_fips_mode" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_file_ownership_var_log_audit" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_file_permissions_var_log_audit" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_audit_argument" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_audit_backlog_limit_argument" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_disable_interactive_boot" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_enable_selinux" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_nousb_argument" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_page_poison_argument" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_pti_argument" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_slub_debug_argument" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_uefi_password" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_vsyscall_argument" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_harden_ssh_client_crypto_policy" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_harden_sshd_crypto_policy" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_atm_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_bluetooth_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_can_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_firewire-core_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_sctp_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_tipc_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_network_nmcli_permissions" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_no_direct_root_logins" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_no_shelllogin_for_systemaccounts" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_package_aide_installed" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_package_audit_installed" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_package_fapolicyd_installed" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_package_usbguard_installed" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_require_singleuser_auth" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_selinux_confinement_of_daemons" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_selinux_policytype" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_selinux_state" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_auditd_enabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_chronyd_or_ntpd_enabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_debug-shell_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_fapolicyd_enabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_rngd_enabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_systemd-coredump_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_usbguard_enabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sshd_disable_rhosts" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sssd_run_as_sssd_user" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_fs_protected_hardlinks" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_fs_protected_symlinks" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_core_pattern" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_dmesg_restrict" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_kexec_load_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_kptr_restrict" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_perf_event_paranoid" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_unprivileged_bpf_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_yama_ptrace_scope" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_core_bpf_jit_harden" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_accept_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_accept_source_route" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_rp_filter" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_secure_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_accept_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_accept_source_route" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_rp_filter" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_secure_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_icmp_echo_ignore_broadcasts" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_icmp_ignore_bogus_error_responses" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_source_route" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_source_route" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_user_max_user_namespaces" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_usbguard_allow_hid_and_hub" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_wireless_disable_in_bios" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_wireless_disable_interfaces" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_remediation_functions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_selinux-booleans" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-firewalld" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_firewalld_activation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ruleset_modifications" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_activation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_ruleset_modifications" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_log_and_drop_suspicious" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_icmp_disabled" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_disable_unused_interfaces" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-ipsec" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_ipv6" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_ipv6_limit_requests" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_permissions_within_important_dirs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_permissions_important_account_files" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_partitions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_enable_nx" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_daemon_umask" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rpm_verification" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_certified-vendor" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_endpoint_security_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mcafee_security_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mcafee_hbss_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_media_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_network_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_login_screen" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_system_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_remote_access_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_system-tools" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_updating" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disk_partitioning" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sap_host" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_logging" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_logwatch_on_logserver" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rsyslog_accepting_remote_messages" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ensure_rsyslog_log_file_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rsyslog_sending_messages" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_log_rotation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_bootloader-grub-legacy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_policy_rules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_entropy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-session" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_user_umask" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_root_paths" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smart_card_login" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_console_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gui_login_banner" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_account_expiration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_expiration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-pam" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_locking_out_password_attempts" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality_pamcracklib" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality_pwquality" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_set_password_hashing_algorithm" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_avahi" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_avahi_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disable_avahi_group" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_xwindows" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_xwindows" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_radius" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_deprecated" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_apt" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_protection" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_partition_with_views" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_separate_internal_external" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dns_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_isolation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_dedicated" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_chroot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_cron_and_at" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_restrict_at_cron_users" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_routing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_quagga" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sssd-ldap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_and_rpc" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_clients" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mounting_remote_filesystems" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfsd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_netfs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfs_services" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_all_machines" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configure_fixed_ports" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_client_or_server_not_both" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_servers" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_export_filesystems_read_only" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_use_acl_enforce_auth_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_exports_restrictively" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_use_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_configure_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_restrict_users" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sshd_strengthen_firewall" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp_server_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp_client_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dhcp_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dhcp_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_imap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dovecot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_dovecot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_enabling_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_support_necessary_protocols" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_allow_imap_access" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_http" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_installing_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimal_modules_installed" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_securing_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_restrict_info_leakage" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_secure_content" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_php_securely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_modules_improve_security" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_deploy_mod_security" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_deploy_mod_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_directory_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_os_protect_web_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_chroot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_restrict_file_dir_access" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_use_dos_protection_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_perl_securely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimize_loadable_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_core_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimize_config_files_included" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_optional_components" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_basic_authentication" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_snmp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_snmp_service" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_snmp_configure_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_samba" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configuring_samba" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb_disable_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb_restrict_file_sharing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_proxy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_squid" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_docker" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mail" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_harden_os" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_cfg" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_mail_smtpd_recipient_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_mail_smtpd_relay_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_smtp_auth_for_untrusted" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_require_tls" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_set_trusted" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_dos" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_configure_ssl_certs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_install_ssl_cert" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_kerberos" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_obsolete" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nis" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_r_services" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_tftp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_telnet" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_talk" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_inetd_and_xinetd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ldap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_openldap_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ldap_server_config_certificate_files" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_openldap_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_base" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_general-principles" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-use-security-tools" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-encrypt-transmitted-data" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-least-privilege" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-separate-servers" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_how-to-use" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-formatting-conventions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-reboot-required" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-root-shell-assumed" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-test-non-production" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-read-sections-completely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_openshift" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_api-server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_etcd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ocp-permissions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ocp-files" selected="false"/>
+        <ns10:refine-value idref="xccdf_org.ssgproject.content_value_var_auditd_flush" selector="incremental_async"/>
+        <ns10:refine-value idref="xccdf_org.ssgproject.content_value_var_auditd_action_mail_acct" selector="root"/>
+        <ns10:refine-value idref="xccdf_org.ssgproject.content_value_var_auditd_space_left_action" selector="email"/>
+        <ns10:refine-value idref="xccdf_org.ssgproject.content_value_var_selinux_state" selector="enforcing"/>
+        <ns10:refine-value idref="xccdf_org.ssgproject.content_value_var_selinux_policy_name" selector="targeted"/>
+        <ns10:refine-value idref="xccdf_org.ssgproject.content_value_var_system_crypto_policy" selector="fips"/>
+        <ns10:refine-rule idref="xccdf_org.ssgproject.content_rule_grub2_vsyscall_argument" role="unscored" severity="info"/>
+        <ns10:refine-rule idref="xccdf_org.ssgproject.content_rule_sysctl_user_max_user_namespaces" role="unscored" severity="info"/>
+      </ns10:Profile>
+      <ns10:Profile id="xccdf_org.ssgproject.content_profile_opencis-node">
+        <ns10:title override="true" xml:lang="en-US">Open Computing Information Security Profile for OpenShift Node</ns10:title>
+        <ns10:description override="true" xml:lang="en-US">This baseline was inspired by the Center for Internet Security
+(CIS) Kubernetes Benchmark, v1.2.0 - 01-31-2017.
+
+For the ComplianceAsCode project to remain in compliance with
+CIS' terms and conditions, specifically Restrictions(8), note
+there is no representation or claim that the OpenCIS profile will
+ensure a system is in compliance or consistency with the CIS
+baseline.</ns10:description>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_file_permissions_node_config" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_remediation_functions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_system" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_selinux" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_selinux-booleans" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-firewalld" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_firewalld_activation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ruleset_modifications" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-iptables" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_activation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_ruleset_modifications" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_log_and_drop_suspicious" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_icmp_disabled" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_disable_unused_interfaces" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-wireless" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_wireless_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-ipsec" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-uncommon" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-kernel" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_host_parameters" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_host_and_router_parameters" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-ipv6" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_ipv6" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configuring_ipv6" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_ipv6_limit_requests" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_permissions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_files" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_permissions_within_important_dirs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_permissions_important_account_files" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mounting" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_partitions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_enable_execshield_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_enable_nx" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_coredumps" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_daemon_umask" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_poisoning" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_integrity" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_fips" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_crypto" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_software-integrity" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rpm_verification" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_aide" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_certified-vendor" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_endpoint_security_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mcafee_security_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mcafee_hbss_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_media_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_network_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_login_screen" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_system_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_remote_access_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_system-tools" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_updating" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disk_partitioning" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sap_host" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sudo" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_logging" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_logwatch_on_logserver" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rsyslog_accepting_remote_messages" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ensure_rsyslog_log_file_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rsyslog_sending_messages" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_log_rotation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_bootloader-grub-legacy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_bootloader-grub2" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_auditing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_auditd_configure_rules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_file_modification" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_execution_selinux_commands" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_kernel_module_loading" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_time_rules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_dac_actions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_file_deletion_events" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_privileged_commands" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_login_events" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_auditd_data_retention" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_policy_rules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_entropy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-session" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_user_umask" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_root_paths" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-physical" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smart_card_login" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_console_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-banners" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gui_login_banner" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_account_expiration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_expiration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_storage" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_root_logins" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-pam" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_locking_out_password_attempts" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality_pamcracklib" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality_pwquality" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_set_password_hashing_algorithm" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_services" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_avahi" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_avahi_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disable_avahi_group" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_xwindows" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_xwindows" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_radius" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_deprecated" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_apt" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_protection" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_partition_with_views" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_separate_internal_external" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dns_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_isolation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_dedicated" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_chroot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_cron_and_at" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_restrict_at_cron_users" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rng" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ntp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_routing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_quagga" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sssd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sssd-ldap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_and_rpc" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_clients" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mounting_remote_filesystems" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfsd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_netfs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfs_services" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_all_machines" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configure_fixed_ports" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_client_or_server_not_both" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_servers" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_export_filesystems_read_only" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_use_acl_enforce_auth_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_exports_restrictively" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_use_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_configure_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_restrict_users" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ssh" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ssh_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sshd_strengthen_firewall" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp_server_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp_client_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dhcp_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dhcp_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_imap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dovecot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_dovecot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_enabling_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_support_necessary_protocols" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_allow_imap_access" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_http" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_installing_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimal_modules_installed" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_securing_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_restrict_info_leakage" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_secure_content" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_php_securely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_modules_improve_security" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_deploy_mod_security" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_deploy_mod_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_directory_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_os_protect_web_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_chroot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_restrict_file_dir_access" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_use_dos_protection_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_perl_securely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimize_loadable_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_core_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimize_config_files_included" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_optional_components" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_basic_authentication" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_snmp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_snmp_service" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_snmp_configure_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_samba" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configuring_samba" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb_disable_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb_restrict_file_sharing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_proxy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_squid" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_docker" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mail" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_harden_os" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_cfg" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_mail_smtpd_recipient_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_mail_smtpd_relay_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_smtp_auth_for_untrusted" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_require_tls" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_set_trusted" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_dos" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_configure_ssl_certs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_install_ssl_cert" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_kerberos" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_usbguard" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_obsolete" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nis" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_r_services" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_tftp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_telnet" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_talk" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_inetd_and_xinetd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_fapolicyd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ldap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_openldap_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ldap_server_config_certificate_files" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_openldap_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_base" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_general-principles" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-use-security-tools" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-encrypt-transmitted-data" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-least-privilege" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-separate-servers" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_how-to-use" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-formatting-conventions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-reboot-required" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-root-shell-assumed" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-test-non-production" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-read-sections-completely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_api-server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_etcd" selected="false"/>
+      </ns10:Profile>
+      <ns10:Profile id="xccdf_org.ssgproject.content_profile_opencis-master">
+        <ns10:title override="true" xml:lang="en-US">Open Computing Information Security Profile for OpenShift Master Node</ns10:title>
+        <ns10:description override="true" xml:lang="en-US">This baseline was inspired by the Center for Internet Security
+(CIS) Kubernetes Benchmark, v1.5.0 - 10-14-2019.
+
+For the ComplianceAsCode project to remain in compliance with
+CIS' terms and conditions, specifically Restrictions(8), note
+there is no representation or claim that the OpenCIS profile will
+ensure a system is in compliance or consistency with the CIS
+baseline.</ns10:description>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_anonymous_auth" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_audit_log_path" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_authorization_mode" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_basic_auth" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_client_ca" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_etcd_ca" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_etcd_cert" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_etcd_key" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_insecure_port" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_kubelet_https" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_request_timeout" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_secure_port" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_service_account_public_key" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_tls_cert" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_tls_private_key" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_api_server_token_auth" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_etcd_auto_tls" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_etcd_cert_file" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_etcd_client_cert_auth" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_etcd_key_file" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_etcd_peer_cert_file" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_etcd_peer_key_file" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_etcd_unique_ca" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_etcd_wal_dir" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_remediation_functions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_system" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_selinux" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_selinux-booleans" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-firewalld" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_firewalld_activation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ruleset_modifications" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-iptables" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_activation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_ruleset_modifications" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_log_and_drop_suspicious" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_icmp_disabled" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_disable_unused_interfaces" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-wireless" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_wireless_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-ipsec" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-uncommon" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-kernel" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_host_parameters" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_host_and_router_parameters" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-ipv6" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_ipv6" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configuring_ipv6" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_ipv6_limit_requests" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_permissions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_files" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_permissions_within_important_dirs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_permissions_important_account_files" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mounting" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_partitions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_enable_execshield_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_enable_nx" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_coredumps" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_daemon_umask" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_poisoning" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_integrity" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_fips" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_crypto" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_software-integrity" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rpm_verification" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_aide" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_certified-vendor" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_endpoint_security_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mcafee_security_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mcafee_hbss_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_media_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_network_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_login_screen" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_system_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_remote_access_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_system-tools" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_updating" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disk_partitioning" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sap_host" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sudo" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_logging" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_logwatch_on_logserver" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rsyslog_accepting_remote_messages" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ensure_rsyslog_log_file_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rsyslog_sending_messages" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_log_rotation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_bootloader-grub-legacy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_bootloader-grub2" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_auditing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_auditd_configure_rules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_file_modification" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_execution_selinux_commands" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_kernel_module_loading" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_time_rules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_dac_actions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_file_deletion_events" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_privileged_commands" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_audit_login_events" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_auditd_data_retention" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_policy_rules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_entropy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-session" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_user_umask" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_root_paths" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-physical" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smart_card_login" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_console_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-banners" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gui_login_banner" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_account_expiration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_expiration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_storage" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_root_logins" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-pam" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_locking_out_password_attempts" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality_pamcracklib" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality_pwquality" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_set_password_hashing_algorithm" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_services" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_avahi" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_avahi_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disable_avahi_group" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_xwindows" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_xwindows" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_radius" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_deprecated" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_apt" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_protection" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_partition_with_views" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_separate_internal_external" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dns_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_isolation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_dedicated" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_chroot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_cron_and_at" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_restrict_at_cron_users" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rng" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ntp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_routing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_quagga" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sssd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sssd-ldap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_and_rpc" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_clients" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mounting_remote_filesystems" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfsd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_netfs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfs_services" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_all_machines" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configure_fixed_ports" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_client_or_server_not_both" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_servers" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_export_filesystems_read_only" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_use_acl_enforce_auth_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_exports_restrictively" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_use_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_configure_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_restrict_users" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ssh" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ssh_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sshd_strengthen_firewall" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp_server_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp_client_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dhcp_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dhcp_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_imap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dovecot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_dovecot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_enabling_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_support_necessary_protocols" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_allow_imap_access" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_http" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_installing_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimal_modules_installed" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_securing_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_restrict_info_leakage" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_secure_content" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_php_securely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_modules_improve_security" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_deploy_mod_security" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_deploy_mod_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_directory_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_os_protect_web_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_chroot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_restrict_file_dir_access" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_use_dos_protection_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_perl_securely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimize_loadable_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_core_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimize_config_files_included" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_optional_components" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_basic_authentication" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_snmp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_snmp_service" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_snmp_configure_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_samba" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configuring_samba" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb_disable_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb_restrict_file_sharing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_proxy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_squid" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_docker" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mail" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_harden_os" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_cfg" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_mail_smtpd_recipient_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_mail_smtpd_relay_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_smtp_auth_for_untrusted" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_require_tls" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_set_trusted" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_dos" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_configure_ssl_certs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_install_ssl_cert" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_kerberos" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_usbguard" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_obsolete" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nis" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_r_services" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_tftp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_telnet" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_talk" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_inetd_and_xinetd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_fapolicyd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ldap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_openldap_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ldap_server_config_certificate_files" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_openldap_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_base" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_general-principles" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-use-security-tools" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-encrypt-transmitted-data" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-least-privilege" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-separate-servers" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_how-to-use" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-formatting-conventions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-reboot-required" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-root-shell-assumed" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-test-non-production" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-read-sections-completely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ocp-permissions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ocp-files" selected="false"/>
+      </ns10:Profile>
+      <ns10:Profile id="xccdf_org.ssgproject.content_profile_moderate">
+        <ns10:title override="true" xml:lang="en-US">NIST 800-53 Moderate-Impact Baseline for Red Hat Enterprise Linux CoreOS</ns10:title>
+        <ns10:description override="true" xml:lang="en-US">This compliance profile reflects the core set of Moderate-Impact Baseline
+configuration settings for deployment of Red Hat Enterprise
+Linux CoreOS into U.S. Defense, Intelligence, and Civilian agencies.
+Development partners and sponsors include the U.S. National Institute
+of Standards and Technology (NIST), U.S. Department of Defense,
+the National Security Agency, and Red Hat.
+
+This baseline implements configuration requirements from the following
+sources:
+
+- NIST 800-53 control selections for Moderate-Impact systems (NIST 800-53)
+
+For any differing configuration requirements, e.g. password lengths, the stricter
+security setting was chosen. Security Requirement Traceability Guides (RTMs) and
+sample System Security Configuration Guides are provided via the
+scap-security-guide-docs package.
+
+This profile reflects U.S. Government consensus content and is developed through
+the ComplianceAsCode initiative, championed by the National
+Security Agency. Except for differences in formatting to accommodate
+publishing processes, this profile mirrors ComplianceAsCode
+content as minor divergences, such as bugfixes, work through the
+consensus and release processes.</ns10:description>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_account_disable_post_pw_expiration" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_accounts_no_uid_except_zero" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_chmod" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_chown" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fchmod" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fchmodat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fchown" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fchownat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fremovexattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_fsetxattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_lchown" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_lremovexattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_lsetxattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_removexattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_dac_modification_setxattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_group_open" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_group_open_by_handle_at" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_group_openat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_gshadow_open" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_gshadow_open_by_handle_at" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_gshadow_openat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_passwd_open" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_passwd_open_by_handle_at" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_passwd_openat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_shadow_open" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_shadow_open_by_handle_at" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_etc_shadow_openat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_chcon" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_restorecon" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_semanage" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setfiles" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_setsebool" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_execution_seunshare" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rename" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_renameat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rmdir" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlink" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlinkat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_immutable" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_finit" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_faillock" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_lastlog" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_login_events_tallylog" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_mac_modification" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_media_export" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_at" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_chage" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_chsh" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_crontab" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_gpasswd" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_mount" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_newgidmap" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_newgrp" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_newuidmap" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_pam_timestamp_check" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_passwd" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_postdrop" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_postqueue" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_pt_chown" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_ssh_keysign" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_su" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_sudo" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_sudoedit" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_umount" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_unix_chkpwd" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_userhelper" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_usernetctl" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_session_events" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_sysadmin_actions" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_time_adjtimex" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_time_stime" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_chmod" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_chown" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_creat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_fchmod" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_fchmodat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_fchown" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_fchownat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_fremovexattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_fsetxattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_ftruncate" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_lchown" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_lremovexattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_lsetxattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_by_handle_at" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_by_handle_at_rule_order" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_o_creat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_o_trunc_write" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_open_rule_order" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_openat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_openat_o_creat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_openat_o_trunc_write" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_openat_rule_order" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_removexattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_rename" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_renameat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_setxattr" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_truncate" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_unlink" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_unsuccessful_file_modification_unlinkat" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_group" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_gshadow" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_opasswd" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_passwd" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification_shadow" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_disk_error_action" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_disk_full_action" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_action_mail_acct" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_admin_space_left_action" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_flush" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_num_logs" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left_action" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_freq" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_local_events" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_log_format" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_name_format" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_auditd_write_logs" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_banner_etc_issue" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_bios_disable_usb_boot" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_chronyd_client_only" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_chronyd_no_chronyc_network" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_chronyd_or_ntpd_set_maxpoll" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_chronyd_or_ntpd_specify_multiple_servers" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_chronyd_or_ntpd_specify_remote_server" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_configure_crypto_policy" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_configure_kerberos_crypto_policy" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_configure_openssl_crypto_policy" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_configure_usbguard_auditbackend" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_coredump_disable_backtraces" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_coredump_disable_storage" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_directory_access_var_log_audit" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_directory_permissions_var_log_audit" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_disable_ctrlaltdel_burstaction" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_disable_ctrlaltdel_reboot" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_disable_users_coredumps" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_enable_dracut_fips_module" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_enable_fips_mode" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_ensure_logrotate_activated" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_file_ownership_var_log_audit" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_file_permissions_var_log_audit" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_audit_argument" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_audit_backlog_limit_argument" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_disable_interactive_boot" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_enable_selinux" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_nousb_argument" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_page_poison_argument" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_pti_argument" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_slub_debug_argument" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_uefi_password" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_grub2_vsyscall_argument" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_harden_ssh_client_crypto_policy" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_harden_sshd_crypto_policy" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_atm_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_bluetooth_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_can_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_firewire-core_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_freevxfs_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_hfs_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_hfsplus_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_jffs2_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_sctp_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_squashfs_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_tipc_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_udf_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_usb-storage_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_kernel_module_vfat_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_network_nmcli_permissions" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_no_direct_root_logins" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_no_empty_passwords" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_no_netrc_files" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_no_shelllogin_for_systemaccounts" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_package_audit_installed" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_package_fapolicyd_installed" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_package_iptables_installed" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_package_sudo_installed" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_package_usbguard_installed" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_require_singleuser_auth" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_rpm_verify_ownership" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_rpm_verify_permissions" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_selinux_confinement_of_daemons" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_selinux_policytype" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_selinux_state" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_auditd_enabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_autofs_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_chronyd_or_ntpd_enabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_debug-shell_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_fapolicyd_enabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_rngd_enabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_systemd-coredump_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_service_usbguard_enabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sshd_disable_rhosts" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sshd_limit_user_access" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sssd_run_as_sssd_user" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_fs_protected_hardlinks" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_fs_protected_symlinks" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_core_pattern" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_dmesg_restrict" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_kexec_load_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_kptr_restrict" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_perf_event_paranoid" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_unprivileged_bpf_disabled" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_kernel_yama_ptrace_scope" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_core_bpf_jit_harden" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_accept_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_accept_source_route" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_log_martians" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_rp_filter" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_secure_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_all_send_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_accept_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_accept_source_route" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_log_martians" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_rp_filter" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_secure_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_conf_default_send_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_icmp_echo_ignore_broadcasts" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_icmp_ignore_bogus_error_responses" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_ra" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_all_accept_source_route" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_ra" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_redirects" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_sysctl_net_ipv6_conf_default_accept_source_route" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_usbguard_allow_hid_and_hub" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_wireless_disable_in_bios" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_rule_wireless_disable_interfaces" selected="true"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_remediation_functions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_selinux-booleans" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-firewalld" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_firewalld_activation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ruleset_modifications" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_activation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_ruleset_modifications" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_log_and_drop_suspicious" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_iptables_icmp_disabled" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_disable_unused_interfaces" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network-ipsec" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_ipv6" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_network_ipv6_limit_requests" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_permissions_within_important_dirs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_permissions_important_account_files" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_partitions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_enable_nx" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_daemon_umask" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_aide" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_certified-vendor" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_endpoint_security_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mcafee_security_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mcafee_hbss_software" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_media_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_network_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_login_screen" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_system_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gnome_remote_access_settings" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_system-tools" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_updating" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disk_partitioning" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sap_host" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_logwatch_on_logserver" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rsyslog_accepting_remote_messages" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ensure_rsyslog_log_file_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_rsyslog_sending_messages" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_bootloader-grub-legacy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_policy_rules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_entropy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-session" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_user_umask" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_root_paths" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smart_card_login" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_console_screen_locking" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_gui_login_banner" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_expiration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_accounts-pam" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_locking_out_password_attempts" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality_pamcracklib" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_password_quality_pwquality" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_set_password_hashing_algorithm" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_avahi" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_avahi_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disable_avahi_group" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_xwindows" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_xwindows" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_radius" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_deprecated" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_apt" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_protection" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_partition_with_views" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_separate_internal_external" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dns_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_isolation" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_dedicated" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dns_server_chroot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_cron_and_at" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_restrict_at_cron_users" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_routing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_quagga" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sssd-ldap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_and_rpc" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_clients" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mounting_remote_filesystems" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfsd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_netfs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_nfs_services" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_all_machines" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configure_fixed_ports" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_client_or_server_not_both" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nfs_configuring_servers" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_export_filesystems_read_only" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_use_acl_enforce_auth_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_exports_restrictively" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_use_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_configure_vsftpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ftp_restrict_users" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_sshd_strengthen_firewall" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp_server_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dhcp_client_configuration" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dhcp_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dhcp_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_imap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_dovecot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_dovecot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_enabling_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_support_necessary_protocols" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_dovecot_allow_imap_access" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_http" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_installing_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimal_modules_installed" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_securing_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_restrict_info_leakage" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_secure_content" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_php_securely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_modules_improve_security" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_deploy_mod_security" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_deploy_mod_ssl" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_directory_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_os_protect_web_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_chroot" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_restrict_file_dir_access" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_use_dos_protection_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_configure_perl_securely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimize_loadable_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_core_modules" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_minimize_config_files_included" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_optional_components" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_httpd_basic_authentication" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_httpd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configure_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_snmp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_snmp_service" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_snmp_configure_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_samba" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_configuring_samba" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb_disable_printing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_smb_restrict_file_sharing" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_proxy" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_disabling_squid" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_docker" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_mail" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_harden_os" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_cfg" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_mail_smtpd_recipient_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_mail_smtpd_relay_restrictions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_smtp_auth_for_untrusted" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_require_tls" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_relay_set_trusted" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_server_dos" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_configure_ssl_certs" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_install_ssl_cert" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_postfix_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_kerberos" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_obsolete" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_nis" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_r_services" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_tftp" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_telnet" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_talk" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_inetd_and_xinetd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ldap" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_openldap_server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ldap_server_config_certificate_files" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_openldap_client" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_base" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_general-principles" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-use-security-tools" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-encrypt-transmitted-data" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-least-privilege" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_principle-separate-servers" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_how-to-use" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-formatting-conventions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-reboot-required" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-root-shell-assumed" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-test-non-production" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_intro-read-sections-completely" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_api-server" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_etcd" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ocp-permissions" selected="false"/>
+        <ns10:select idref="xccdf_org.ssgproject.content_group_ocp-files" selected="false"/>
+        <ns10:refine-value idref="xccdf_org.ssgproject.content_value_var_auditd_flush" selector="incremental_async"/>
+        <ns10:refine-value idref="xccdf_org.ssgproject.content_value_var_auditd_action_mail_acct" selector="root"/>
+        <ns10:refine-value idref="xccdf_org.ssgproject.content_value_var_auditd_space_left_action" selector="email"/>
+        <ns10:refine-value idref="xccdf_org.ssgproject.content_value_var_selinux_state" selector="enforcing"/>
+        <ns10:refine-value idref="xccdf_org.ssgproject.content_value_var_selinux_policy_name" selector="targeted"/>
+        <ns10:refine-value idref="xccdf_org.ssgproject.content_value_var_system_crypto_policy" selector="fips"/>
+        <ns10:refine-rule idref="xccdf_org.ssgproject.content_rule_grub2_vsyscall_argument" role="unscored" severity="info"/>
+      </ns10:Profile>
+        <ns10:Rule id="xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd" selected="false" severity="medium">
+          <ns10:title xml:lang="en-US">The Identity Providers don't use the htpasswd-based authentication</ns10:title>
+          <ns10:description xml:lang="en-US">TBD</ns10:description>
+          <ns10:warning category="general" xml:lang="en-US">This rule's check operates on the cluster configuration dump.
+Therefore, you need to use a tool that can query the OCP API, retreive the <html:code class="ocp-api-endpoint">/apis/config.openshift.io/v1/oauths/cluster</html:code> API endpoint to the local <html:code class="ocp-dump-location"><ns10:sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy"/>/idp.yml</html:code> file.</ns10:warning>
+          <ns10:rationale xml:lang="en-US">TBD</ns10:rationale>
+          <ns10:ident system="https://nvd.nist.gov/cce/index.cfm">CCE-84209-6</ns10:ident>
+          <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <ns10:check-export export-name="oval:ssg-ocp_data_root:var:1" value-id="xccdf_org.ssgproject.content_value_ocp_data_root"/>
+            <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-ocp_idp_no_htpasswd:def:1"/>
+          </ns10:check>
+        </ns10:Rule>
+        <ns10:Group id="xccdf_org.ssgproject.content_group_api-server">
+          <ns10:title xml:lang="en-US">OpenShift API Server</ns10:title>
+          <ns10:description xml:lang="en-US">This section contains recommendations for kube-apiserver configuration.</ns10:description>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_secure_port" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Enable the Secure Port for the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure traffic is served over HTTPS, edit the API Server pod specification
+file <html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master node(s)
+and either remove the <html:code>secure-port</html:code>  or set it to a different
+(non-zero) desired port.
+    in <html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code>:
+<html:pre>
+"apiServerArguments":{
+  ...
+  "secure-port":[
+    "8443"
+  ],
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.20</ns10:reference>
+            <ns10:rationale xml:lang="en-US">The secure port is used to serve HTTPS with authentication and authorization.
+If <html:code>secure-port</html:code> is disabled, as indicated with a value of <html:code>0</html:code>,
+HTTPS traffic will not be served and all traffic will be unencrypted.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_secure_port:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_secure_port_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup" selected="false" severity="low">
+            <ns10:title xml:lang="en-US">Configure the Maximum Retained Audit Logs</ns10:title>
+            <ns10:description xml:lang="en-US">To configure how many rotations of audit logs are retained, edit the API Server
+pod specification file <html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code>
+on the master node(s) and set the <html:code>maximumRetainedFiles</html:code> parameter to
+<html:code>10</html:code> or to an organizationally appropriate value:
+   <html:pre>
+"auditConfig":{
+  ...
+  "maximumRetainedFiles":10,
+  ...
+ </html:pre></ns10:description>
+            <ns10:reference href="">1.2.24</ns10:reference>
+            <ns10:rationale xml:lang="en-US">OpenShift automatically rotates the log files. Retaining old log files ensures
+OpenShift Operators will have sufficient log data available for carrying out
+any investigation or correlation. For example, if the audit log size is set to
+100 MB and the number of retained log files is set to 10, OpenShift Operators
+would have approximately 1 GB of log data to use during analysis.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_audit_log_maxbackup:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_audit_log_maxbackup_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_service_account_public_key" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Configure the Service Account Public Key for the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure the API Server utilizes its own key pair, edit the
+API Server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master node(s)
+and set the <html:code>serviceAccountPublicKeyFiles</html:code> parameter to the public
+key file for service accounts:
+<html:pre>
+...
+"serviceAccountPublicKeyFiles":[
+  "/etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs"
+],
+...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.28</ns10:reference>
+            <ns10:rationale xml:lang="en-US">By default, if no <html:code>privateKeyFile</html:code> is specified to the
+API Server, the API Server uses the private key from the TLS serving
+certificate to verify service account tokens. To ensure that the keys
+for service account tokens could be rotated as needed, a separate
+public/private key pair should be used for signing service account
+tokens.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_service_account_public_key:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_service_account_public_key_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Enable the NodeRestriction Admission Control Plugin</ns10:title>
+            <ns10:description xml:lang="en-US">To limit the <html:code>Node</html:code> and <html:code>Pod</html:code> objects that a kubelet could
+modify, follow the OpenShift documentation and configure
+<html:code>NodeRestriction</html:code> plugin on kubelets. Then, edit the API Server pod
+specification file <html:code>/etc/origin/master/master-config.yaml</html:code>
+on the master node(s) and set the <html:code>admissionConfig</html:code> to include <html:code>NodeRestriction</html:code>:
+<html:pre>admissionConfig:
+  pluginConfig:
+    NodeRestriction:
+      configuration:
+      kind: DefaultAdmissionConfig
+      apiVersion: v1
+      disable: false</html:pre></ns10:description>
+            <ns10:reference href="">1.2.17</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Using the <html:code>NodeRestriction</html:code> plugin ensures that the kubelet is
+restricted to the <html:code>Node</html:code> and <html:code>Pod</html:code> objects that it could
+modify as defined. Such kubelets will only be allowed to modify their
+own <html:code>Node</html:code> API object, and only modify <html:code>Pod</html:code> API objects
+that are bound to their node.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_admission_control_plugin_NodeRestriction:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_admission_control_plugin_NodeRestriction_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Enable the PodSecurityPolicy Admission Control Plugin</ns10:title>
+            <ns10:description xml:lang="en-US">To reject pods that do not match Pod Security Policies, follow the
+OpenShift documentation and create Pod Security Policy objects as per your
+environment. Then, edit the API Server pod specification file
+<html:code>/etc/origin/master/master-config.yaml</html:code> on the master node(s)
+and set the <html:code>admissionConfig</html:code> to include <html:code>PodSecurityPolicy</html:code>:
+<html:pre>admissionConfig:
+  pluginConfig:
+    PodSecurityPolicy:
+      configuration:
+      kind: DefaultAdmissionConfig
+      apiVersion: v1
+      disable: false</html:pre>
+
+Once configured, the API Server service will need to be restarted.</ns10:description>
+            <ns10:warning category="management" xml:lang="en-US">When the <html:code>PodSecurityPolicy</html:code> admission plugin is in use, there
+needs to be at least one <html:code>PodSecurityPolicy</html:code> in place for ANY pods to
+be admitted.</ns10:warning>
+            <ns10:reference href="">1.2.16</ns10:reference>
+            <ns10:rationale xml:lang="en-US">A Pod Security Policy is a cluster-level resource that controls the actions
+which a pod can perform and what the pod may access. The
+<html:code>PodSecurityPolicy</html:code> objects define a set of conditions that a pod
+must run with in order to be accepted into the system. Pod Security Policies
+are comprised of settings and strategies that control the security features
+a pod has access to and hence this must be used to control pod access
+permissions.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_admission_control_plugin_PodSecurityPolicy:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_admission_control_plugin_PodSecurityPolicy_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key" selected="false" severity="high">
+            <ns10:title xml:lang="en-US">Configure the kubelet Certificate Key for the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">To enable certificate based kubelet authentication, follow the OpenShift
+documentation and setup the TLS connection between the API Server and
+kubelets. Then, verify
+that <html:code>kubeletClientInfo</html:code> has the <html:code>keyFile</html:code> configured in 
+the API Server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master
+node(s) to something similar to:
+<html:pre>
+"storageConfig":{
+  ...
+  "keyFile":"/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key",
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.5</ns10:reference>
+            <ns10:rationale xml:lang="en-US">By default the API Server does not authenticate itself to the kubelet's
+HTTPS endpoints. Requests from the API Server are treated anonymously.
+Configuring certificate-based kubelet authentication ensures that the
+API Server authenticates itself to kubelets when submitting requests.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_kubelet_client_key:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_kubelet_client_key_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Configure the Encryption Provider</ns10:title>
+            <ns10:description xml:lang="en-US">To encrypt the etcd key-value store, follow the OpenShift documentation
+and configure a <html:code>EncryptionConfig</html:code> file. Then, edit the API Server
+pod specification file
+<html:code>/etc/origin/master/master-config.yaml</html:code> on the master
+node(s) and set <html:code>experimental-encryption-provider-config</html:code>
+to the path of that file:
+<html:pre>kubernetesMasterConfig:
+  apiServerArguments:
+    experimental-encryption-provider-config:
+    - /etc/origin/master/encryption-config.yaml</html:pre></ns10:description>
+            <ns10:reference href="">1.2.33</ns10:reference>
+            <ns10:rationale xml:lang="en-US">etcd is a highly available key-value store used by OpenShift deployments
+for persistent storage of all REST API objects. These objects are
+sensitive in nature and should be encrypted at rest to avoid any
+disclosures.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_encryption_provider_config:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_encryption_provider_config_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_tls_cert" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Configure the Certificate for the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure the API Server utilizes its own TLS certificates, the
+<html:code>certFile</html:code> must be configured. Verify
+that <html:code>servingInfo</html:code> has the <html:code>certFile</html:code> configured in 
+the API Server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master
+node(s) to something similar to:
+<html:pre>
+"servingInfo":{
+  ...
+  "certFile":"/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt",
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.30</ns10:reference>
+            <ns10:rationale xml:lang="en-US">API Server communication contains sensitive parameters that should remain
+encrypted in transit. Configure the API Server to serve only HTTPS
+traffic.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_tls_cert:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_tls_cert_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Configure the Encryption Provider Cipher</ns10:title>
+            <ns10:description xml:lang="en-US">To configure OpenShift to use the <html:code>aescbc</html:code> encryption provider,
+follow the OpenShift documentation to create or modify an
+<html:code>EncryptionConfig</html:code> file at <html:code>/etc/origin/master/encryption-config.yaml</html:code>.
+In this file, choose <html:code>aescbc</html:code> as the encryption provider:
+<html:pre>kind: EncryptionConfig
+apiVersion: v1
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aescbc:
+        keys:
+        - name: key1
+          secret: <html:i>32-byte base64-encoded secret</html:i></html:pre></ns10:description>
+            <ns10:reference href="">1.2.34</ns10:reference>
+            <ns10:rationale xml:lang="en-US"><html:code>aescbc</html:code> is currently the strongest encryption provider, it should
+be preferred over other providers.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_encryption_provider_cipher:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_encryption_provider_cipher_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Configure Maximum Audit Log Size</ns10:title>
+            <ns10:description xml:lang="en-US">To rotate audit logs upon reaching a maximum size, edit the API Server pod
+specification file <html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on
+the master node(s) and set the <html:code>maximumFileSizeMegabytes</html:code> parameter to
+an appropriate size in MB. For example, to set it to 100 MB:
+<html:pre>
+"auditConfig":{
+  ...
+  "maximumFileSizeMegabytes":100,
+  ...
+ </html:pre></ns10:description>
+            <ns10:reference href="">1.2.25</ns10:reference>
+            <ns10:rationale xml:lang="en-US">OpenShift automatically rotates log files. Retaining old log files ensures that
+OpenShift Operators have sufficient log data available for carrying out any
+investigation or correlation. If you have set file size of 100 MB and the number of
+old log files to keep as 10, there would be approximately 1 GB of log data
+available for use in analysis.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_audit_log_maxsize:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_audit_log_maxsize_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_token_auth" selected="false" severity="high">
+            <ns10:title xml:lang="en-US">Disable Token-based Authentication</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure OpenShift does not accept token-based authentication,
+follow the OpenShift documentation and configure alternate mechanisms for
+authentication. Then, edit the API Server pod specification file
+<html:code>/etc/origin/master/master-config.yaml</html:code> on the master
+node(s) and remove the <html:code>token-auth-file</html:code> setting.
+<html:pre>
+"apiServerArguments":{
+  ...
+  "token-auth-file":[
+    "/path/to/file"
+  ],
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.3</ns10:reference>
+            <ns10:rationale xml:lang="en-US">The token-based authentication utilizes static tokens to authenticate
+requests to the API Server. The tokens are stored in clear-text in a file
+on the API Server, and cannot be revoked or rotated without restarting the
+API Server.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_token_auth:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_token_auth_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages" selected="false" severity="high">
+            <ns10:title xml:lang="en-US">Enable the AlwaysPullImages Admission Control Plugin</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure credentials are required to pull images, edit the API Server pod
+specification file
+<html:code>/etc/origin/master/master-config.yaml</html:code> on the master node(s) and
+set the <html:code>admissionConfig</html:code> to include <html:code>AlwaysPullImages</html:code>:
+<html:pre>admissionConfig:
+  pluginConfig:
+    AlwaysPullImages:
+      configuration:
+      kind: DefaultAdmissionConfig
+      apiVersion: v1
+      disable: false</html:pre></ns10:description>
+            <ns10:reference href="">1.2.12</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Setting admission control policy to include <html:code>AlwaysPullImages</html:code> forces
+every new pod to pull the required images during every build. In a multi-tenant
+cluster users can be assured that private images can only be used by those who
+have the credentials to pull them. Without this admission control policy, once
+an image has been pulled to a node, any pod from any user can use it simply by
+knowing the image's name (without any authorization check against the image
+access control lists). When this plugin is enabled, images are always pulled
+prior to starting containers and forces authorization.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_admission_control_plugin_AlwaysPullImages:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_admission_control_plugin_AlwaysPullImages_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_authorization_mode" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Ensure API Server authorization-mode is set to Webhook</ns10:title>
+            <ns10:description xml:lang="en-US">By default, unauthenticated/unauthorized users have no access to OpenShift nodes
+and the API Server <html:code>authorization-mode</html:code> is set to <html:code>Webhook</html:code>.
+To ensure that the API server requires authorization for API requests,
+validate that <html:code>authorization-mode</html:code> is configured to <html:code>Webhook</html:code>
+in <html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code>:
+<html:pre>
+"apiServerArguments":{
+  ...
+  "authorization-mode":[
+    "Webhook"
+  ],
+  ...
+</html:pre></ns10:description>
+            <ns10:warning category="functionality" xml:lang="en-US">If <html:code>authorization-mode</html:code> is not configured to <html:code>Webhook</html:code>, the node
+systemd service (<html:code>atomic-openshift-node</html:code>) will not start.</ns10:warning>
+            <ns10:reference href="">1.2.7</ns10:reference>
+            <ns10:reference href="">1.2.8</ns10:reference>
+            <ns10:reference href="">1.2.9</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Ensuring <html:code>authorization-mode</html:code> is set to <html:code>Webhook</html:code> helps enforce that
+unauthenticated/unauthorized users have no access to OpenShift nodes.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_authorization_mode:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_authorization_mode_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Disable the AlwaysAdmit Admission Control Plugin</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure OpenShift only responses to requests explicitly allowed by the
+admissions control plugin, edit the API Server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master node(s)
+
+and ensure the <html:code>admissionConfig</html:code> is not configured to include <html:code>AlwaysAdmit</html:code>.</ns10:description>
+            <ns10:reference href="">1.2.11</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Enabling the admission control plugin <html:code>AlwaysAdmin</html:code> allows all
+requests and does not provide any filtering.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_admission_control_plugin_AlwaysAdmit:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_admission_control_plugin_AlwaysAdmit_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Disable Use of the Insecure Bind Address</ns10:title>
+            <ns10:description xml:lang="en-US">OpenShift should not bind to non-loopback insecure addresses. Edit the API
+Server pod specification file <html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code>
+on the master node(s) and remove the <html:code>insecure-bind-address</html:code>
+parameter.
+<html:pre>
+"apiServerArguments":{
+  ...
+  "insecure-bind-address":[
+    "127.0.0.1"
+  ],
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.18</ns10:reference>
+            <ns10:rationale xml:lang="en-US">If the API Server is bound to an insecure address the installation would
+be susceptible to unauthented and unencrypted access to the master node(s).
+The API Server does not perform authentication checking for insecure
+binds and the traffic is generally not encrypted.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_insecure_bind_address:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_insecure_bind_address_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_profiling" selected="false" severity="low">
+            <ns10:title xml:lang="en-US">Disable Profiling on the API server</ns10:title>
+            <ns10:description xml:lang="en-US">To disable profiling, edit the API Server pod specification file
+<html:code>/etc/origin/master/master-config.yaml</html:code> on the master node(s)
+and set <html:code>profiling</html:code> to <html:code>false</html:code>:
+<html:pre>kubernetesMasterConfig:
+  schedulerArguments:
+    profiling:
+    - false</html:pre></ns10:description>
+            <ns10:reference href="">1.2.21</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Profiling allows for the identification of specific performance bottlenecks. It
+generates a significant amount of program data that could potentially be
+exploited to uncover system and program details. If the profiler is not
+needed for troubleshooting purposes, it is recommended to turn off for
+reduction of potential attack surface.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_profiling:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_profiling_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_kubelet_https" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Enable kubelet HTTPS connections to the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">HTTPS should be used for connections between the API Server and Kubelets.
+Edit the API Server pod specification file <html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code>
+on the master node(s) and remove the <html:code>kubelet-https</html:code> parameter. This will ensure communications
+are encrypted using TLS (the default setting).
+<html:pre>
+"apiServerArguments":{
+  ...
+  "kubelet-https":[
+    "false"
+  ],
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.4</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Connections from the API Server to Kubelets could potentially carry
+sensitive data such as secrets and keys. It is important to use
+in-transit encryption for any communication between the API
+Server and the Kubelets.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_kubelet_https:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_kubelet_https_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_etcd_ca" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Configure the etcd Certificate Authority for the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure etcd is configured to make use of TLS encryption for client
+connections, follow the OpenShift documentation and setup the TLS
+connection between the API Server and etcd. Then, verify
+that <html:code>storageConfig</html:code> has the <html:code>ca</html:code> configured in 
+the API Server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master
+node(s) to something similar to:
+<html:pre>
+"storageConfig":{
+  ...
+  "ca":"/etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt",
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.32</ns10:reference>
+            <ns10:rationale xml:lang="en-US">etcd is a highly-available key-value store used by OpenShift deployments
+for persistent storage of all REST API objects. These objects are
+sensitive in nature and should be protected by client authentication. This
+requires the API Server to identify itself to the etcd server using
+a SSL Certificate Authority file.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_etcd_ca:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_etcd_ca_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert" selected="false" severity="high">
+            <ns10:title xml:lang="en-US">Configure the kubelet Certificate File for the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">To enable certificate based kubelet authentication, follow the OpenShift
+documentation and setup the TLS connection between the API Server and
+kubelets. Then, verify
+that <html:code>kubeletClientInfo</html:code> has the <html:code>certFile</html:code> configured in 
+the API Server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master
+node(s) to something similar to:
+<html:pre>
+"kubeletClientInfo":{
+  ...
+  "certFile":"/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt",
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.5</ns10:reference>
+            <ns10:rationale xml:lang="en-US">By default the API Server does not authenticate itself to the kublet's
+HTTPS endpoints. Requests from the API Server are treated anonymously.
+Configuring certificate-based kubelet authentication ensures that the
+API Server authenticates itself to kubelets when submitting requests.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_kubelet_client_cert:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_kubelet_client_cert_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Use Strong Cryptographic Ciphers on the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure that the API Server is configured to only use strong
+cryptographic ciphers, edit the API Server pod specification file
+<html:code>/etc/origin/master/master-config.yaml</html:code> on the master
+node and set the parameter below:
+<html:pre>servingInfo:
+  cipherSuites:
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+  - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+  - TLS_RSA_WITH_AES_256_GCM_SHA384
+  - TLS_RSA_WITH_AES_128_GCM_SHA256</html:pre></ns10:description>
+            <ns10:warning category="management" xml:lang="en-US">Once configured, API Server clients that cannot support modern
+cryptographic ciphers will not be able to make connections to the API
+server.</ns10:warning>
+            <ns10:reference href="">1.2.35</ns10:reference>
+            <ns10:rationale xml:lang="en-US">TLS ciphers have had a number of known vulnerabilities and weaknesses,
+which can reduce the protection provided. By default OpenShift supports
+a number of TLS ciphersuites including some that have security concerns,
+weakening the protection provided.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_tls_cipher_suites:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_tls_cipher_suites_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_client_ca" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Configure the Client Certificate Authority for the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">Certificates must be provided to fully setup TLS client certificate
+authentication. To ensure the API Server utilizes its own TLS certificates, the
+<html:code>clientCA</html:code> must be configured. Verify
+that <html:code>servingInfo</html:code> has the <html:code>clientCA</html:code> configured in 
+the API Server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master
+node(s) to something similar to:
+<html:pre>
+"servingInfo":{
+  ...
+  "clientCA":"/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt",
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.31</ns10:reference>
+            <ns10:rationale xml:lang="en-US">API Server communication contains sensitive parameters that should remain
+encrypted in transit. Configure the API Server to serve only HTTPS traffic.
+If <html:code>-clientCA</html:code> is set, any request presenting a client
+certificate signed by one of the authorities in the <html:code>client-ca-file</html:code>
+is authenticated with an identity corresponding to the <html:i>CommonName</html:i> of
+the client certificate.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_client_ca:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_client_ca_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority" selected="false" severity="high">
+            <ns10:title xml:lang="en-US">Configure the kubelet Certificate Authority for the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure OpenShift verifies kubelet certificates before establishing
+connections, follow the OpenShift documentation and setup the TLS connection
+between the API Server and kubelets. Then, verify
+that <html:code>kubeletClientInfo</html:code> has the <html:code>ca</html:code> configured in 
+the API Server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master
+node(s) to something similar to:
+<html:pre>
+"kubeletClientInfo":{
+  ...
+  "ca":"/etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt",
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.6</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Connections from the API Server to the kubelet are used for fetching logs
+for pods, attaching (through kubectl) to running pods, and using the kubelet
+port-forwarding functionality. These connections terminate at the kubelet
+HTTPS endpoint. By default, the API Server does not verify the kubelet serving
+certificate, which makes the connection subject to man-in-the-middle attacks,
+and unsafe to run over untrusted and/or public networks.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_kubelet_certificate_authority:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_kubelet_certificate_authority_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_basic_auth" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Disable basic-auth-file for the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">Basic Authentication should not be used. Follow the OpenShift documentation
+and configure alternate mechanisms for authentication. Then, edit API
+server pod specification file <html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code>
+on the master node and remove the <html:code>basic-auth-file</html:code> parameter.
+<html:pre>
+"apiServerArguments":{
+  ...
+  "basic-auth-file":[
+    "/path/to/any/file"
+  ],
+  ...
+</html:pre>
+
+
+Alternate authentication mechanisms such as tokens and certificates will need to be
+used. Username and password for basic authentication will be disabled.</ns10:description>
+            <ns10:reference href="">1.2.2</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Basic authentication uses plaintext credentials for authentication.
+Currently the basic authentication credentials last indefinitely, and
+the password cannot be changed without restarting the API Server. The
+Basic Authentication is currently supported for convenience and is
+not intended for production workloads.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_basic_auth:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_basic_auth_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Enable the ServiceAccount Admission Control Plugin</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure <html:code>ServiceAccount</html:code> objects must be created and granted
+before pod creation is allowed, follow the documentation and create
+<html:code>ServiceAccount</html:code> objects as per your environment. Then, edit the
+API Server pod specification file
+<html:code>/etc/origin/master/master-config.yaml</html:code> on the master node(s)
+set the <html:code>admissionConfig</html:code> to include <html:code>ServiceAccount</html:code>:
+<html:pre>admissionConfig:
+  pluginConfig:
+    ServiceAccount:
+      configuration:
+      kind: DefaultAdmissionConfig
+      apiVersion: v1
+      disable: false</html:pre></ns10:description>
+            <ns10:reference href="">1.2.14</ns10:reference>
+            <ns10:rationale xml:lang="en-US">When a pod is created, if a service account is not specified, the pod
+is automatically assigned the <html:i>default</html:i> service account in the same
+namespace. OpenShift operators should create unique service accounts
+and let the API Server manage its security tokens.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_admission_control_plugin_ServiceAccount:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_admission_control_plugin_ServiceAccount_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_etcd_key" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Configure the etcd Certificate Key for the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure etcd is configured to make use of TLS encryption for client
+communications, follow the OpenShift documentation and setup the TLS
+connection between the API Server and etcd. Then, verify
+that <html:code>storageConfig</html:code> has the <html:code>keyFile</html:code> configured in 
+the API Server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master
+node(s) to something similar to:
+<html:pre>
+"storageConfig":{
+  ...
+  "keyFile":"/etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.key",
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.29</ns10:reference>
+            <ns10:rationale xml:lang="en-US">etcd is a highly-available key-value store used by OpenShift deployments
+for persistent storage of all REST API objects. These objects are sensitive
+in nature and should be protected by client authentication. This requires the
+API Server to identify itself to the etcd server using a client certificate
+and key.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_etcd_key:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_etcd_key_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Enable the EventRateLimit Admission Control Plugin</ns10:title>
+            <ns10:description xml:lang="en-US">To limit the rate at which the API Server accepts requests, follow
+the OpenShift documentation and set the desired limits in a configuration
+file. Then, edit the API Server pod specification file
+<html:code>/etc/origin/master/master-config.yaml</html:code> and
+set the <html:code>admissionConfig</html:code> to include <html:code>DenyEscalatingExec</html:code>:
+<html:pre>admissionConfig:
+  pluginConfig:
+    EventRateLimit:
+      configuration:
+      kind: DefaultAdmissionConfig
+      apiVersion: v1
+      disable: false</html:pre></ns10:description>
+            <ns10:reference href="">1.2.10</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Using <html:code>EventRateLimit</html:code> admission control enforces a limit on the
+number of events that the API Server will accept in a given time slice.
+In a large multi-tenant cluster, there might be a small percentage of
+misbehaving tenants which could have a significant impact on the
+performance of the cluster overall. It is recommended to limit the rate
+of events that the API Server will accept.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_admission_control_plugin_EventRateLimit:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_admission_control_plugin_EventRateLimit_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_tls_private_key" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Configure the Certificate Key for the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure the API Server utilizes its own TLS certificates, the
+<html:code>keyFile</html:code> must be configured. To, verify
+that <html:code>servingInfo</html:code> has the <html:code>keyFile</html:code> configured in 
+the API Server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master
+node(s) to something similar to:
+<html:pre>
+"servingInfo":{
+  ...
+  "keyFile":"/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key",
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.30</ns10:reference>
+            <ns10:rationale xml:lang="en-US">API Server communication contains sensitive parameters that should remain
+encrypted in transit. Configure the API Server to serve only HTTPS
+traffic.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_tls_private_key:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_tls_private_key_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_request_timeout" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Configure the API Server Request Timeout</ns10:title>
+            <ns10:description xml:lang="en-US">All components that use the API should connect via the secured port,
+authenticate themselves, and be authorized to use the API. To ensure
+such a configuration, edit the API Server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master
+node(s) and set the <html:code>request-timeout</html:code> to <html:code>300</html:code>:
+<html:pre>
+"apiServerArguments":{
+  ...
+  "request-timeout":[
+    "300"
+  ],
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.26</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Setting global request timout allows extending the API Server request
+timeout limit to a duration appropriate to the user's connection speed.
+By default, it is set to 60 seconds which might be problematic on
+slower connections making cluster resources inaccessible once the data
+volume for requests exceeds what can be transmitted in 60 seconds. But,
+setting this timeout limit to be too large can exhaust the API Server
+resources making it prone to Denial-of-Service attack. It is recommended
+to set this limit as appropriate and change the default limit of 60
+seconds only if needed.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_request_timeout:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_request_timeout_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_audit_log_path" selected="false" severity="high">
+            <ns10:title xml:lang="en-US">Configure the Audit Log Path</ns10:title>
+            <ns10:description xml:lang="en-US">To enable auditing on the OpenShift API Server, the audit log path
+must be set. Edit the API Server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master node(s)
+and set the <html:code>audit-log-path</html:code> to a suitable path and file
+where you would like audit logs to be written. For example:
+<html:pre>
+"auditConfig":{
+  ...
+  "auditFilePath":"/var/log/kube-apiserver/audit.log",
+  ...
+ </html:pre></ns10:description>
+            <ns10:reference href="">1.2.22</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Auditing of the API Server is not enabled by default. Auditing the API Server
+provides a security-relevant chronological set of records documenting the sequence
+of activities that have affected the system by users, administrators, or other
+system components.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_audit_log_path:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_audit_log_path_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_anonymous_auth" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Disable Anonymous Authentication to the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">By default, anonymous access to the OpenShift API is enabled. This
+configuration check ensures that anonymous requests to the OpenShift
+API server are disabled. Edit the API server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master node(s)
+and set the below parameter:
+<html:pre>
+"apiServerArguments":{
+  ...
+  "anonymous-auth":[
+    "false"
+  ],
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.1</ns10:reference>
+            <ns10:rationale xml:lang="en-US">When enabled, requests that are not rejected by other configured
+authentication methods are treated as anonymous requests. These
+requests are then served by the API server. OpenShift Operators should
+rely on authentication to authorize access and disallow anonymous
+requests.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_anonymous_auth:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_anonymous_auth_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_etcd_cert" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Configure the etcd Certificate for the API Server</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure etcd is configured to make use of TLS encryption for client
+communications, follow the OpenShift documentation and setup the TLS
+connection between the API Server and etcd. Then, verify
+that <html:code>storageConfig</html:code> has the <html:code>certFile</html:code> configured in 
+the API Server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master
+node(s) to something similar to:
+<html:pre>
+"storageConfig":{
+  ...
+  "certFile":"/etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.crt",
+  ...
+</html:pre></ns10:description>
+            <ns10:reference href="">1.2.29</ns10:reference>
+            <ns10:rationale xml:lang="en-US">etcd is a highly-available key-value store used by OpenShift deployments
+for persistent storage of all REST API objects. These objects are sensitive
+in nature and should be protected by client authentication. This requires the
+API Server to identify itself to the etcd server using a client certificate
+and key.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_etcd_cert:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_etcd_cert_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Configure the Audit Log Maximum Retention Days (maximumFileRetentionDays)</ns10:title>
+            <ns10:description xml:lang="en-US">To configure audit log retention, edit the API Server pod specification file
+<html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master node(s) and set
+the <html:code>maximumFileRetentionDays</html:code> parameter to <html:code>30</html:code> or as appropriate for the number of days:
+<html:pre>
+"auditConfig":{
+  ...
+  "maximumFileRetentionDays":30,
+  ...
+ </html:pre></ns10:description>
+            <ns10:reference href="">1.2.23</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Retaining audit logs for a specified period of time allows OpenShift Operators
+to retroactively review and correlate events, such as for investigative purposes.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_audit_log_maxage:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_audit_log_maxage_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_insecure_port" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Prevent Insecure Port Access</ns10:title>
+            <ns10:description xml:lang="en-US">By default, traffic for the OpenShift API server is served over
+HTTPS with authentication and authorization, and the secure API endpoint
+is bound to 0.0.0.0:8443. To ensure that the insecure port configuration
+has not been enabled, the <html:code>insecure-port</html:code> setting should not exist
+in <html:code>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</html:code> on the master node(s).</ns10:description>
+            <ns10:reference href="">1.2.19</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Configuring the API Server on an insecure port would allow unauthenticated
+and unencrypted access to your master node(s). It is assumed firewall rules
+will be configured to ensure this port is not reachable from outside
+the cluster, however as a defense in depth measure, OpenShift should not
+be configured to use insecure ports.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_insecure_port:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_insecure_port_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Enable the SecurityContextDeny Admission Control Plugin</ns10:title>
+            <ns10:description xml:lang="en-US">Instead of using a customized SecurityContext for pods, a Pod Security
+Policy (PSP) should be used. PSP is a cluster-level resource that controls
+the actions that a pod can perform and what resource the pod may access.
+The <html:code>SecurityContextDeny</html:code> admission control policy enables PSP. To
+configure OpenShift to use PSP, edit the API Server pod specification file
+<html:code>/etc/origin/master/master-config.yaml</html:code> on the master node(s) and
+set the <html:code>admissionConfig</html:code> to include <html:code>SecurityContextDeny</html:code>:
+<html:pre>admissionConfig:
+  pluginConfig:
+    SecurityContextDeny:
+      configuration:
+      kind: DefaultAdmissionConfig
+      apiVersion: v1
+      disable: false</html:pre></ns10:description>
+            <ns10:reference href="">1.2.13</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Setting admission control policy to <html:code>SecurityContextDeny</html:code> denies the
+pod level SecurityContext customization. Any attempts to customize the
+SecurityContext that are not explicitly defined in the Pod Security Policy
+(PSP) are blocked. This ensures that all pods adhere to the PSP defined
+by your organization and you have a uniform pod level security posture.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_admission_control_plugin_SecurityContextDeny:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_admission_control_plugin_SecurityContextDeny_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Enable the NamespaceLifecyle Admission Control Plugin</ns10:title>
+            <ns10:description xml:lang="en-US">To enable <html:code>NamespaceLifecycle</html:code>, edit the API Server pod specification
+file <html:code>/etc/origin/master/master-config.yaml</html:code> on the master node(s)
+and set the <html:code>admissionConfig</html:code> to include <html:code>NamespaceLifecyle</html:code>:
+<html:pre>admissionConfig:
+  pluginConfig:
+    NamespaceLifecyle:
+      configuration:
+      kind: DefaultAdmissionConfig
+      apiVersion: v1
+      disable: false</html:pre></ns10:description>
+            <ns10:reference href="">1.2.15</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Setting admission control policy to <html:code>NamespaceLifecycle</html:code> ensures that
+objects cannot be created in non-existent namespaces, and that namespaces
+undergoing termination are not used for creating new objects. This
+is recommended to enforce the integrity of the namespace termination process
+and also for the availability of new objects.</ns10:rationale>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-api_server_admission_control_plugin_NamespaceLifecycle:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-api_server_admission_control_plugin_NamespaceLifecycle_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+        </ns10:Group>
+        <ns10:Group id="xccdf_org.ssgproject.content_group_etcd">
+          <ns10:title xml:lang="en-US">OpenShift etcd Settings</ns10:title>
+          <ns10:description xml:lang="en-US">Contains rules that check correct OpenShift etcd settings.</ns10:description>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_etcd_client_cert_auth" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Enable The Client Certificate Authentication</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure the <html:code>etcd</html:code> service is serving TLS to clients,
+edit the <html:code>etcd</html:code> configuration file
+<html:code>/etc/etcd/etcd.conf</html:code> on the master node and set
+<html:code>ETCD_CLIENT_CERT_AUTH</html:code> to <html:code>true</html:code>.
+<html:pre>ETCD_CLIENT_CERT_AUTH=true</html:pre></ns10:description>
+            <ns10:reference href="">2.2</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Without cryptographic integrity protections, information can be
+altered by unauthorized users without detection.</ns10:rationale>
+            <ns10:fix id="etcd_client_cert_auth" system="urn:xccdf:fix:script:sh"><ns10:sub idref="xccdf_org.ssgproject.content_value_function_replace_or_append" use="legacy"/>
+replace_or_append '/etc/etcd/etcd.conf' '^ETCD_CLIENT_CERT_AUTH=' 'true' '' '%s=%s'
+</ns10:fix>
+            <ns10:fix complexity="low" disruption="low" id="etcd_client_cert_auth" strategy="restrict" system="urn:xccdf:fix:script:ansible">- name: '@RULE_TITLE@'
+  lineinfile:
+    path: /etc/etcd/etcd.conf
+    regexp: ^ETCD_CLIENT_CERT_AUTH=
+    line: ETCD_CLIENT_CERT_AUTH=true
+    create: true
+  tags:
+    - etcd_client_cert_auth
+    - medium_severity
+    - restrict_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed
+</ns10:fix>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-etcd_client_cert_auth:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-etcd_client_cert_auth_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_etcd_wal_dir" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Configure etcd Log Storage</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure the <html:code>etcd</html:code> service is storing logs separate
+from data, set
+<html:code>ETCD_WAL_DIR</html:code> to <html:code>/var/lib/etcd/member/wal</html:code>
+in <html:code>/etc/etcd/etcd.conf</html:code> on the master node:
+<html:pre>ETCD_WAL_DIR=/var/lib/etcd/member/wal</html:pre></ns10:description>
+            <ns10:rationale xml:lang="en-US">etcd log files should be stored in a separate location from the etcd data.
+This not only ensures data integrity but also helps to prevent IO degradation.</ns10:rationale>
+            <ns10:fix id="etcd_wal_dir" system="urn:xccdf:fix:script:sh"><ns10:sub idref="xccdf_org.ssgproject.content_value_function_replace_or_append" use="legacy"/>
+replace_or_append '/etc/etcd/etcd.conf' '^ETCD_WAL_DIR=' '/var/lib/etcd/member/wal' '' '%s=%s'
+</ns10:fix>
+            <ns10:fix complexity="low" disruption="low" id="etcd_wal_dir" strategy="restrict" system="urn:xccdf:fix:script:ansible">- name: '@RULE_TITLE@'
+  lineinfile:
+    path: /etc/etcd/etcd.conf
+    regexp: ^ETCD_WAL_DIR=
+    line: ETCD_WAL_DIR=/var/lib/etcd/member/wal
+    create: true
+  tags:
+    - etcd_wal_dir
+    - medium_severity
+    - restrict_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed
+</ns10:fix>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-etcd_wal_dir:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-etcd_wal_dir_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_etcd_auto_tls" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Disable etcd Self-Signed Certificates</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure the <html:code>etcd</html:code> service is not using self-signed
+certificates, edit the <html:code>etcd</html:code> configuration file
+<html:code>/etc/etcd/etcd.conf</html:code> from the master node and set
+<html:code>ETCD_AUTO_TLS</html:code> to <html:code>false</html:code>:
+<html:pre>ETCD_AUTO_TLS=false</html:pre></ns10:description>
+            <ns10:reference href="">2.3</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Without cryptographic integrity protections, information can be
+altered by unauthorized users without detection. Using self-signed
+certificates ensures that the certificates are never validated
+against a certificate authority and could lead to compromised
+and invalidated data.</ns10:rationale>
+            <ns10:fix id="etcd_auto_tls" system="urn:xccdf:fix:script:sh"><ns10:sub idref="xccdf_org.ssgproject.content_value_function_replace_or_append" use="legacy"/>
+replace_or_append '/etc/etcd/etcd.conf' '^ETCD_AUTO_TLS=' 'false' '' '%s=%s'
+</ns10:fix>
+            <ns10:fix complexity="low" disruption="low" id="etcd_auto_tls" strategy="restrict" system="urn:xccdf:fix:script:ansible">- name: '@RULE_TITLE@'
+  lineinfile:
+    path: /etc/etcd/etcd.conf
+    regexp: ^ETCD_AUTO_TLS=
+    line: ETCD_AUTO_TLS=false
+    create: true
+  tags:
+    - etcd_auto_tls
+    - medium_severity
+    - restrict_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed
+</ns10:fix>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-etcd_auto_tls:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-etcd_auto_tls_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_etcd_cert_file" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Ensure That The etcd Client Certificate Is Correctly Set</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure the <html:code>etcd</html:code> service is serving TLS to clients,
+edit the <html:code>etcd</html:code> configuration file
+<html:code>/etc/etcd/etcd.conf</html:code> on the master and adding a certificate
+to <html:code>ETCD_CERT_FILE</html:code>:
+<html:pre>ETCD_CERT_FILE=/etc/ssl/etcd/system:etcd-server:<html:i>etcd_dns_name</html:i>.crt</html:pre></ns10:description>
+            <ns10:reference href="">2.1</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Without cryptographic integrity protections, information can be
+altered by unauthorized users without detection.</ns10:rationale>
+            <ns10:fix id="etcd_cert_file" system="urn:xccdf:fix:script:sh"><ns10:sub idref="xccdf_org.ssgproject.content_value_function_replace_or_append" use="legacy"/>
+replace_or_append '/etc/etcd/etcd.conf' '^ETCD_CERT_FILE=' /etc/etcd/server.crt '' '%s=%s'
+</ns10:fix>
+            <ns10:fix complexity="low" disruption="low" id="etcd_cert_file" strategy="restrict" system="urn:xccdf:fix:script:ansible">- name: '@RULE_TITLE@'
+  lineinfile:
+    path: /etc/etcd/etcd.conf
+    regexp: ^ETCD_CERT_FILE
+    line: ETCD_CERT_FILE=/etc/etcd/server.crt
+    create: true
+  tags:
+    - etcd_cert_file
+    - medium_severity
+    - restrict_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed
+</ns10:fix>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-etcd_cert_file:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-etcd_cert_file_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Disable etcd Peer Self-Signed Certificates</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure the <html:code>etcd</html:code> service is not using self-signed
+certificates, edit the <html:code>etcd</html:code> configuration file
+<html:code>/etc/etcd/etcd.conf</html:code> from the master node and set
+<html:code>ETCD_PEER_AUTO_TLS</html:code> to <html:code>false</html:code>:
+<html:pre>ETCD_PEER_AUTO_TLS=false</html:pre></ns10:description>
+            <ns10:reference href="">2.6</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Without cryptographic integrity protections, information can be
+altered by unauthorized users without detection. Using self-signed
+certificates ensures that the certificates are never validated
+against a certificate authority and could lead to compromised
+and invalidated data.</ns10:rationale>
+            <ns10:fix id="etcd_peer_auto_tls" system="urn:xccdf:fix:script:sh"><ns10:sub idref="xccdf_org.ssgproject.content_value_function_replace_or_append" use="legacy"/>
+replace_or_append '/etc/etcd/etcd.conf' '^ETCD_PEER_AUTO_TLS=' 'false' '' '%s=%s'
+</ns10:fix>
+            <ns10:fix complexity="low" disruption="low" id="etcd_peer_auto_tls" strategy="restrict" system="urn:xccdf:fix:script:ansible">- name: '@RULE_TITLE@'
+  lineinfile:
+    path: /etc/etcd/etcd.conf
+    regexp: ^ETCD_PEER_AUTO_TLS=
+    line: ETCD_PEER_AUTO_TLS=false
+    create: true
+  tags:
+    - etcd_peer_auto_tls
+    - medium_severity
+    - restrict_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed
+</ns10:fix>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-etcd_peer_auto_tls:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-etcd_peer_auto_tls_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_etcd_unique_ca" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Configure A Unique CA Certificate for etcd</ns10:title>
+            <ns10:description xml:lang="en-US">A unique and different CA certificate should be created for <html:code>etcd</html:code>.
+To ensure the <html:code>etcd</html:code> service is using a unique certificate,
+, set <html:code>ETCD_TRUSTED_CA_FILE</html:code> to <html:code>/etc/etcd/ca.crt</html:code>
+in <html:code>/etc/etcd/etcd.conf</html:code> on the master node that does NOT match
+the OpenShift CA certificate:
+<html:pre>ETCD_TRUSTED_CA_FILE=/etc/ssl/etcd/ca.crt</html:pre></ns10:description>
+            <ns10:reference href="">2.7</ns10:reference>
+            <ns10:rationale xml:lang="en-US">A unique CA certificate that is utilized by etcd and is different from
+OpenShift ensures that the etcd data is still protected in the event that
+the OpenShift certificate is compromised.</ns10:rationale>
+            <ns10:fix id="etcd_unique_ca" system="urn:xccdf:fix:script:sh"><ns10:sub idref="xccdf_org.ssgproject.content_value_function_replace_or_append" use="legacy"/>
+replace_or_append '/etc/etcd/etcd.conf' '^ETCD_TRUSTED_CA_FILE=' '/etc/etcd/ca.crt' '' '%s=%s'
+</ns10:fix>
+            <ns10:fix complexity="low" disruption="low" id="etcd_unique_ca" strategy="restrict" system="urn:xccdf:fix:script:ansible">- name: '@RULE_TITLE@'
+  lineinfile:
+    path: /etc/etcd/etcd.conf
+    regexp: ^ETCD_TRUSTED_CA_FILE=
+    line: ETCD_TRUSTED_CA_FILE=/etc/etcd/ca.crt
+    create: true
+  tags:
+    - etcd_unique_ca
+    - medium_severity
+    - restrict_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed
+</ns10:fix>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-etcd_unique_ca:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-etcd_unique_ca_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_etcd_key_file" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Ensure That The etcd Key File Is Correctly Set</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure the <html:code>etcd</html:code> service is serving TLS to clients,
+edit the <html:code>etcd</html:code> configuration file
+<html:code>/etc/etcd/etcd.conf</html:code> on the master and
+adding a key file to <html:code>ETCD_KEY_FILE</html:code>:
+<html:pre>ETCD_CERT_FILE=/etc/ssl/etcd/system:etcd-server:<html:i>etcd_dns_name</html:i>.key</html:pre></ns10:description>
+            <ns10:reference href="">2.1</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Without cryptographic integrity protections, information can be
+altered by unauthorized users without detection.</ns10:rationale>
+            <ns10:fix id="etcd_key_file" system="urn:xccdf:fix:script:sh"><ns10:sub idref="xccdf_org.ssgproject.content_value_function_replace_or_append" use="legacy"/>
+replace_or_append '/etc/etcd/etcd.conf' '^ETCD_KEY_FILE=' /etc/etcd/server.key '' '%s=%s'
+</ns10:fix>
+            <ns10:fix complexity="low" disruption="low" id="etcd_key_file" strategy="restrict" system="urn:xccdf:fix:script:ansible">- name: '@RULE_TITLE@'
+  lineinfile:
+    path: /etc/etcd/etcd.conf
+    regexp: ^ETCD_KEY_FILE=
+    line: ETCD_KEY_FILE=/etc/etcd/server.key
+    create: true
+  tags:
+    - etcd_key_file
+    - medium_severity
+    - restrict_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed
+</ns10:fix>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-etcd_key_file:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-etcd_key_file_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_etcd_peer_cert_file" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Ensure That The etcd Peer Client Certificate Is Correctly Set</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure the <html:code>etcd</html:code> service is serving TLS to clients,
+edit the <html:code>etcd</html:code> configuration file
+<html:code>/etc/etcd/etcd.conf</html:code> on the master and adding a certificate
+to <html:code>ETCD_PEER_CERT_FILE</html:code>:
+<html:pre>ETCD_PEER_CERT_FILE=/etc/ssl/etcd/system:etcd-peer:<html:i>etcd_dns_name</html:i>.crt</html:pre></ns10:description>
+            <ns10:reference href="">2.4</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Without cryptographic integrity protections, information can be
+altered by unauthorized users without detection.</ns10:rationale>
+            <ns10:fix id="etcd_peer_cert_file" system="urn:xccdf:fix:script:sh"><ns10:sub idref="xccdf_org.ssgproject.content_value_function_replace_or_append" use="legacy"/>
+replace_or_append '/etc/etcd/etcd.conf' '^ETCD_PEER_CERT_FILE=' /etc/etcd/peer.crt '' '%s=%s'
+</ns10:fix>
+            <ns10:fix complexity="low" disruption="low" id="etcd_peer_cert_file" strategy="restrict" system="urn:xccdf:fix:script:ansible">- name: '@RULE_TITLE@'
+  lineinfile:
+    path: /etc/etcd/etcd.conf
+    regexp: ^ETCD_PEER_CERT_FILE
+    line: ETCD_PEER_CERT_FILE=/etc/etcd/peer.crt
+    create: true
+  tags:
+    - etcd_peer_cert_file
+    - medium_severity
+    - restrict_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed
+</ns10:fix>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-etcd_peer_cert_file:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-etcd_peer_cert_file_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Enable The Peer Client Certificate Authentication</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure the <html:code>etcd</html:code> service is serving TLS to clients,
+edit the <html:code>etcd</html:code> configuration file
+<html:code>/etc/etcd/etcd.conf</html:code> on the master node and set
+<html:code>ETCD_PEER_CLIENT_CERT_AUTH</html:code> to <html:code>true</html:code>.
+<html:pre>ETCD_PEER_CLIENT_CERT_AUTH=true</html:pre></ns10:description>
+            <ns10:reference href="">2.5</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Without cryptographic integrity protections, information can be
+altered by unauthorized users without detection.</ns10:rationale>
+            <ns10:fix id="etcd_peer_client_cert_auth" system="urn:xccdf:fix:script:sh"><ns10:sub idref="xccdf_org.ssgproject.content_value_function_replace_or_append" use="legacy"/>
+replace_or_append '/etc/etcd/etcd.conf' '^ETCD_PEER_CLIENT_CERT_AUTH=' 'true' '' '%s=%s'
+</ns10:fix>
+            <ns10:fix complexity="low" disruption="low" id="etcd_peer_client_cert_auth" strategy="restrict" system="urn:xccdf:fix:script:ansible">- name: '@RULE_TITLE@'
+  lineinfile:
+    path: /etc/etcd/etcd.conf
+    regexp: ^ETCD_PEER_CLIENT_CERT_AUTH=
+    line: ETCD_PEER_CLIENT_CERT_AUTH=true
+    create: true
+  tags:
+    - etcd_peer_client_cert_auth
+    - medium_severity
+    - restrict_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed
+</ns10:fix>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-etcd_peer_client_cert_auth:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-etcd_peer_client_cert_auth_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+          <ns10:Rule id="xccdf_org.ssgproject.content_rule_etcd_peer_key_file" selected="false" severity="medium">
+            <ns10:title xml:lang="en-US">Ensure That The etcd Peer Key File Is Correctly Set</ns10:title>
+            <ns10:description xml:lang="en-US">To ensure the <html:code>etcd</html:code> service is serving TLS to clients,
+edit the <html:code>etcd</html:code> configuration file
+<html:code>/etc/etcd/etcd.conf</html:code> on the master on the master and
+adding a key file to <html:code>ETCD_PEER_KEY_FILE</html:code>:
+<html:pre>ETCD_PEER_KEY_FILE=/etc/ssl/etcd/system:etcd-peer:<html:i>etcd_dns_name</html:i>.key</html:pre></ns10:description>
+            <ns10:reference href="">2.4</ns10:reference>
+            <ns10:rationale xml:lang="en-US">Without cryptographic integrity protections, information can be
+altered by unauthorized users without detection.</ns10:rationale>
+            <ns10:fix id="etcd_peer_key_file" system="urn:xccdf:fix:script:sh"><ns10:sub idref="xccdf_org.ssgproject.content_value_function_replace_or_append" use="legacy"/>
+replace_or_append '/etc/etcd/etcd.conf' '^ETCD_PEER_KEY_FILE=' /etc/etcd/peer.key '' '%s=%s'
+</ns10:fix>
+            <ns10:fix complexity="low" disruption="low" id="etcd_peer_key_file" strategy="restrict" system="urn:xccdf:fix:script:ansible">- name: '@RULE_TITLE@'
+  lineinfile:
+    path: /etc/etcd/etcd.conf
+    regexp: ^ETCD_PEER_KEY_FILE
+    line: ETCD_PEER_KEY_FILE=/etc/etcd/peer.key
+    create: true
+  tags:
+    - etcd_peer_key_file
+    - medium_severity
+    - restrict_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed
+</ns10:fix>
+            <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-etcd_peer_key_file:def:1"/>
+            </ns10:check>
+            <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+              <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-etcd_peer_key_file_ocil:questionnaire:1"/>
+            </ns10:check>
+          </ns10:Rule>
+        </ns10:Group>
+        <ns10:Group id="xccdf_org.ssgproject.content_group_ocp-permissions">
+          <ns10:title xml:lang="en-US">Permissions</ns10:title>
+          <ns10:description xml:lang="en-US">Traditional security relies heavily on file and
+directory permissions to prevent unauthorized users from reading or
+modifying files to which they should not have access.</ns10:description>
+          <ns10:Group id="xccdf_org.ssgproject.content_group_ocp-files">
+            <ns10:title xml:lang="en-US">Verify Permissions on Important Files and
+Directories</ns10:title>
+            <ns10:description xml:lang="en-US">Permissions for many files on a system must be set
+restrictively to ensure sensitive information is properly protected.
+This section discusses important
+permission restrictions which can be verified
+to ensure that no harmful discrepancies have
+arisen.</ns10:description>
+            <ns10:Rule id="xccdf_org.ssgproject.content_rule_file_permissions_node_config" selected="false" severity="medium">
+              <ns10:title xml:lang="en-US">Verify Permissions on the OpenShift Node Configuration File</ns10:title>
+              <ns10:description xml:lang="en-US">
+To properly set the permissions of <html:code>/etc/origin/node/node-config.yaml</html:code>, run the command:
+<html:pre>$ sudo chmod 0600 /etc/origin/node/node-config.yaml</html:pre></ns10:description>
+              <ns10:reference href="">2.2.1</ns10:reference>
+              <ns10:rationale xml:lang="en-US">If the <html:code>/etc/origin/node/node-config.yaml</html:code> file is writable by a group-owner or the
+world the risk of its compromise is increased. The file contains the configuration of
+an OpenShift node that is configured on the system. Protection of this file is
+critical for OpenShift security.</ns10:rationale>
+              <ns10:fix complexity="low" disruption="low" id="file_permissions_node_config" strategy="configure" system="urn:xccdf:fix:script:sh">
+chmod 0600 /etc/origin/node/node-config.yaml
+</ns10:fix>
+              <ns10:fix complexity="low" disruption="low" id="file_permissions_node_config" strategy="configure" system="urn:xccdf:fix:script:ansible">- name: Test for existence /etc/origin/node/node-config.yaml
+  stat:
+    path: /etc/origin/node/node-config.yaml
+  register: file_exists
+  tags:
+    - file_permissions_node_config
+    - medium_severity
+    - configure_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed
+
+- name: Ensure permission 0600 on /etc/origin/node/node-config.yaml
+  file:
+    path: /etc/origin/node/node-config.yaml
+    mode: '0600'
+  when: file_exists.stat is defined and file_exists.stat.exists
+  tags:
+    - file_permissions_node_config
+    - medium_severity
+    - configure_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed
+</ns10:fix>
+              <ns10:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                <ns10:check-content-ref href="ssg-ocp4-oval.xml" name="oval:ssg-file_permissions_node_config:def:1"/>
+              </ns10:check>
+              <ns10:check system="http://scap.nist.gov/schema/ocil/2">
+                <ns10:check-content-ref href="ssg-ocp4-ocil.xml" name="ocil:ssg-file_permissions_node_config_ocil:questionnaire:1"/>
+              </ns10:check>
+            </ns10:Rule>
+          </ns10:Group>
+      </ns10:Group></ns0:component>
+  <ns0:component id="scap_org.open-scap_comp_ssg-ocp4-cpe-oval.xml" timestamp="2020-04-20T13:24:48">
+    <ns3:oval_definitions xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd         http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd         http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd         http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd         http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd">
+      <ns3:generator>
+        <ns5:product_name>combine_ovals.py from SCAP Security Guide</ns5:product_name>
+        <ns5:product_version>ssg: [0, 1, 50], python: 3.7.6</ns5:product_version>
+        <ns5:schema_version>5.11</ns5:schema_version>
+        <ns5:timestamp>2020-04-20T17:24:40</ns5:timestamp>
+      </ns3:generator>
+      <ns3:definitions>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_centos6:def:1" version="2">
+          <ns3:metadata>
+            <ns3:title>CentOS 6</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:centos:centos:6" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      CentOS 6</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:extend_definition comment="Installed OS is part of the Unix family" definition_ref="oval:ssg-installed_OS_is_part_of_Unix_family:def:1"/>
+            <ns3:criterion comment="CentOS6 is installed" test_ref="oval:ssg-test_centos6:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_centos7:def:1" version="2">
+          <ns3:metadata>
+            <ns3:title>CentOS 7</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:centos:centos:7" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      CentOS 7</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria operator="AND">
+            <ns3:extend_definition comment="Installed OS is part of the Unix family" definition_ref="oval:ssg-installed_OS_is_part_of_Unix_family:def:1"/>
+            <ns3:criterion comment="CentOS7 is installed" test_ref="oval:ssg-test_centos7:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_centos8:def:1" version="2">
+          <ns3:metadata>
+            <ns3:title>CentOS 8</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:centos:centos:8" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      CentOS 8</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria operator="AND">
+            <ns3:extend_definition comment="Installed OS is part of the Unix family" definition_ref="oval:ssg-installed_OS_is_part_of_Unix_family:def:1"/>
+            <ns3:criterion comment="CentOS8 is installed" test_ref="oval:ssg-test_centos8:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_debian:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Debian</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>The operating system installed is a Debian System</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria comment="System is Debian" operator="AND">
+            <ns3:extend_definition comment="Installed OS is part of the Unix family" definition_ref="oval:ssg-installed_OS_is_part_of_Unix_family:def:1"/>
+            <ns3:criterion comment="Debian is installed" test_ref="oval:ssg-test_debian:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_debian10:def:1" version="3">
+          <ns3:metadata>
+            <ns3:title>Debian Linux 10</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:debian:debian_linux:10" source="CPE"/>
+            <ns3:description>The operating system installed on the system is Debian 10</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria comment="Debian Linux is version 10" operator="AND">
+            <ns3:extend_definition comment="Debian is installed" definition_ref="oval:ssg-installed_OS_is_debian:def:1"/>
+            <ns3:criterion comment="Debian10 is installed" test_ref="oval:ssg-test_debian_10:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_debian8:def:1" version="3">
+          <ns3:metadata>
+            <ns3:title>Debian 8</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:debian:debian_linux:8" source="CPE"/>
+            <ns3:description>The operating system installed on the system is Debian 8</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria comment="current Debian version is Debian jessie" operator="AND">
+            <ns3:extend_definition comment="Debian is installed" definition_ref="oval:ssg-installed_OS_is_debian:def:1"/>
+            <ns3:criterion comment="Debian8 is installed" test_ref="oval:ssg-test_debian_8:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_debian9:def:1" version="3">
+          <ns3:metadata>
+            <ns3:title>Debian 9</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:debian:debian_linux:9" source="CPE"/>
+            <ns3:description>The operating system installed on the system is Debian 9</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria comment="current Debian version is Debian Stretch" operator="AND">
+            <ns3:extend_definition comment="Debian is installed" definition_ref="oval:ssg-installed_OS_is_debian:def:1"/>
+            <ns3:criterion comment="Debian9 is installed" test_ref="oval:ssg-test_debian_9:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_fedora:def:1" version="3">
+          <ns3:metadata>
+            <ns3:title>Installed operating system is Fedora</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:fedoraproject:fedora:28" source="CPE"/>
+            <ns3:description>The operating system installed on the system is Fedora</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria operator="AND">
+            <ns3:extend_definition comment="Installed OS is part of the Unix family" definition_ref="oval:ssg-installed_OS_is_part_of_Unix_family:def:1"/>
+            <ns3:criterion comment="fedora-release RPM packages are installed" test_ref="oval:ssg-test_fedora_release_rpm:tst:1"/>
+            <ns3:criterion comment="CPE vendor is 'fedoraproject' and product is 'fedora'" test_ref="oval:ssg-test_fedora_vendor_product:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_ol6_family:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Oracle Linux 6</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:oracle:linux:6" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      Oracle Linux 6</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:extend_definition comment="Installed OS is part of the Unix family" definition_ref="oval:ssg-installed_OS_is_part_of_Unix_family:def:1"/>
+            <ns3:criteria operator="OR">
+              <ns3:criterion comment="Oracle Linux 6 System is installed" test_ref="oval:ssg-test_ol6_system:tst:1"/>
+            </ns3:criteria>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_ol7_family:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Oracle Linux 7</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:oracle:linux:7" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      Oracle Linux 7</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:extend_definition comment="Installed OS is part of the Unix family" definition_ref="oval:ssg-installed_OS_is_part_of_Unix_family:def:1"/>
+            <ns3:criteria operator="OR">
+              <ns3:criterion comment="Oracle Linux 7 System is installed" test_ref="oval:ssg-test_ol7_system:tst:1"/>
+            </ns3:criteria>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_ol8_family:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Oracle Linux 8</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:oracle:linux:8" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      Oracle Linux 8</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:extend_definition comment="Installed OS is part of the Unix family" definition_ref="oval:ssg-installed_OS_is_part_of_Unix_family:def:1"/>
+            <ns3:criteria operator="OR">
+              <ns3:criterion comment="Oracle Linux 8 System is installed" test_ref="oval:ssg-test_ol8_system:tst:1"/>
+            </ns3:criteria>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_opensuse:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>openSUSE</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>The operating system installed on the system is openSUSE.</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria operator="AND">
+            <ns3:extend_definition comment="Installed OS is part of the Unix family" definition_ref="oval:ssg-installed_OS_is_part_of_Unix_family:def:1"/>
+            <ns3:criterion comment="openSUSE is installed" test_ref="oval:ssg-test_opensuse_installed:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_opensuse_leap15:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>openSUSE Leap 15</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:opensuse:leap:15.0" source="CPE"/>
+            <ns3:description>The operating system installed on the system is openSUSE Leap 15.</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria operator="AND">
+            <ns3:extend_definition comment="openSUSE is installed" definition_ref="oval:ssg-installed_OS_is_opensuse:def:1"/>
+            <ns3:criterion comment="openSUSE Leap 15 is installed" test_ref="oval:ssg-test_opensuse_leap15_installed:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_opensuse_leap42:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>openSUSE Leap 42</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:opensuse:leap:42.1" source="CPE"/>
+            <ns3:reference ref_id="cpe:/o:opensuse:leap:42.2" source="CPE"/>
+            <ns3:reference ref_id="cpe:/o:opensuse:leap:42.3" source="CPE"/>
+            <ns3:description>The operating system installed on the system is openSUSE Leap 42.</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria operator="AND">
+            <ns3:extend_definition comment="openSUSE is installed" definition_ref="oval:ssg-installed_OS_is_opensuse:def:1"/>
+            <ns3:criterion comment="openSUSE Leap 42 is installed" test_ref="oval:ssg-test_opensuse_leap42_installed:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_part_of_Unix_family:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Installed operating system is part of the Unix family</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>The operating system installed on the system is part of the Unix OS family</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Installed operating system is part of the unix family" test_ref="oval:ssg-test_unix_family:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_rhel6:def:1" version="2">
+          <ns3:metadata>
+            <ns3:title>Red Hat Enterprise Linux 6</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:redhat:enterprise_linux:6" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      Red Hat Enterprise Linux 6</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria operator="AND">
+            <ns3:extend_definition comment="Installed OS is part of the Unix family" definition_ref="oval:ssg-installed_OS_is_part_of_Unix_family:def:1"/>
+            <ns3:criteria operator="OR">
+              <ns3:criterion comment="RHEL 6 Client is installed" test_ref="oval:ssg-test_rhel_client:tst:1"/>
+              <ns3:criterion comment="RHEL 6 Workstation is installed" test_ref="oval:ssg-test_rhel_workstation:tst:1"/>
+              <ns3:criterion comment="RHEL 6 Server is installed" test_ref="oval:ssg-test_rhel_server:tst:1"/>
+              <ns3:criterion comment="RHEL 6 Compute Node is installed" test_ref="oval:ssg-test_rhel_computenode:tst:1"/>
+            </ns3:criteria>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_rhel7:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Red Hat Enterprise Linux 7</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:redhat:enterprise_linux:7" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      Red Hat Enterprise Linux 7</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Installed operating system is part of the unix family" test_ref="oval:ssg-test_rhel7_unix_family:tst:1"/>
+            <ns3:criteria operator="OR">
+              <ns3:criterion comment="RHEL 7 Client is installed" test_ref="oval:ssg-test_rhel7_client:tst:1"/>
+              <ns3:criterion comment="RHEL 7 Workstation is installed" test_ref="oval:ssg-test_rhel7_workstation:tst:1"/>
+              <ns3:criterion comment="RHEL 7 Server is installed" test_ref="oval:ssg-test_rhel7_server:tst:1"/>
+              <ns3:criterion comment="RHEL 7 Compute Node is installed" test_ref="oval:ssg-test_rhel7_computenode:tst:1"/>
+              <ns3:criteria comment="Red Hat Enterprise Virtualization Host is installed" operator="AND">
+                <ns3:criterion comment="Red Hat Virtualization Host (RHVH)" test_ref="oval:ssg-test_rhvh4_version:tst:1"/>
+                <ns3:criterion comment="Red Hat Enterprise Virtualization Host is based on RHEL 7" test_ref="oval:ssg-test_rhevh_rhel7_version:tst:1"/>
+              </ns3:criteria>
+            </ns3:criteria>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_rhel8:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Red Hat Enterprise Linux 8</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:redhat:enterprise_linux:8" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      Red Hat Enterprise Linux 8</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Installed operating system is part of the unix family" test_ref="oval:ssg-test_rhel8_unix_family:tst:1"/>
+            <ns3:criteria operator="OR">
+              <ns3:criterion comment="RHEL 8 is installed" test_ref="oval:ssg-test_rhel8:tst:1"/>
+              <ns3:criterion comment="RHEL 8 CoreOS is installed" test_ref="oval:ssg-test_rhel8_coreos:tst:1"/>
+              <ns3:criteria comment="Red Hat Enterprise Virtualization Host is installed" operator="AND">
+                <ns3:criterion comment="Red Hat Virtualization Host (RHVH)" test_ref="oval:ssg-test_rhvh4_version:tst:1"/>
+                <ns3:criterion comment="Red Hat Enterprise Virtualization Host is based on RHEL 8" test_ref="oval:ssg-test_rhevh_rhel8_version:tst:1"/>
+              </ns3:criteria>
+            </ns3:criteria>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_rhv4:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Red Hat Virtualization 4</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:redhat:virtualization:4" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      Red Hat Virtualization Host 4.4+ or Red Hat Enterprise Host.</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria operator="OR">
+            <ns3:extend_definition comment="RHEL8 OS installed" definition_ref="oval:ssg-installed_OS_is_rhel8:def:1"/>
+            <ns3:criterion comment="Red Hat Virtualization Host (RHVH)" test_ref="oval:ssg-test_rhvh4_version:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_sl6:def:1" version="2">
+          <ns3:metadata>
+            <ns3:title>Scientific Linux 6</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:scientificlinux:scientificlinux:6" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      Scientific Linux 6</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria operator="AND">
+            <ns3:extend_definition comment="Installed OS is part of the Unix family" definition_ref="oval:ssg-installed_OS_is_part_of_Unix_family:def:1"/>
+            <ns3:criterion comment="Scientific Linux 6 is installed" test_ref="oval:ssg-test_sl6:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_sl7:def:1" version="2">
+          <ns3:metadata>
+            <ns3:title>Scientific Linux 7</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:scientificlinux:scientificlinux:7" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      Scientific Linux 7</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria operator="AND">
+            <ns3:extend_definition comment="Installed OS is part of the Unix family" definition_ref="oval:ssg-installed_OS_is_part_of_Unix_family:def:1"/>
+            <ns3:criterion comment="Scientific Linux 7 is installed" test_ref="oval:ssg-test_sl7:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_sle11:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>SUSE Linux Enterprise 11</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:suse:linux_enterprise_server:11" source="CPE"/>
+            <ns3:reference ref_id="cpe:/o:suse:linux_enterprise_desktop:11" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      SUSE Linux Enterprise 11.</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Installed operating system is part of the unix family" test_ref="oval:ssg-test_sle11_unix_family:tst:1"/>
+            <ns3:criteria operator="OR">
+              <ns3:criterion comment="SLE 11 Desktop is installed" test_ref="oval:ssg-test_sle11_desktop:tst:1"/>
+              <ns3:criterion comment="SLE 11 Server is installed" test_ref="oval:ssg-test_sle11_server:tst:1"/>
+            </ns3:criteria>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_sle12:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>SUSE Linux Enterprise 12</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:suse:linux_enterprise_server:12" source="CPE"/>
+            <ns3:reference ref_id="cpe:/o:suse:linux_enterprise_desktop:12" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      SUSE Linux Enterprise 12.</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Installed operating system is part of the unix family" test_ref="oval:ssg-test_sle12_unix_family:tst:1"/>
+            <ns3:criteria operator="OR">
+              <ns3:criterion comment="SLE 12 Desktop is installed" test_ref="oval:ssg-test_sle12_desktop:tst:1"/>
+              <ns3:criterion comment="SLE 12 Server is installed" test_ref="oval:ssg-test_sle12_server:tst:1"/>
+            </ns3:criteria>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_sle15:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>SUSE Linux Enterprise 15</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:suse:linux_enterprise_server:15" source="CPE"/>
+            <ns3:reference ref_id="cpe:/o:suse:linux_enterprise_desktop:15" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      SUSE Linux Enterprise 15.</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Installed operating system is part of the unix family" test_ref="oval:ssg-test_sle15_unix_family:tst:1"/>
+            <ns3:criteria operator="OR">
+              <ns3:criterion comment="SLE 15 Desktop is installed" test_ref="oval:ssg-test_sle15_desktop:tst:1"/>
+              <ns3:criterion comment="SLE 15 Server is installed" test_ref="oval:ssg-test_sle15_server:tst:1"/>
+            </ns3:criteria>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_ubuntu:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Ubuntu</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>The operating system installed is an Ubuntu System</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria comment="System is Ubuntu" operator="AND">
+            <ns3:extend_definition comment="Installed OS is part of the Unix family" definition_ref="oval:ssg-installed_OS_is_part_of_Unix_family:def:1"/>
+            <ns3:criterion comment="lsb-based distrib" test_ref="oval:ssg-test_lsb:tst:1"/>
+            <ns3:criterion comment="Ubuntu is installed" test_ref="oval:ssg-test_ubuntu:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_ubuntu1404:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Ubuntu 1404</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:canonical:ubuntu_linux:14.04" source="CPE"/>
+            <ns3:description>The operating system installed on the system is Ubuntu 1404</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria comment="current Ubuntu version is Trusty" operator="AND">
+            <ns3:extend_definition comment="Ubuntu is installed" definition_ref="oval:ssg-installed_OS_is_ubuntu:def:1"/>
+            <ns3:criterion comment="Trusty is installed" test_ref="oval:ssg-test_ubuntu_trusty:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_ubuntu1604:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Ubuntu 1604</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:canonical:ubuntu_linux:16.04" source="CPE"/>
+            <ns3:description>The operating system installed on the system is Ubuntu 1604</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria comment="current Ubuntu version is Xenial" operator="AND">
+            <ns3:extend_definition comment="Ubuntu is installed" definition_ref="oval:ssg-installed_OS_is_ubuntu:def:1"/>
+            <ns3:criterion comment="Xenial is installed" test_ref="oval:ssg-test_ubuntu_xenial:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_ubuntu1804:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Ubuntu 1804</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:canonical:ubuntu_linux:18.04" source="CPE"/>
+            <ns3:description>The operating system installed on the system is Ubuntu 1804</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria comment="current Ubuntu version is Bionic" operator="AND">
+            <ns3:extend_definition comment="Ubuntu is installed" definition_ref="oval:ssg-installed_OS_is_ubuntu:def:1"/>
+            <ns3:criterion comment="Bionic is installed" test_ref="oval:ssg-test_ubuntu_bionic:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_wrlinux1019:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>WRLinux 1019</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:windriver:wrlinux" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      Wind River Linux 1019</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria operator="AND">
+            <ns3:criterion comment="Installed operating system is part of the unix family" test_ref="oval:ssg-test_unix_wrlinux1019:tst:1"/>
+            <ns3:criterion comment="Produce name is WRLinux" test_ref="oval:ssg-test_wrlinux1019_name:tst:1"/>
+            <ns3:criterion comment="WRLinux version is 1019" test_ref="oval:ssg-test_wrlinux1019_version:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_OS_is_wrlinux8:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>WRLinux 8</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/o:windriver:wrlinux" source="CPE"/>
+            <ns3:description>The operating system installed on the system is
+      Wind River Linux 8</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria comment="current WRLinux version is WRLinux8" operator="AND">
+            <ns3:criterion comment="Installed operating system is part of the unix family" test_ref="oval:ssg-test_unix_wrlinux8:tst:1"/>
+            <ns3:criterion comment="WRLinux 8 is installed" test_ref="oval:ssg-test_wrlinux8_version:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_app_is_ocp3:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Red Hat OpenShift Container Platform</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/a:redhat:openshift_container_platform:3.10" source="CPE"/>
+            <ns3:reference ref_id="cpe:/a:redhat:openshift_container_platform:3.11" source="CPE"/>
+            <ns3:description>The application installed installed on the system is
+      OpenShift 3.</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:extend_definition comment="RHEL7 OS installed" definition_ref="oval:ssg-installed_OS_is_rhel7:def:1"/>
+            <ns3:criterion comment="OpenShift Node is installed" test_ref="oval:ssg-test_ocp3_node:tst:1"/>
+            <ns3:criterion comment="OpenShift Hyperkube is installed" test_ref="oval:ssg-test_ocp3_hyperkube:tst:1"/>
+            <ns3:criterion comment="Atomic OpenShift is installed" test_ref="oval:ssg-test_ocp3_atomic:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_app_is_ocp4:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Red Hat OpenShift Container Platform</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/a:redhat:openshift_container_platform:4.1" source="CPE"/>
+            <ns3:description>The application installed installed on the system is OpenShift 4.</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:extend_definition comment="RHEL8 OS installed" definition_ref="oval:ssg-installed_OS_is_rhel8:def:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_app_is_rhosp10:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Red Hat OpenStack Platform</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/a:redhat:openstack:10" source="CPE"/>
+            <ns3:description>The application installed installed on the system is
+      Red Hat OpenStack Platform 10.</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:extend_definition comment="RHEL7 OS installed" definition_ref="oval:ssg-installed_OS_is_rhel7:def:1"/>
+            <ns3:criterion comment="OpenStack is installed" test_ref="oval:ssg-test_rhosp10_release:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_app_is_rhosp13:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Red Hat OpenStack Platform</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/a:redhat:openstack:13.0" source="CPE"/>
+            <ns3:description>The application installed installed on the system is
+      Red Hat OpenStack Platform 13.</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:extend_definition comment="RHEL7 OS installed" definition_ref="oval:ssg-installed_OS_is_rhel7:def:1"/>
+            <ns3:criterion comment="OpenStack is installed" test_ref="oval:ssg-test_rhosp13_release:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_app_is_rhv4:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Red Hat Virtualization 4</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:reference ref_id="cpe:/a:redhat:virtualization:4" source="CPE"/>
+            <ns3:description>The application installed installed on the system is
+      Red Hat Virtualization 4.</ns3:description>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:extend_definition comment="RHEL7 OS installed" definition_ref="oval:ssg-installed_OS_is_rhel7:def:1"/>
+            <ns3:criterion comment="Red Hat Virtualization Manager (RHVM)" test_ref="oval:ssg-test_rhevm4_version:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_env_has_chrony_package:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Package chrony is installed</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>Checks if package chrony is installed.</ns3:description>
+            <ns3:reference ref_id="cpe:/a:chrony" source="CPE"/>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Package chrony is installed" test_ref="oval:ssg-test_env_has_chrony_installed:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_env_has_gdm_package:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Package gdm is installed</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>Checks if package gdm is installed.</ns3:description>
+            <ns3:reference ref_id="cpe:/a:gdm" source="CPE"/>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Package gdm is installed" test_ref="oval:ssg-test_env_has_gdm_installed:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_env_has_libuser_package:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Package libuser is installed</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>Checks if package libuser is installed.</ns3:description>
+            <ns3:reference ref_id="cpe:/a:libuser" source="CPE"/>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Package libuser is installed" test_ref="oval:ssg-test_env_has_libuser_installed:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_env_has_login_defs:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Package providing /etc/login.defs is installed</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>Checks if package providing /etc/login.defs and is installed.</ns3:description>
+            <ns3:reference ref_id="cpe:/a:login_defs" source="CPE"/>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Package providing /etc/login.defs is installed" test_ref="oval:ssg-test_env_has_login_defs_installed:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_env_has_nss-pam-ldapd_package:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Package nss-pam-ldapd is installed</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>Checks if package nss-pam-ldapd is installed.</ns3:description>
+            <ns3:reference ref_id="cpe:/a:nss-pam-ldapd" source="CPE"/>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Package nss-pam-ldapd is installed" test_ref="oval:ssg-test_env_has_nss-pam-ldapd_installed:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_env_has_ntp_package:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Package ntp is installed</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>Checks if package ntp is installed.</ns3:description>
+            <ns3:reference ref_id="cpe:/a:ntp" source="CPE"/>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Package ntp is installed" test_ref="oval:ssg-test_env_has_ntp_installed:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_env_has_pam_package:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Package pam is installed</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>Checks if package pam is installed.</ns3:description>
+            <ns3:reference ref_id="cpe:/a:pam" source="CPE"/>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Package pam is installed" test_ref="oval:ssg-test_env_has_pam_installed:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_env_has_sssd-common_package:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Package sssd-common is installed</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>Checks if package sssd-common is installed.</ns3:description>
+            <ns3:reference ref_id="cpe:/a:sssd" source="CPE"/>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Package sssd-common is installed" test_ref="oval:ssg-test_env_has_sssd-common_installed:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_env_has_systemd_package:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Package systemd is installed</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>Checks if package systemd is installed.</ns3:description>
+            <ns3:reference ref_id="cpe:/a:systemd" source="CPE"/>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Package systemd is installed" test_ref="oval:ssg-test_env_has_systemd_installed:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_env_has_yum_package:def:1" version="1">
+          <ns3:metadata>
+            <ns3:title>Package yum is installed</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>Checks if package yum is installed.</ns3:description>
+            <ns3:reference ref_id="cpe:/a:yum" source="CPE"/>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:criterion comment="Package yum is installed" test_ref="oval:ssg-test_env_has_yum_installed:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_env_is_a_container:def:1" version="2">
+          <ns3:metadata>
+            <ns3:title>Check if the scan target is a container</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>Check for presence of files characterizing container filesystems.</ns3:description>
+            <ns3:reference ref_id="cpe:/a:container" source="CPE"/>
+          </ns3:metadata>
+          <ns3:criteria operator="OR">
+            <ns3:criterion comment="Check if /.dockerenv exists" test_ref="oval:ssg-test_installed_env_is_a_docker_container:tst:1"/>
+            <ns3:criterion comment="Check if /run/.containerenv exists" test_ref="oval:ssg-test_installed_env_is_a_podman_container:tst:1"/>
+          </ns3:criteria>
+        </ns3:definition>
+        <ns3:definition class="inventory" id="oval:ssg-installed_env_is_a_machine:def:1" version="2">
+          <ns3:metadata>
+            <ns3:title>Check if the scan target is a machine</ns3:title>
+            <ns3:affected family="unix">
+              <ns3:platform>Red Hat OpenShift Container Platform 4</ns3:platform>
+            </ns3:affected>
+            <ns3:description>Check for absence of files characterizing container filesystems.</ns3:description>
+            <ns3:reference ref_id="cpe:/a:machine" source="CPE"/>
+          </ns3:metadata>
+          <ns3:criteria>
+            <ns3:extend_definition comment="If environment is not a container, it is machine" definition_ref="oval:ssg-installed_env_is_a_container:def:1" negate="true"/>
+          </ns3:criteria>
+        </ns3:definition>
+      </ns3:definitions>
+      <ns3:tests>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 6" id="oval:ssg-test_centos6:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_centos6:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_centos6:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 7" id="oval:ssg-test_centos7:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_centos7:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_centos7:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 8" id="oval:ssg-test_centos8:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_centos8:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_centos8:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns7:file_test check="all" check_existence="all_exist" comment="/etc/debian_version exists" id="oval:ssg-test_debian:tst:1" version="1">
+          <ns7:object object_ref="oval:ssg-obj_debian:obj:1"/>
+        </ns7:file_test>
+        <ns6:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check Debian version" id="oval:ssg-test_debian_10:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_debian_10:obj:1"/>
+        </ns6:textfilecontent54_test>
+        <ns6:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check Debian version" id="oval:ssg-test_debian_8:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_debian_8:obj:1"/>
+        </ns6:textfilecontent54_test>
+        <ns6:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check Debian version" id="oval:ssg-test_debian_9:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_debian_9:obj:1"/>
+        </ns6:textfilecontent54_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="fedora-release RPM packages are installed" id="oval:ssg-test_fedora_release_rpm:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-object_fedora_release_rpm:obj:1"/>
+        </ns8:rpminfo_test>
+        <ns6:textfilecontent54_test check="all" comment="CPE vendor is 'fedoraproject' and 'product' is fedora" id="oval:ssg-test_fedora_vendor_product:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-object_fedora_vendor_product:obj:1"/>
+        </ns6:textfilecontent54_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="oraclelinux-release is version 6" id="oval:ssg-test_ol6_system:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_ol6_system:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_ol6_system:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="oraclelinux-release is version 7" id="oval:ssg-test_ol7_system:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_ol7_system:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_ol7_system:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="oraclelinux-release is version 8" id="oval:ssg-test_ol8_system:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_ol8_system:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_ol8_system:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="openSUSE is installed" id="oval:ssg-test_opensuse_installed:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_opensuse_installed:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_opensuse_installed:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="openSUSE Leap 15 is installed" id="oval:ssg-test_opensuse_leap15_installed:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_opensuse_leap15_installed:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_opensuse_leap15_installed:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="openSUSE Leap 42 is installed" id="oval:ssg-test_opensuse_leap42_installed:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_opensuse_leap42_installed:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_opensuse_leap42_installed:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns6:family_test check="all" check_existence="at_least_one_exists" comment="Test installed OS is part of the unix family" id="oval:ssg-test_unix_family:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-object_unix_family:obj:1"/>
+          <ns6:state state_ref="oval:ssg-state_unix_family:ste:1"/>
+        </ns6:family_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-client is version 6" id="oval:ssg-test_rhel_client:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_rhel_client:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_rhel_client:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-workstation is version 6" id="oval:ssg-test_rhel_workstation:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_rhel_workstation:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_rhel_workstation:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-server is version 6" id="oval:ssg-test_rhel_server:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_rhel_server:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_rhel_server:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-computenode is version 6" id="oval:ssg-test_rhel_computenode:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_rhel_computenode:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_rhel_computenode:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns6:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="oval:ssg-test_rhel7_unix_family:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_rhel7_unix_family:obj:1"/>
+          <ns6:state state_ref="oval:ssg-state_rhel7_unix_family:ste:1"/>
+        </ns6:family_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-client is version 7" id="oval:ssg-test_rhel7_client:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_rhel7_client:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_rhel7_client:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-workstation is version 7" id="oval:ssg-test_rhel7_workstation:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_rhel7_workstation:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_rhel7_workstation:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-server is version 7" id="oval:ssg-test_rhel7_server:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_rhel7_server:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_rhel7_server:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-computenode is version 7" id="oval:ssg-test_rhel7_computenode:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_rhel7_computenode:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_rhel7_computenode:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns6:textfilecontent54_test check="all" comment="RHEVH base RHEL is version 7" id="oval:ssg-test_rhevh_rhel7_version:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_rhevh_rhel7_version:obj:1"/>
+          <ns6:state state_ref="oval:ssg-state_rhevh_rhel7_version:ste:1"/>
+        </ns6:textfilecontent54_test>
+        <ns6:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="oval:ssg-test_rhel8_unix_family:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_rhel8_unix_family:obj:1"/>
+          <ns6:state state_ref="oval:ssg-state_rhel8_unix_family:ste:1"/>
+        </ns6:family_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8" id="oval:ssg-test_rhel8:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_rhel8:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_rhel8:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns6:textfilecontent54_test check="all" comment="redhat-release-coreos is version 8" id="oval:ssg-test_rhel8_coreos:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_rhel8_coreos:obj:1"/>
+          <ns6:state state_ref="oval:ssg-state_rhel8_coreos:ste:1"/>
+        </ns6:textfilecontent54_test>
+        <ns6:textfilecontent54_test check="all" comment="RHEVH base RHEL is version 8" id="oval:ssg-test_rhevh_rhel8_version:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_rhevh_rhel8_version:obj:1"/>
+          <ns6:state state_ref="oval:ssg-state_rhevh_rhel8_version:ste:1"/>
+        </ns6:textfilecontent54_test>
+        <ns8:rpminfo_test check="all" check_existence="only_one_exists" comment="redhat-release-virtualization-host RPM package is installed" id="oval:ssg-test_rhvh4_version:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_rhvh4_version:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_rhvh4_version:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sl-release is version 6" id="oval:ssg-test_sl6:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_sl6:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_sl6:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sl-release is version 7" id="oval:ssg-test_sl7:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_sl7:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_sl7:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns6:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="oval:ssg-test_sle11_unix_family:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_sle11_unix_family:obj:1"/>
+          <ns6:state state_ref="oval:ssg-state_sle11_unix_family:ste:1"/>
+        </ns6:family_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sled-release is version 6" id="oval:ssg-test_sle11_desktop:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_sle11_desktop:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_sle11_desktop:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sles-release is version 6" id="oval:ssg-test_sle11_server:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_sle11_server:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_sle11_server:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns6:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="oval:ssg-test_sle12_unix_family:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_sle12_unix_family:obj:1"/>
+          <ns6:state state_ref="oval:ssg-state_sle12_unix_family:ste:1"/>
+        </ns6:family_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sled-release is version 6" id="oval:ssg-test_sle12_desktop:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_sle12_desktop:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_sle12_desktop:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sles-release is version 6" id="oval:ssg-test_sle12_server:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_sle12_server:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_sle12_server:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns6:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="oval:ssg-test_sle15_unix_family:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_sle15_unix_family:obj:1"/>
+          <ns6:state state_ref="oval:ssg-state_sle15_unix_family:ste:1"/>
+        </ns6:family_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sled-release is version 15" id="oval:ssg-test_sle15_desktop:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_sle15_desktop:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_sle15_desktop:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sles-release is version 15" id="oval:ssg-test_sle15_server:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_sle15_server:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_sle15_server:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns7:file_test check="all" check_existence="all_exist" comment="/etc/lsb-release exists" id="oval:ssg-test_lsb:tst:1" version="1">
+          <ns7:object object_ref="oval:ssg-obj_lsb:obj:1"/>
+        </ns7:file_test>
+        <ns6:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check Ubuntu" id="oval:ssg-test_ubuntu:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_ubuntu:obj:1"/>
+        </ns6:textfilecontent54_test>
+        <ns6:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check Ubuntu version" id="oval:ssg-test_ubuntu_trusty:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_ubuntu_trusty:obj:1"/>
+        </ns6:textfilecontent54_test>
+        <ns6:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check Ubuntu version" id="oval:ssg-test_ubuntu_xenial:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_ubuntu_xenial:obj:1"/>
+        </ns6:textfilecontent54_test>
+        <ns6:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check Ubuntu version" id="oval:ssg-test_ubuntu_bionic:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_ubuntu_bionic:obj:1"/>
+        </ns6:textfilecontent54_test>
+        <ns6:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="oval:ssg-test_unix_wrlinux1019:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_unix_wrlinux1019:obj:1"/>
+          <ns6:state state_ref="oval:ssg-state_unix_wrlinux1019:ste:1"/>
+        </ns6:family_test>
+        <ns6:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check WRLinux10.19 version" id="oval:ssg-test_wrlinux1019_name:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_name_wrlinux1019:obj:1"/>
+        </ns6:textfilecontent54_test>
+        <ns6:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check WRLinux10.19 version" id="oval:ssg-test_wrlinux1019_version:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_version_wrlinux1019:obj:1"/>
+        </ns6:textfilecontent54_test>
+        <ns6:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="oval:ssg-test_unix_wrlinux8:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_unix_wrlinux8:obj:1"/>
+          <ns6:state state_ref="oval:ssg-state_unix_wrlinux8:ste:1"/>
+        </ns6:family_test>
+        <ns6:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check WRLinux8 version" id="oval:ssg-test_wrlinux8_version:tst:1" version="1">
+          <ns6:object object_ref="oval:ssg-obj_version_wrlinux8:obj:1"/>
+        </ns6:textfilecontent54_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="atomic-openshift is version 3" id="oval:ssg-test_ocp3_atomic:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_ocp3_atomic:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_ocp3_atomic:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="atomic-openshift-node is version 3" id="oval:ssg-test_ocp3_node:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_ocp3_node:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_ocp3_node:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="atomic-openshift-hyperkube is version 3" id="oval:ssg-test_ocp3_hyperkube:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_ocp3_hyperkube:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_ocp3_hyperkube:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="OpenStack is version 10" id="oval:ssg-test_rhosp10_release:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_rhosp10_release:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_rhosp10_release:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="OpenStack is version 13" id="oval:ssg-test_rhosp13_release:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_rhosp13_release:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_rhosp13_release:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="rhevm4-appliance is installed" id="oval:ssg-test_rhevm4_version:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_rhevm4_version:obj:1"/>
+          <ns8:state state_ref="oval:ssg-state_rhevm4_version:ste:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="all_exist" comment="package chrony is installed" id="oval:ssg-test_env_has_chrony_installed:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_test_env_has_chrony_installed:obj:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="system has package gdm installed" id="oval:ssg-test_env_has_gdm_installed:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_env_has_gdm_installed:obj:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="system has package libuser installed" id="oval:ssg-test_env_has_libuser_installed:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_env_has_libuser_installed:obj:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="system has package shadow-utils installed, which provides the /etc/login.defs file." id="oval:ssg-test_env_has_login_defs_installed:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_env_has_login_defs_installed:obj:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="system has package nss-pam-ldapd installed" id="oval:ssg-test_env_has_nss-pam-ldapd_installed:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_env_has_nss-pam-ldapd_installed:obj:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="all_exist" comment="package ntp is installed" id="oval:ssg-test_env_has_ntp_installed:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_test_env_has_ntp_installed:obj:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="system has package pam installed" id="oval:ssg-test_env_has_pam_installed:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_env_has_pam_installed:obj:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="system has package sssd-common installed" id="oval:ssg-test_env_has_sssd-common_installed:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_env_has_sssd-common_installed:obj:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="system has package systemd installed" id="oval:ssg-test_env_has_systemd_installed:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_env_has_systemd_installed:obj:1"/>
+        </ns8:rpminfo_test>
+        <ns8:rpminfo_test check="all" check_existence="at_least_one_exists" comment="system has package yum installed" id="oval:ssg-test_env_has_yum_installed:tst:1" version="1">
+          <ns8:object object_ref="oval:ssg-obj_env_has_yum_installed:obj:1"/>
+        </ns8:rpminfo_test>
+        <ns7:file_test check="all" check_existence="all_exist" comment="Check if /.dockerenv exists" id="oval:ssg-test_installed_env_is_a_docker_container:tst:1" version="1">
+          <ns7:object object_ref="oval:ssg-object_installed_env_is_a_docker_container:obj:1"/>
+        </ns7:file_test>
+        <ns7:file_test check="all" check_existence="all_exist" comment="Check if /run/.containerenv exists" id="oval:ssg-test_installed_env_is_a_podman_container:tst:1" version="1">
+          <ns7:object object_ref="oval:ssg-object_installed_env_is_a_podman_container:obj:1"/>
+        </ns7:file_test>
+      </ns3:tests>
+      <ns3:objects>
+        <ns8:rpminfo_object id="oval:ssg-obj_centos6:obj:1" version="1">
+          <ns8:name>centos-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_centos7:obj:1" version="1">
+          <ns8:name>centos-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_centos8:obj:1" version="1">
+          <ns8:name>centos-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns7:file_object comment="check /etc/debian_version file" id="oval:ssg-obj_debian:obj:1" version="1">
+          <ns7:filepath>/etc/debian_version</ns7:filepath>
+        </ns7:file_object>
+        <ns6:textfilecontent54_object comment="Check Debian version" id="oval:ssg-obj_debian_10:obj:1" version="1">
+          <ns6:filepath>/etc/debian_version</ns6:filepath>
+          <ns6:pattern operation="pattern match">^10.[0-9]+$</ns6:pattern>
+          <ns6:instance datatype="int">1</ns6:instance>
+        </ns6:textfilecontent54_object>
+        <ns6:textfilecontent54_object comment="Check Debian version" id="oval:ssg-obj_debian_8:obj:1" version="1">
+          <ns6:filepath>/etc/debian_version</ns6:filepath>
+          <ns6:pattern operation="pattern match">^8.[0-9]+$</ns6:pattern>
+          <ns6:instance datatype="int">1</ns6:instance>
+        </ns6:textfilecontent54_object>
+        <ns6:textfilecontent54_object comment="Check Debian version" id="oval:ssg-obj_debian_9:obj:1" version="1">
+          <ns6:filepath>/etc/debian_version</ns6:filepath>
+          <ns6:pattern operation="pattern match">^9.[0-9]+$</ns6:pattern>
+          <ns6:instance datatype="int">1</ns6:instance>
+        </ns6:textfilecontent54_object>
+        <ns8:rpminfo_object id="oval:ssg-object_fedora_release_rpm:obj:1" version="1">
+          <ns8:name operation="pattern match">fedora-release.*</ns8:name>
+        </ns8:rpminfo_object>
+        <ns6:textfilecontent54_object id="oval:ssg-object_fedora_vendor_product:obj:1" version="1">
+          <ns6:filepath>/etc/system-release-cpe</ns6:filepath>
+          <ns6:pattern operation="pattern match">^cpe:\/o:fedoraproject:fedora:[\d]+$</ns6:pattern>
+          <ns6:instance datatype="int" operation="equals">1</ns6:instance>
+        </ns6:textfilecontent54_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_ol6_system:obj:1" version="1">
+          <ns8:name>oraclelinux-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_ol7_system:obj:1" version="1">
+          <ns8:name>oraclelinux-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_ol8_system:obj:1" version="1">
+          <ns8:name>oraclelinux-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_opensuse_installed:obj:1" version="1">
+          <ns8:name>openSUSE-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_opensuse_leap15_installed:obj:1" version="1">
+          <ns8:name>openSUSE-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_opensuse_leap42_installed:obj:1" version="1">
+          <ns8:name>openSUSE-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns6:family_object id="oval:ssg-object_unix_family:obj:1" version="1"/>
+        <ns8:rpminfo_object id="oval:ssg-obj_rhel_client:obj:1" version="1">
+          <ns8:name>redhat-release-client</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_rhel_workstation:obj:1" version="1">
+          <ns8:name>redhat-release-workstation</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_rhel_server:obj:1" version="1">
+          <ns8:name>redhat-release-server</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_rhel_computenode:obj:1" version="1">
+          <ns8:name>redhat-release-computenode</ns8:name>
+        </ns8:rpminfo_object>
+        <ns6:family_object id="oval:ssg-obj_rhel7_unix_family:obj:1" version="1"/>
+        <ns8:rpminfo_object id="oval:ssg-obj_rhel7_client:obj:1" version="1">
+          <ns8:name>redhat-release-client</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_rhel7_workstation:obj:1" version="1">
+          <ns8:name>redhat-release-workstation</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_rhel7_server:obj:1" version="1">
+          <ns8:name>redhat-release-server</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_rhel7_computenode:obj:1" version="1">
+          <ns8:name>redhat-release-computenode</ns8:name>
+        </ns8:rpminfo_object>
+        <ns6:textfilecontent54_object id="oval:ssg-obj_rhevh_rhel7_version:obj:1" version="1">
+          <ns6:filepath>/etc/redhat-release</ns6:filepath>
+          <ns6:pattern operation="pattern match">^Red Hat Enterprise Linux release (\d)\.\d+$</ns6:pattern>
+          <ns6:instance datatype="int" operation="greater than or equal">1</ns6:instance>
+        </ns6:textfilecontent54_object>
+        <ns6:family_object id="oval:ssg-obj_rhel8_unix_family:obj:1" version="1"/>
+        <ns8:rpminfo_object id="oval:ssg-obj_rhel8:obj:1" version="1">
+          <ns8:name>redhat-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns6:textfilecontent54_object id="oval:ssg-obj_rhel8_coreos:obj:1" version="1">
+          <ns6:filepath>/etc/os-release</ns6:filepath>
+          <ns6:pattern operation="pattern match">^PRETTY_NAME="Red Hat Enterprise Linux CoreOS \d+\.(\d)\d+\.[\d\.\-]+ \([\w\s]+\)"$</ns6:pattern>
+          <ns6:instance datatype="int" operation="greater than or equal">1</ns6:instance>
+        </ns6:textfilecontent54_object>
+        <ns6:textfilecontent54_object id="oval:ssg-obj_rhevh_rhel8_version:obj:1" version="1">
+          <ns6:filepath>/etc/redhat-release</ns6:filepath>
+          <ns6:pattern operation="pattern match">^Red Hat Enterprise Linux release (\d)\.\d+$</ns6:pattern>
+          <ns6:instance datatype="int" operation="greater than or equal">1</ns6:instance>
+        </ns6:textfilecontent54_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_rhvh4_version:obj:1" version="1">
+          <ns8:name>redhat-release-virtualization-host</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_sl6:obj:1" version="1">
+          <ns8:name>sl-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_sl7:obj:1" version="1">
+          <ns8:name>sl-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns6:family_object id="oval:ssg-obj_sle11_unix_family:obj:1" version="1"/>
+        <ns8:rpminfo_object id="oval:ssg-obj_sle11_desktop:obj:1" version="1">
+          <ns8:name>sled-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_sle11_server:obj:1" version="1">
+          <ns8:name>sles-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns6:family_object id="oval:ssg-obj_sle12_unix_family:obj:1" version="1"/>
+        <ns8:rpminfo_object id="oval:ssg-obj_sle12_desktop:obj:1" version="1">
+          <ns8:name>sled-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_sle12_server:obj:1" version="1">
+          <ns8:name>sles-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns6:family_object id="oval:ssg-obj_sle15_unix_family:obj:1" version="1"/>
+        <ns8:rpminfo_object id="oval:ssg-obj_sle15_desktop:obj:1" version="1">
+          <ns8:name>sled-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_sle15_server:obj:1" version="1">
+          <ns8:name>sles-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns7:file_object comment="check /etc/lsb-release file" id="oval:ssg-obj_lsb:obj:1" version="1">
+          <ns7:filepath>/etc/lsb-release</ns7:filepath>
+        </ns7:file_object>
+        <ns6:textfilecontent54_object comment="Check Ubuntu" id="oval:ssg-obj_ubuntu:obj:1" version="1">
+          <ns6:filepath>/etc/lsb-release</ns6:filepath>
+          <ns6:pattern operation="pattern match">^DISTRIB_ID=Ubuntu$</ns6:pattern>
+          <ns6:instance datatype="int">1</ns6:instance>
+        </ns6:textfilecontent54_object>
+        <ns6:textfilecontent54_object comment="Check Ubuntu version" id="oval:ssg-obj_ubuntu_trusty:obj:1" version="1">
+          <ns6:filepath>/etc/lsb-release</ns6:filepath>
+          <ns6:pattern operation="pattern match">^DISTRIB_CODENAME=trusty$</ns6:pattern>
+          <ns6:instance datatype="int">1</ns6:instance>
+        </ns6:textfilecontent54_object>
+        <ns6:textfilecontent54_object comment="Check Ubuntu version" id="oval:ssg-obj_ubuntu_xenial:obj:1" version="1">
+          <ns6:filepath>/etc/lsb-release</ns6:filepath>
+          <ns6:pattern operation="pattern match">^DISTRIB_CODENAME=xenial$</ns6:pattern>
+          <ns6:instance datatype="int">1</ns6:instance>
+        </ns6:textfilecontent54_object>
+        <ns6:textfilecontent54_object comment="Check Ubuntu version" id="oval:ssg-obj_ubuntu_bionic:obj:1" version="1">
+          <ns6:filepath>/etc/lsb-release</ns6:filepath>
+          <ns6:pattern operation="pattern match">^DISTRIB_CODENAME=bionic$</ns6:pattern>
+          <ns6:instance datatype="int">1</ns6:instance>
+        </ns6:textfilecontent54_object>
+        <ns6:family_object id="oval:ssg-obj_unix_wrlinux1019:obj:1" version="1"/>
+        <ns6:textfilecontent54_object comment="Check WRLinux1019 produce name" id="oval:ssg-obj_name_wrlinux1019:obj:1" version="1">
+          <ns6:filepath>/etc/os-release</ns6:filepath>
+          <ns6:pattern operation="pattern match">^NAME=.Wind[\s]+River[\s]+Linux.*$</ns6:pattern>
+          <ns6:instance datatype="int">1</ns6:instance>
+        </ns6:textfilecontent54_object>
+        <ns6:textfilecontent54_object comment="Check WRLinux1019 version" id="oval:ssg-obj_version_wrlinux1019:obj:1" version="1">
+          <ns6:filepath>/etc/os-release</ns6:filepath>
+          <ns6:pattern operation="pattern match">^VERSION=.10\.19.*$</ns6:pattern>
+          <ns6:instance datatype="int">1</ns6:instance>
+        </ns6:textfilecontent54_object>
+        <ns6:family_object id="oval:ssg-obj_unix_wrlinux8:obj:1" version="1"/>
+        <ns6:textfilecontent54_object comment="Check WRLinux8 version" id="oval:ssg-obj_version_wrlinux8:obj:1" version="1">
+          <ns6:filepath>/etc/wrlinux-release</ns6:filepath>
+          <ns6:pattern operation="pattern match">^VERSION=.8\.0.*$</ns6:pattern>
+          <ns6:instance datatype="int">1</ns6:instance>
+        </ns6:textfilecontent54_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_ocp3_atomic:obj:1" version="1">
+          <ns8:name>atomic-openshift</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_ocp3_node:obj:1" version="1">
+          <ns8:name>atomic-openshift-node</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_ocp3_hyperkube:obj:1" version="1">
+          <ns8:name>atomic-openshift-hyperkube</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_rhosp10_release:obj:1" version="1">
+          <ns8:name>rhosp-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_rhosp13_release:obj:1" version="1">
+          <ns8:name>rhosp-release</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_rhevm4_version:obj:1" version="1">
+          <ns8:name>rhvm-appliance</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_test_env_has_chrony_installed:obj:1" version="1">
+          <ns8:name>chrony</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_env_has_gdm_installed:obj:1" version="1">
+          <ns8:name>gdm</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_env_has_libuser_installed:obj:1" version="1">
+          <ns8:name>libuser</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_env_has_login_defs_installed:obj:1" version="1">
+          <ns8:name>shadow-utils</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_env_has_nss-pam-ldapd_installed:obj:1" version="1">
+          <ns8:name>nss-pam-ldapd</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_test_env_has_ntp_installed:obj:1" version="1">
+          <ns8:name>ntp</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_env_has_pam_installed:obj:1" version="1">
+          <ns8:name>pam</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_env_has_sssd-common_installed:obj:1" version="1">
+          <ns8:name>sssd-common</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_env_has_systemd_installed:obj:1" version="1">
+          <ns8:name>systemd</ns8:name>
+        </ns8:rpminfo_object>
+        <ns8:rpminfo_object id="oval:ssg-obj_env_has_yum_installed:obj:1" version="1">
+          <ns8:name>yum</ns8:name>
+        </ns8:rpminfo_object>
+        <ns7:file_object comment="Check file /.dockerenv" id="oval:ssg-object_installed_env_is_a_docker_container:obj:1" version="1">
+          <ns7:filepath datatype="string">/.dockerenv</ns7:filepath>
+        </ns7:file_object>
+        <ns7:file_object comment="Check file /run/.containerenv" id="oval:ssg-object_installed_env_is_a_podman_container:obj:1" version="1">
+          <ns7:filepath datatype="string">/run/.containerenv</ns7:filepath>
+        </ns7:file_object>
+      </ns3:objects>
+      <ns3:states>
+        <ns8:rpminfo_state id="oval:ssg-state_centos6:ste:1" version="1">
+          <ns8:version operation="pattern match">^6.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_centos7:ste:1" version="1">
+          <ns8:version operation="pattern match">^7.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_centos8:ste:1" version="1">
+          <ns8:version operation="pattern match">^8.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_ol6_system:ste:1" version="1">
+          <ns8:version operation="pattern match">^6Server$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_ol7_system:ste:1" version="1">
+          <ns8:version operation="pattern match">^7.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_ol8_system:ste:1" version="1">
+          <ns8:version operation="pattern match">^8.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_opensuse_installed:ste:1" version="1">
+          <ns8:name operation="pattern match">openSUSE-release</ns8:name>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_opensuse_leap15_installed:ste:1" version="1">
+          <ns8:version operation="pattern match">^15.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_opensuse_leap42_installed:ste:1" version="1">
+          <ns8:version operation="pattern match">^42.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns6:family_state id="oval:ssg-state_unix_family:ste:1" version="1">
+          <ns6:family>unix</ns6:family>
+        </ns6:family_state>
+        <ns8:rpminfo_state id="oval:ssg-state_rhel_client:ste:1" version="1">
+          <ns8:version operation="pattern match">^6.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_rhel_workstation:ste:1" version="1">
+          <ns8:version operation="pattern match">^6.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_rhel_server:ste:1" version="1">
+          <ns8:version operation="pattern match">^6.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_rhel_computenode:ste:1" version="1">
+          <ns8:version operation="pattern match">^6.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns6:family_state id="oval:ssg-state_rhel7_unix_family:ste:1" version="1">
+          <ns6:family>unix</ns6:family>
+        </ns6:family_state>
+        <ns8:rpminfo_state id="oval:ssg-state_rhel7_client:ste:1" version="1">
+          <ns8:version operation="pattern match">^7.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_rhel7_workstation:ste:1" version="1">
+          <ns8:version operation="pattern match">^7.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_rhel7_server:ste:1" version="1">
+          <ns8:version operation="pattern match">^7.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_rhel7_computenode:ste:1" version="1">
+          <ns8:version operation="pattern match">^7.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns6:textfilecontent54_state id="oval:ssg-state_rhevh_rhel7_version:ste:1" version="1">
+          <ns6:subexpression operation="pattern match">7</ns6:subexpression>
+        </ns6:textfilecontent54_state>
+        <ns6:family_state id="oval:ssg-state_rhel8_unix_family:ste:1" version="1">
+          <ns6:family>unix</ns6:family>
+        </ns6:family_state>
+        <ns8:rpminfo_state id="oval:ssg-state_rhel8:ste:1" version="1">
+          <ns8:version operation="pattern match">^8.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns6:textfilecontent54_state id="oval:ssg-state_rhel8_coreos:ste:1" version="1">
+          <ns6:subexpression operation="pattern match">8</ns6:subexpression>
+        </ns6:textfilecontent54_state>
+        <ns6:textfilecontent54_state id="oval:ssg-state_rhevh_rhel8_version:ste:1" version="1">
+          <ns6:subexpression operation="pattern match">8</ns6:subexpression>
+        </ns6:textfilecontent54_state>
+        <ns8:rpminfo_state id="oval:ssg-state_rhvh4_version:ste:1" version="1">
+          <ns8:evr datatype="evr_string" operation="greater than or equal">0:4.4</ns8:evr>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_sl6:ste:1" version="1">
+          <ns8:version operation="pattern match">^6.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_sl7:ste:1" version="1">
+          <ns8:version operation="pattern match">^7.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns6:family_state id="oval:ssg-state_sle11_unix_family:ste:1" version="1">
+          <ns6:family>unix</ns6:family>
+        </ns6:family_state>
+        <ns8:rpminfo_state id="oval:ssg-state_sle11_desktop:ste:1" version="1">
+          <ns8:version operation="pattern match">^11.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_sle11_server:ste:1" version="1">
+          <ns8:version operation="pattern match">^11.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns6:family_state id="oval:ssg-state_sle12_unix_family:ste:1" version="1">
+          <ns6:family>unix</ns6:family>
+        </ns6:family_state>
+        <ns8:rpminfo_state id="oval:ssg-state_sle12_desktop:ste:1" version="1">
+          <ns8:version operation="pattern match">^12.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_sle12_server:ste:1" version="1">
+          <ns8:version operation="pattern match">^12.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns6:family_state id="oval:ssg-state_sle15_unix_family:ste:1" version="1">
+          <ns6:family>unix</ns6:family>
+        </ns6:family_state>
+        <ns8:rpminfo_state id="oval:ssg-state_sle15_desktop:ste:1" version="1">
+          <ns8:version operation="pattern match">^15.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_sle15_server:ste:1" version="1">
+          <ns8:version operation="pattern match">^15.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns6:family_state id="oval:ssg-state_unix_wrlinux1019:ste:1" version="1">
+          <ns6:family>unix</ns6:family>
+        </ns6:family_state>
+        <ns6:family_state id="oval:ssg-state_unix_wrlinux8:ste:1" version="1">
+          <ns6:family>unix</ns6:family>
+        </ns6:family_state>
+        <ns8:rpminfo_state id="oval:ssg-state_ocp3_atomic:ste:1" version="1">
+          <ns8:version operation="pattern match">^3.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_ocp3_node:ste:1" version="1">
+          <ns8:version operation="pattern match">^3.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_ocp3_hyperkube:ste:1" version="1">
+          <ns8:version operation="pattern match">^3.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_rhosp10_release:ste:1" version="1">
+          <ns8:version operation="pattern match">^10.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_rhosp13_release:ste:1" version="1">
+          <ns8:version operation="pattern match">^13.*$</ns8:version>
+        </ns8:rpminfo_state>
+        <ns8:rpminfo_state id="oval:ssg-state_rhevm4_version:ste:1" version="1">
+          <ns8:version operation="pattern match">^4.*$</ns8:version>
+        </ns8:rpminfo_state>
+      </ns3:states>
+    </ns3:oval_definitions>
+  </ns0:component>
+  <ns0:component id="scap_org.open-scap_comp_ssg-ocp4-cpe-dictionary.xml" timestamp="2020-04-20T13:24:48">
+    <ns13:cpe-list xsi:schemaLocation="http://cpe.mitre.org/dictionary/2.0 http://cpe.mitre.org/files/cpe-dictionary_2.1.xsd">
+      <ns13:cpe-item name="cpe:/a:redhat:openshift_container_platform:4.1">
+        <ns13:title xml:lang="en-us">Red Hat OpenShift Container Platform 4</ns13:title>
+        <ns13:check href="ssg-ocp4-cpe-oval.xml" system="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:ssg-installed_app_is_ocp4:def:1</ns13:check>
+      </ns13:cpe-item>
+      <ns13:cpe-item name="cpe:/a:machine">
+        <ns13:title xml:lang="en-us">Bare-metal or Virtual Machine</ns13:title>
+        <ns13:check href="ssg-ocp4-cpe-oval.xml" system="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:ssg-installed_env_is_a_machine:def:1</ns13:check>
+      </ns13:cpe-item>
+      <ns13:cpe-item name="cpe:/a:chrony">
+        <ns13:title xml:lang="en-us">Package chrony is installed</ns13:title>
+        <ns13:check href="ssg-ocp4-cpe-oval.xml" system="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:ssg-installed_env_has_chrony_package:def:1</ns13:check>
+      </ns13:cpe-item>
+      <ns13:cpe-item name="cpe:/a:gdm">
+        <ns13:title xml:lang="en-us">Package gdm is installed</ns13:title>
+        <ns13:check href="ssg-ocp4-cpe-oval.xml" system="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:ssg-installed_env_has_gdm_package:def:1</ns13:check>
+      </ns13:cpe-item>
+      <ns13:cpe-item name="cpe:/a:login_defs">
+        <ns13:title xml:lang="en-us">Package providing /etc/login.defs is installed</ns13:title>
+        <ns13:check href="ssg-ocp4-cpe-oval.xml" system="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:ssg-installed_env_has_login_defs:def:1</ns13:check>
+      </ns13:cpe-item>
+      <ns13:cpe-item name="cpe:/a:sssd">
+        <ns13:title xml:lang="en-us">Package sssd-common is installed</ns13:title>
+        <ns13:check href="ssg-ocp4-cpe-oval.xml" system="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:ssg-installed_env_has_sssd-common_package:def:1</ns13:check>
+      </ns13:cpe-item>
+      <ns13:cpe-item name="cpe:/a:pam">
+        <ns13:title xml:lang="en-us">Package pam is installed</ns13:title>
+        <ns13:check href="ssg-ocp4-cpe-oval.xml" system="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:ssg-installed_env_has_pam_package:def:1</ns13:check>
+      </ns13:cpe-item>
+      <ns13:cpe-item name="cpe:/a:libuser">
+        <ns13:title xml:lang="en-us">Package libuser is installed</ns13:title>
+        <ns13:check href="ssg-ocp4-cpe-oval.xml" system="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:ssg-installed_env_has_libuser_package:def:1</ns13:check>
+      </ns13:cpe-item>
+      <ns13:cpe-item name="cpe:/a:nss-pam-ldapd">
+        <ns13:title xml:lang="en-us">Package nss-pam-ldapd is installed</ns13:title>
+        <ns13:check href="ssg-ocp4-cpe-oval.xml" system="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:ssg-installed_env_has_nss-pam-ldapd_package:def:1</ns13:check>
+      </ns13:cpe-item>
+      <ns13:cpe-item name="cpe:/a:systemd">
+        <ns13:title xml:lang="en-us">Package systemd is installed</ns13:title>
+        <ns13:check href="ssg-ocp4-cpe-oval.xml" system="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:ssg-installed_env_has_systemd_package:def:1</ns13:check>
+      </ns13:cpe-item>
+      <ns13:cpe-item name="cpe:/a:yum">
+        <ns13:title xml:lang="en-us">Package yum is installed</ns13:title>
+        <ns13:check href="ssg-ocp4-cpe-oval.xml" system="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:ssg-installed_env_has_yum_package:def:1</ns13:check>
+      </ns13:cpe-item>
+    </ns13:cpe-list>
+  </ns0:component>
+</ns0:data-stream-collection>


### PR DESCRIPTION
This enables the "Platform" scan type. The added api-resource-collector component runs as an init container for the platform scan pod. It fetches API objects using a generic client (The cluster's API URL is found by the in-cluster kubeconfig) and saves them to temporary files to be read by the scanner in an offline mode. The API object paths for a scan are sourced from the provided content image and selected by profile. 