### PR TITLE
Shorten remediation annotations in MachineConfig

### DIFF
--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -27,7 +27,7 @@ import (
 var log = logf.Log.WithName("remediationctrl")
 
 const (
-	remediationNameAnnotationKey = "remediation.compliance.openshift.io/"
+	remediationNameAnnotationKey = "remediation/"
 )
 
 // Add creates a new ComplianceRemediation Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -368,7 +368,7 @@ func updateMachineConfig(r *ReconcileComplianceRemediation, current *mcfgv1.Mach
 }
 
 func getRemediationAnnotationKey(remName string) string {
-	return remediationNameAnnotationKey + remName
+	return utils.DNSLengthName(remediationNameAnnotationKey, remediationNameAnnotationKey+"%s", remName)
 }
 
 func ensureRemediationAnnotationIsSet(mc *mcfgv1.MachineConfig, rem *compv1alpha1.ComplianceRemediation) {

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -11,12 +11,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/openshift/compliance-operator/pkg/utils"
 )
 
 const aggregatorSA = "remediation-aggregator"
 
 func createAggregatorPodName(scanName string) string {
-	return dnsLengthName("aggregator-pod-", "aggregator-pod-%s", scanName)
+	return utils.DNSLengthName("aggregator-pod-", "aggregator-pod-%s", scanName)
 }
 
 func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Logger) *corev1.Pod {

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/openshift/compliance-operator/pkg/utils"
 )
 
 var log = logf.Log.WithName("scanctrl")
@@ -479,11 +480,11 @@ func getPVCForScan(instance *compv1alpha1.ComplianceScan) *corev1.PersistentVolu
 // pod names are limited to 63 chars, inclusive. Try to use a friendly name, if that can't be done,
 // just use a hash. Either way, the node would be present in a label of the pod.
 func getPodForNodeName(scanName, nodeName string) string {
-	return dnsLengthName("openscap-pod-", "%s-%s-pod", scanName, nodeName)
+	return utils.DNSLengthName("openscap-pod-", "%s-%s-pod", scanName, nodeName)
 }
 
 func getConfigMapForNodeName(scanName, nodeName string) string {
-	return dnsLengthName("openscap-pod-", "%s-%s-pod", scanName, nodeName)
+	return utils.DNSLengthName("openscap-pod-", "%s-%s-pod", scanName, nodeName)
 }
 
 func getPVCForScanName(instance *compv1alpha1.ComplianceScan) string {

--- a/pkg/controller/compliancescan/config.go
+++ b/pkg/controller/compliancescan/config.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/openshift/compliance-operator/pkg/utils"
 )
 
 const (
@@ -190,11 +191,11 @@ func defaultOpenScapEnvCm(name string, scan *compv1alpha1.ComplianceScan) *corev
 }
 
 func scriptCmForScan(scan *compv1alpha1.ComplianceScan) string {
-	return dnsLengthName("scap-entrypoint-", "%s-%s", scan.Name, OpenScapScriptConfigMapName)
+	return utils.DNSLengthName("scap-entrypoint-", "%s-%s", scan.Name, OpenScapScriptConfigMapName)
 }
 
 func envCmForScan(scan *compv1alpha1.ComplianceScan) string {
-	return dnsLengthName("scap-env-", "%s-%s", scan.Name, OpenScapEnvConfigMapName)
+	return utils.DNSLengthName("scap-env-", "%s-%s", scan.Name, OpenScapEnvConfigMapName)
 }
 
 func asOwner(scan *compv1alpha1.ComplianceScan) metav1.OwnerReference {

--- a/pkg/controller/compliancescan/utils.go
+++ b/pkg/controller/compliancescan/utils.go
@@ -3,12 +3,11 @@ package compliancescan
 import (
 	"context"
 	"path"
+
 	// we can suppress the gosec warning about sha1 here because we don't use sha1 for crypto
 	// purposes, but only as a string shortener
 	// #nosec G505
-	"crypto/sha1"
-	"fmt"
-	"io"
+
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
@@ -63,24 +62,6 @@ func GetComponentImage(component ComplianceComponent) string {
 		imageTag = comp.defaultImage
 	}
 	return imageTag
-}
-
-func dnsLengthName(hashPrefix string, format string, a ...interface{}) string {
-	const maxDnsLen = 64
-
-	friendlyName := fmt.Sprintf(format, a...)
-	if len(friendlyName) < maxDnsLen {
-		return friendlyName
-	}
-
-	// If that's too long, just hash the name. It's not very user friendly, but whatever
-	//
-	// We can suppress the gosec warning about sha1 here because we don't use sha1 for crypto
-	// purposes, but only as a string shortener
-	// #nosec G401
-	hasher := sha1.New()
-	io.WriteString(hasher, friendlyName)
-	return hashPrefix + fmt.Sprintf("%x", hasher.Sum(nil))
 }
 
 func absContentPath(relContentPath string) string {

--- a/pkg/utils/nameutils.go
+++ b/pkg/utils/nameutils.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	// #nosec G505
+	"crypto/sha1"
+	"fmt"
+	"io"
+)
+
+// LengthName creates a string of maximum defined length.
+func LengthName(maxLen int, hashPrefix string, format string, a ...interface{}) (string, error) {
+	friendlyName := fmt.Sprintf(format, a...)
+	if len(friendlyName) < maxLen {
+		return friendlyName, nil
+	}
+
+	// If that's too long, just hash the name. It's not very user friendly, but whatever
+	//
+	// We can suppress the gosec warning about sha1 here because we don't use sha1 for crypto
+	// purposes, but only as a string shortener
+	// #nosec G401
+	hasher := sha1.New()
+	io.WriteString(hasher, friendlyName)
+	hashedName := hashPrefix + fmt.Sprintf("%x", hasher.Sum(nil))
+
+	if len(hashedName) >= maxLen {
+		return "", fmt.Errorf("Cannot shorten '%s' with prefix %s", friendlyName, hashPrefix)
+	}
+	return hashedName, nil
+}
+
+func DNSLengthName(hashPrefix string, format string, a ...interface{}) string {
+	const maxDNSLen = 64
+
+	// TODO(jaosorior): Handle error
+	name, _ := LengthName(maxDNSLen, hashPrefix, format, a...)
+	return name
+}


### PR DESCRIPTION
Annotation keys have a maximum size of 63 and we were hitting it. This
shortens it by using hashing instead if the annotation is too long.

On the other hand, the prefix for the annotation was shortened from
`remediation.compliance.openshift.io/` to just `remediation/`