### PR TITLE
Replace conditional cleanup code with flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ e2e: namespace operator-sdk image-to-cluster openshift-user ## Run the end-to-en
 	@sed -i 's%$(IMAGE_REPO)/$(RESULTSERVER_IMAGE_NAME):latest%$(RESULTSERVER_IMAGE_PATH)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(REMEDIATION_AGGREGATOR_IMAGE_NAME):latest%$(REMEDIATION_AGGREGATOR_IMAGE_PATH)%' deploy/operator.yaml
 	@echo "Running e2e tests"
-	unset GOFLAGS && $(GOPATH)/bin/operator-sdk test local ./tests/e2e --image "$(OPERATOR_IMAGE_PATH)" --namespace "$(NAMESPACE)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
+	unset GOFLAGS && $(GOPATH)/bin/operator-sdk test local ./tests/e2e --skip-cleanup-error --image "$(OPERATOR_IMAGE_PATH)" --namespace "$(NAMESPACE)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
 	@echo "Restoring image references in deploy/operator.yaml"
 	@sed -i 's%$(RESULTSCOLLECTOR_IMAGE_PATH)%$(IMAGE_REPO)/$(RESULTSCOLLECTOR_IMAGE_NAME):latest%' deploy/operator.yaml
 	@sed -i 's%$(RESULTSERVER_IMAGE_PATH)%$(IMAGE_REPO)/$(RESULTSERVER_IMAGE_NAME):latest%' deploy/operator.yaml
@@ -228,7 +228,7 @@ e2e-local: operator-sdk ## Run the end-to-end tests on a locally running operato
 	@echo "Replacing workload references in deploy/operator.yaml"
 	@sed -i 's%$(IMAGE_REPO)/$(RESULTSCOLLECTOR_IMAGE_NAME):latest%$(RESULTSCOLLECTOR_IMAGE_PATH)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(RESULTSERVER_IMAGE_NAME):latest%$(RESULTSERVER_IMAGE_PATH)%' deploy/operator.yaml
-	unset GOFLAGS && $(GOPATH)/bin/operator-sdk test local ./tests/e2e --up-local --image "$(OPERATOR_IMAGE_PATH)" --namespace "$(NAMESPACE)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
+	unset GOFLAGS && $(GOPATH)/bin/operator-sdk test local ./tests/e2e --up-local --skip-cleanup-error --image "$(OPERATOR_IMAGE_PATH)" --namespace "$(NAMESPACE)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
 	@echo "Restoring image references in deploy/operator.yaml"
 	@sed -i 's%$(RESULTSCOLLECTOR_IMAGE_PATH)%$(IMAGE_REPO)/$(RESULTSCOLLECTOR_IMAGE_NAME):latest%' deploy/operator.yaml
 	@sed -i 's%$(RESULTSERVER_IMAGE_PATH)%$(IMAGE_REPO)/$(RESULTSERVER_IMAGE_NAME):latest%' deploy/operator.yaml

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -105,7 +105,7 @@ func (c *mcTestCtx) createE2EPool() error {
 // executeTest sets up everything that a e2e test needs to run, and executes the test.
 func executeTests(t *testing.T, tests ...testExecution) {
 	ctx := setupTestRequirements(t)
-	defer cleanupTestEnv(t, ctx)
+	defer ctx.Cleanup()
 
 	setupComplianceOperatorCluster(t, ctx)
 
@@ -130,17 +130,6 @@ func executeTests(t *testing.T, tests ...testExecution) {
 			}
 		})
 
-	}
-}
-
-func cleanupTestEnv(t *testing.T, ctx *framework.Context) {
-	// If the tests didn't fail, clean up. Else, leave everything
-	// there so developers can debug the issue.
-	if !t.Failed() {
-		t.Log("The tests passed. Cleaning up.")
-		ctx.Cleanup()
-	} else {
-		t.Log("The tests failed. Leaving the env there so you can debug.")
 	}
 }
 


### PR DESCRIPTION
operator-sdk introduced the `--skip-cleanup-error` flag in the v0.16.0
release. This flags does the same stuff we had on the code (not cleaning
up if there was an error in the test).

So let's remove our hack and use the operator-sdk flag instead.