### PR TITLE
Stop relying on annotations for aggregator pod

### DIFF
--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -16,12 +16,12 @@ import (
 
 const aggregatorSA = "remediation-aggregator"
 
-func createAggregatorPodName(scanName string) string {
+func getAggregatorPodName(scanName string) string {
 	return utils.DNSLengthName("aggregator-pod-", "aggregator-pod-%s", scanName)
 }
 
 func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Logger) *corev1.Pod {
-	podName := createAggregatorPodName(scanInstance.Name)
+	podName := getAggregatorPodName(scanInstance.Name)
 
 	podLabels := map[string]string{
 		"complianceScan": scanInstance.Name,
@@ -92,17 +92,8 @@ func (r *ReconcileComplianceScan) launchAggregatorPod(scanInstance *compv1alpha1
 		return err
 	}
 
-	if errors.IsAlreadyExists(err) {
-		// If the pod was already created, just return
-		return nil
-	}
-
-	if scanInstance.Annotations == nil {
-		scanInstance.Annotations = make(map[string]string)
-	}
-
-	scanInstance.Annotations[AggregatorPodAnnotation] = pod.Name
-	return r.client.Update(context.TODO(), scanInstance)
+	// If the pod was already created, just return
+	return nil
 }
 
 func (r *ReconcileComplianceScan) deleteAggregator(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
@@ -119,6 +110,6 @@ func (r *ReconcileComplianceScan) deleteAggregator(instance *compv1alpha1.Compli
 func isAggregatorRunning(r *ReconcileComplianceScan, scanInstance *compv1alpha1.ComplianceScan, logger logr.Logger) (bool, error) {
 	logger.Info("Checking aggregator pod for scan", "ComplianceScan.Name", scanInstance.Name)
 
-	podName := scanInstance.Annotations[AggregatorPodAnnotation]
+	podName := getAggregatorPodName(scanInstance.Name)
 	return isPodRunning(r, podName, scanInstance.Namespace, logger)
 }

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -39,7 +39,6 @@ const (
 	// OpenSCAPScanContainerName defines the name of the contianer that will run OpenSCAP
 	OpenSCAPScanContainerName = "openscap-ocp"
 	NodeHostnameLabel         = "kubernetes.io/hostname"
-	AggregatorPodAnnotation   = "scan-aggregator"
 	// The default time we should wait before requeuing
 	requeueAfterDefault = 10 * time.Second
 )


### PR DESCRIPTION
The name of the aggregator pod is already predictable, so we don't need
to rely on annotations in order to check if it's running or not.

This reduces the number of updates we do on a scan.