### PR TITLE
Generic Remediations round #2

### DIFF
--- a/deploy/crds/compliance.openshift.io_complianceremediations_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_complianceremediations_crd.yaml
@@ -61,6 +61,8 @@ spec:
             applicationState:
               description: Whether the remediation is already applied or not
               type: string
+            errorMessage:
+              type: string
           type: object
       type: object
   version: v1alpha1

--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -12,6 +12,7 @@ type RemediationApplicationState string
 const (
 	RemediationNotApplied RemediationApplicationState = "NotApplied"
 	RemediationApplied    RemediationApplicationState = "Applied"
+	RemediationError      RemediationApplicationState = "Error"
 )
 
 type RemediationType string
@@ -51,6 +52,7 @@ type ComplianceRemediationSpec struct {
 type ComplianceRemediationStatus struct {
 	// Whether the remediation is already applied or not
 	ApplicationState RemediationApplicationState `json:"applicationState,omitempty"`
+	ErrorMessage     string                      `json:"errorMessage,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
This implements the missing bits to handle generic remediations in the
operator. If the remediation is not a MachineConfig, it'll just ensure
that the object exists in the cluster.

If the remediation is of an object of a kind that doesn't exist in the
cluster, the error gets reflected in the Remediation CR.