### PR TITLE
Document how to extract ARF from PVs better

### DIFF
--- a/cmd/resultserver/main.go
+++ b/cmd/resultserver/main.go
@@ -121,7 +121,8 @@ func server(c *config) {
 			http.Error(w, "invalid content encoding header", 400)
 			return
 		} else if encoding == "bzip2" {
-			extraExtension = "." + extraExtension
+			// if the results are compressed, they are also base64-encoded, let's make this clear to the user
+			extraExtension = "." + extraExtension + ".base64"
 		}
 		// TODO(jaosorior): Check that content-type is application/xml
 		filePath := path.Join(c.Path, filename+".xml"+extraExtension)


### PR DESCRIPTION
Adds a section to README that shows how exactly to extract the ARF report
from a PV and adds a .base64 extesion to files that are gzipped to make
it more explicit that the files are in fact base64 encoded.