### PR TITLE
Use privileged scc instead of node-exporter

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -145,7 +145,7 @@ rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
-  - node-exporter
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -63,7 +63,7 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 			Namespace: scanInstance.Namespace,
 			Labels:    podLabels,
 			Annotations: map[string]string{
-				"openshift.io/scc": "node-exporter",
+				"openshift.io/scc": "privileged",
 			},
 		},
 		Spec: corev1.PodSpec{


### PR DESCRIPTION
For older deployments OpenShift deployments, the node-exporter SCC
doesn't allow spawning privileged containers. So let's switch back to
using the privileged SCC in order to accomodate for such deployments.

Closes #230