### PR TITLE
Add status and severity labels to ComplianceCheckResult

### DIFF
--- a/cmd/remediation-aggregator/main.go
+++ b/cmd/remediation-aggregator/main.go
@@ -236,10 +236,11 @@ func getRemediationLabels(scan *compv1alpha1.ComplianceScan) (map[string]string,
 	return labels, nil
 }
 
-func getCheckResultLabels(scan *compv1alpha1.ComplianceScan) map[string]string {
+func getCheckResultLabels(cr *compv1alpha1.ComplianceCheckResult, scan *compv1alpha1.ComplianceScan) map[string]string {
 	labels := make(map[string]string)
 	labels[compv1alpha1.ScanLabel] = scan.Name
 	labels[compv1alpha1.SuiteLabel] = scan.Labels["compliancesuite"]
+	labels[compv1alpha1.ComplianceCheckResultStatusLabel] = string(cr.Status)
 
 	return labels
 }
@@ -257,7 +258,7 @@ func createResults(crClient *complianceCrClient, scan *compv1alpha1.ComplianceSc
 			continue
 		}
 
-		checkResultLabels := getCheckResultLabels(scan)
+		checkResultLabels := getCheckResultLabels(pr.CheckResult, scan)
 		if checkResultLabels == nil {
 			return fmt.Errorf("cannot create checkResult labels")
 		}

--- a/cmd/remediation-aggregator/main.go
+++ b/cmd/remediation-aggregator/main.go
@@ -241,6 +241,7 @@ func getCheckResultLabels(cr *compv1alpha1.ComplianceCheckResult, scan *compv1al
 	labels[compv1alpha1.ScanLabel] = scan.Name
 	labels[compv1alpha1.SuiteLabel] = scan.Labels["compliancesuite"]
 	labels[compv1alpha1.ComplianceCheckResultStatusLabel] = string(cr.Status)
+	labels[compv1alpha1.ComplianceCheckResultSeverityLabel] = string(cr.Severity)
 
 	return labels
 }

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -10,6 +10,7 @@ type ComplianceCheckStatus string
 // ComplianceCheckResult objects. It indicates the result in an easy-to-find
 // way.
 const ComplianceCheckResultStatusLabel = "compliance.openshift.io/check-status"
+const ComplianceCheckResultSeverityLabel = "compliance.openshift.io/check-severity"
 
 const (
 	// The check ran to completion and passed

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -6,6 +6,11 @@ import (
 
 type ComplianceCheckStatus string
 
+// ComplianceCheckResultLabel defines a label that will be included in the
+// ComplianceCheckResult objects. It indicates the result in an easy-to-find
+// way.
+const ComplianceCheckResultStatusLabel = "compliance.openshift.io/check-status"
+
 const (
 	// The check ran to completion and passed
 	CheckResultPass ComplianceCheckStatus = "PASS"


### PR DESCRIPTION
This allows us to easily filter passing/failing results using
`kubectl`/`oc`, by filtering with a label. The label that was introduced
is:

    compliance.openshift.io/check-status

The severity was included as well with its own label

    compliance.openshift.io/check-severity