### PR TITLE
Implement re-scanning

### DIFF
--- a/cmd/remediation-aggregator/main.go
+++ b/cmd/remediation-aggregator/main.go
@@ -120,7 +120,7 @@ func getScanConfigMaps(clientset *kubernetes.Clientset, scan, namespace string) 
 
 	// Look for configMap with this scan label
 	listOpts := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("compliance-scan=%s", scan),
+		LabelSelector: fmt.Sprintf("%s=%s", compv1alpha1.ComplianceScanIndicatorLabel, scan),
 	}
 
 	cMapList, err = clientset.CoreV1().ConfigMaps(namespace).List(listOpts)

--- a/cmd/remediation-aggregator/main.go
+++ b/cmd/remediation-aggregator/main.go
@@ -98,6 +98,8 @@ func createCrClient(config *rest.Config) (*complianceCrClient, error) {
 		&compv1alpha1.ComplianceCheckResult{})
 	scheme.AddKnownTypes(compv1alpha1.SchemeGroupVersion,
 		&metav1.CreateOptions{})
+	scheme.AddKnownTypes(compv1alpha1.SchemeGroupVersion,
+		&metav1.UpdateOptions{})
 
 	client, err := runtimeclient.New(config, runtimeclient.Options{
 		Scheme: scheme,
@@ -196,7 +198,7 @@ type compResultIface interface {
 	runtime.Object
 }
 
-func createOneResult(crClient *complianceCrClient, owner metav1.Object, labels map[string]string, res compResultIface) error {
+func createOrUpdateOneResult(crClient *complianceCrClient, owner metav1.Object, labels map[string]string, exists bool, res compResultIface) error {
 	kind := res.GetObjectKind()
 
 	if err := controllerutil.SetControllerReference(owner, res, crClient.scheme); err != nil {
@@ -210,9 +212,14 @@ func createOneResult(crClient *complianceCrClient, owner metav1.Object, labels m
 	fmt.Printf("Creating %s:%s\n", kind.GroupVersionKind().Kind, name)
 
 	err := backoff.Retry(func() error {
-		err := crClient.client.Create(context.TODO(), res)
+		var err error
+		if !exists {
+			err = crClient.client.Create(context.TODO(), res)
+		} else {
+			err = crClient.client.Update(context.TODO(), res)
+		}
 		if err != nil && !errors.IsAlreadyExists(err) {
-			fmt.Printf("Retrying with a backoff because of an error: %v\n", err)
+			fmt.Printf("Retrying with a backoff because of an error while creating or updating object: %v\n", err)
 			return err
 		}
 		return nil
@@ -264,9 +271,18 @@ func createResults(crClient *complianceCrClient, scan *compv1alpha1.ComplianceSc
 			return fmt.Errorf("cannot create checkResult labels")
 		}
 
+		crkey := getObjKey(pr.CheckResult.GetName(), pr.CheckResult.GetNamespace())
+		foundCheckResult := &compv1alpha1.ComplianceCheckResult{}
+		// Copy type metadata so dynamic client copies data correctly
+		foundCheckResult.TypeMeta = pr.CheckResult.TypeMeta
+		checkResultExists, err := getObjectIfFound(crClient, crkey, foundCheckResult)
+		if checkResultExists {
+			// Copy resource version and other metadata needed for update
+			foundCheckResult.ObjectMeta.DeepCopyInto(&pr.CheckResult.ObjectMeta)
+		}
 		// check is owned by the scan
-		if err := createOneResult(crClient, scan, checkResultLabels, pr.CheckResult); err != nil {
-			return fmt.Errorf("cannot create checkResult %s: %v", pr.CheckResult.Name, err)
+		if err := createOrUpdateOneResult(crClient, scan, checkResultLabels, checkResultExists, pr.CheckResult); err != nil {
+			return fmt.Errorf("cannot create or update checkResult %s: %v", pr.CheckResult.Name, err)
 		}
 
 		if pr.Remediation == nil {
@@ -278,14 +294,46 @@ func createResults(crClient *complianceCrClient, scan *compv1alpha1.ComplianceSc
 			return err
 		}
 
+		remkey := getObjKey(pr.Remediation.GetName(), pr.Remediation.GetNamespace())
+		foundRemediation := &compv1alpha1.ComplianceRemediation{}
+		// Copy type metadata so dynamic client copies data correctly
+		foundRemediation.TypeMeta = pr.Remediation.TypeMeta
+		remExists, err := getObjectIfFound(crClient, remkey, foundRemediation)
+		if remExists {
+			// Copy resource version and other metadata needed for update
+			foundRemediation.ObjectMeta.DeepCopyInto(&pr.Remediation.ObjectMeta)
+		}
 		// remediation is owned by the check
-		if err := createOneResult(crClient, pr.CheckResult, remLabels, pr.Remediation); err != nil {
-			return fmt.Errorf("cannot create remediation %s: %v", pr.CheckResult.Name, err)
+		if err := createOrUpdateOneResult(crClient, pr.CheckResult, remLabels, remExists, pr.Remediation); err != nil {
+			return fmt.Errorf("cannot create or update remediation %s: %v", pr.Remediation.Name, err)
 		}
 
 	}
 
 	return nil
+}
+
+func getObjKey(name, ns string) types.NamespacedName {
+	return types.NamespacedName{Name: name, Namespace: ns}
+}
+
+// Returns whether or not an object exists, and updates the data in the obj.
+// If there is an error that is not acceptable, it'll be returned
+func getObjectIfFound(crClient *complianceCrClient, key types.NamespacedName, obj runtime.Object) (bool, error) {
+	var found bool
+	err := backoff.Retry(func() error {
+		err := crClient.client.Get(context.TODO(), key, obj)
+		if errors.IsNotFound(err) {
+			return nil
+		} else if err != nil {
+			fmt.Printf("Retrying with a backoff because of an error while getting object: %v\n", err)
+			return err
+		}
+		found = true
+		return nil
+	}, backoff.WithMaxRetries(backoff.NewExponentialBackOff(), maxRetries))
+
+	return found, err
 }
 
 func readContent(filename string) (*os.File, error) {

--- a/cmd/resultscollector/main.go
+++ b/cmd/resultscollector/main.go
@@ -31,6 +31,7 @@ import (
 
 	backoff "github.com/cenkalti/backoff/v3"
 	"github.com/dsnet/compress/bzip2"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -41,7 +42,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	libgocrypto "github.com/openshift/library-go/pkg/crypto"
+	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
 )
 
 const (
@@ -240,7 +241,7 @@ func getConfigMap(owner *unstructured.Unstructured, configMapName, filename stri
 				},
 			},
 			Labels: map[string]string{
-				"compliance-scan": owner.GetName(),
+				compv1alpha1.ComplianceScanIndicatorLabel: owner.GetName(),
 			},
 		},
 		Data: map[string]string{

--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -87,6 +87,11 @@ spec:
             with the scan; and, more importantly, if the scan is successful (compliant)
             or not (non-compliant)
           properties:
+            currentIndex:
+              description: Specifies the current index of the scan. Given multiple
+                scans, this marks the amount that have been executed.
+              format: int64
+              type: integer
             errormsg:
               description: If there are issues on the scan, this will be filled up
                 with an error message.

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -113,6 +113,11 @@ spec:
                 description: ComplianceScanStatusWrapper provides a ComplianceScanStatus
                   and a Name
                 properties:
+                  currentIndex:
+                    description: Specifies the current index of the scan. Given multiple
+                      scans, this marks the amount that have been executed.
+                    format: int64
+                    type: integer
                   errormsg:
                     description: If there are issues on the scan, this will be filled
                       up with an error message.

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -26,6 +26,8 @@ rules:
   - watch      # The Suite controller must watch configMaps
   - patch      # The Suite controller annotates configMaps
   - update     # The Suite controller annotates configMaps
+  - delete            # Needed for result cleanup on re-scanning
+  - deletecollection  # Needed for result cleanup on re-scanning
 - apiGroups:
   - ""
   resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -183,6 +183,9 @@ rules:
   - complianceremediations
   verbs:
   - create
+  - get
+  - update
+  - patch
 - apiGroups:
   - compliance.openshift.io
   resources:
@@ -190,3 +193,5 @@ rules:
   verbs:
   - create
   - get
+  - update
+  - patch

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -10,6 +10,10 @@ import (
 // should be re-run
 const ComplianceScanRescanAnnotation = "compliance.openshift.io/rescan"
 
+// ComplianceScanIndicatorLabel serves as an indicator for which ComplianceScan
+// owns the referenced object
+const ComplianceScanIndicatorLabel = "compliance-scan"
+
 // Represents the status of the compliance scan run.
 type ComplianceScanStatusPhase string
 

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -6,6 +6,10 @@ import (
 
 // +genclient
 
+// ComplianceScanRescanAnnotation indicates that a ComplianceScan
+// should be re-run
+const ComplianceScanRescanAnnotation = "compliance.openshift.io/rescan"
+
 // Represents the status of the compliance scan run.
 type ComplianceScanStatusPhase string
 
@@ -115,6 +119,9 @@ type ComplianceScanStatus struct {
 	// If there are issues on the scan, this will be filled up with an error
 	// message.
 	ErrorMessage string `json:"errormsg,omitempty"`
+	// Specifies the current index of the scan. Given multiple scans, this marks the
+	// amount that have been executed.
+	CurrentIndex int64 `json:"currentIndex,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -136,6 +143,17 @@ type ComplianceScan struct {
 	// scan; and, more importantly, if the scan is successful (compliant) or
 	// not (non-compliant)
 	Status ComplianceScanStatus `json:"status,omitempty"`
+}
+
+// NeedsRescan indicates whether a ComplianceScan needs to
+// rescan or not
+func (cs *ComplianceScan) NeedsRescan() bool {
+	annotations := cs.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, needsRescan := annotations[ComplianceScanRescanAnnotation]
+	return needsRescan
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -2,6 +2,7 @@ package compliancescan
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -385,7 +386,11 @@ func (r *ReconcileComplianceScan) phaseDoneHandler(instance *compv1alpha1.Compli
 			instanceCopy := instance.DeepCopy()
 			instanceCopy.Status.Phase = compv1alpha1.PhasePending
 			instanceCopy.Status.Result = compv1alpha1.ResultNotAvailable
-			instanceCopy.Status.CurrentIndex = instance.Status.CurrentIndex + 1
+			if instance.Status.CurrentIndex == math.MaxInt64 {
+				instanceCopy.Status.CurrentIndex = 0
+			} else {
+				instanceCopy.Status.CurrentIndex = instance.Status.CurrentIndex + 1
+			}
 			err = r.client.Status().Update(context.TODO(), instanceCopy)
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -118,6 +118,7 @@ func resultServer(scanInstance *compv1alpha1.ComplianceScan, labels map[string]s
 								"--path=/reports/",
 								"--address=0.0.0.0",
 								fmt.Sprintf("--port=%d", ResultServerPort),
+								fmt.Sprintf("--scan-index=%d", scanInstance.Status.CurrentIndex),
 								"--tls-server-cert=/etc/pki/tls/tls.crt",
 								"--tls-server-key=/etc/pki/tls/tls.key",
 								"--tls-ca=/etc/pki/tls/ca.crt",

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -301,7 +301,7 @@ func waitForSuiteScansStatus(t *testing.T, f *framework.Framework, namespace, na
 		}
 
 		if suite.Status.AggregatedPhase != targetStatus {
-			t.Logf("Waiting until suite %s is done", suite.Name)
+			t.Logf("Waiting until suite %s reaches target status '%s'. Current status: %s", suite.Name, targetStatus, suite.Status.AggregatedPhase)
 			return false, nil
 		}
 

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -396,7 +396,7 @@ func getPodsForScan(f *framework.Framework, scanName string) ([]corev1.Pod, erro
 func getConfigMapsFromScan(f *framework.Framework, scaninstance *compv1alpha1.ComplianceScan) []corev1.ConfigMap {
 	var configmaps corev1.ConfigMapList
 	labelselector := map[string]string{
-		"compliance-scan": scaninstance.Name,
+		compv1alpha1.ComplianceScanIndicatorLabel: scaninstance.Name,
 	}
 	lo := &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labelselector),


### PR DESCRIPTION
This makes the annotation `compliance.openshift.io/rescan` execute a
rescan if it's encountered. Note that this only happens in the "DONE"
phase, and if it's found, it also deletes the previous pods and secrets
before going back to the "PENDING" phase. This is done in order to start
from a blank slate and avoid errors.

On the other hand, this introduces the `currentIndex` field to the
ComplianceScan's status. This represents the number of scans that have
been executed, and serves as a directory for the results in the PVC

`ChechResult` objects are updated once the scan is re-run, so fetching the results for the same scan should give you the latest updates.

One details is that the ConfigMaps that contained the results need to be deleted in order to run the scan again. So this happens only once the re-scan is detected and applied.