### PR TITLE
Use official complianceascode content image

### DIFF
--- a/deploy/crds/compliance.openshift.io_v1alpha1_compliancesuite_cr.yaml
+++ b/deploy/crds/compliance.openshift.io_v1alpha1_compliancesuite_cr.yaml
@@ -8,12 +8,12 @@ spec:
       - name: workers-scan
         profile: xccdf_org.ssgproject.content_profile_moderate
         content: ssg-ocp4-ds.xml
-        contentImage: quay.io/jhrozek/ocp4-openscap-content:latest
+        contentImage: quay.io/complianceascode/ocp4:latest
         nodeSelector:
             node-role.kubernetes.io/worker: ""
       - name: masters-scan
         profile: xccdf_org.ssgproject.content_profile_moderate
         content: ssg-ocp4-ds.xml
-        contentImage: quay.io/jhrozek/ocp4-openscap-content:latest
+        contentImage: quay.io/complianceascode/ocp4:latest
         nodeSelector:
             node-role.kubernetes.io/master: ""

--- a/deploy/olm-catalog/compliance-operator/0.1.8/compliance-operator.v0.1.8.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/0.1.8/compliance-operator.v0.1.8.clusterserviceversion.yaml
@@ -71,7 +71,7 @@ metadata:
             "scans": [
               {
                 "content": "ssg-ocp4-ds.xml",
-                "contentImage": "quay.io/jhrozek/ocp4-openscap-content:latest",
+                "contentImage": "quay.io/complianceascode/ocp4:latest",
                 "name": "workers-scan",
                 "nodeSelector": {
                   "node-role.kubernetes.io/worker": ""
@@ -80,7 +80,7 @@ metadata:
               },
               {
                 "content": "ssg-ocp4-ds.xml",
-                "contentImage": "quay.io/jhrozek/ocp4-openscap-content:latest",
+                "contentImage": "quay.io/complianceascode/ocp4:latest",
                 "name": "masters-scan",
                 "nodeSelector": {
                   "node-role.kubernetes.io/master": ""

--- a/pkg/controller/compliancescan/utils.go
+++ b/pkg/controller/compliancescan/utils.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	DefaultContentContainerImage = "quay.io/jhrozek/ocp4-openscap-content:latest"
+	DefaultContentContainerImage = "quay.io/complianceascode/ocp4:latest"
 	CACertDataKey                = "ca.crt"
 	CAKeyDataKey                 = "ca.key"
 	ServerCertInstanceSuffix     = "-rs"


### PR DESCRIPTION
Fixes: #216.

quay.io/complianceascode/ocp4 is set-up to continuously re-build ocp4 content available at https://github.com/ComplianceAsCode/content