### PR TITLE
Remove unnecessary update in createScanPods function

### DIFF
--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -39,11 +39,6 @@ func (r *ReconcileComplianceScan) createScanPods(instance *compv1alpha1.Complian
 		}
 	}
 
-	// make sure the instance is updated with the node-pod labels
-	if err := r.client.Update(context.TODO(), instance); err != nil {
-		log.Error(err, "Failed to update a scan")
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
There was no need to update the ComplianceScan instance in that
function, given that no labels are set anymore.