### PR TITLE
Generate events to be read by RHACM

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -19,6 +19,7 @@ rules:
   - ""
   resources:
   - configmaps  # The log collecting sidecar uses configmaps to store results
+  - events
   verbs:
   - create      # The sidecar must create the configmap to store results in
   - get

--- a/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
@@ -116,3 +116,8 @@ func (s *ComplianceSuite) LowestCommonResult() ComplianceScanStatusResult {
 
 	return lowestCommonResult
 }
+
+func (s *ComplianceSuite) IsResultAvailable() bool {
+	result := s.LowestCommonResult()
+	return result != "" && result != ResultNotAvailable
+}

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -1,18 +1,33 @@
 package common
 
 import (
+	"os"
+
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 )
 
 var complianceOperatorNamespace = "openshift-compliance"
 
 func init() {
-	ns, err := k8sutil.GetOperatorNamespace()
-	if err == nil {
-		complianceOperatorNamespace = ns
+	if isRunModeLocal() {
+		ns, ok := os.LookupEnv("WATCH_NAMESPACE")
+		if ok {
+			complianceOperatorNamespace = ns
+		}
+	} else {
+		ns, err := k8sutil.GetOperatorNamespace()
+		if err == nil {
+			complianceOperatorNamespace = ns
+		}
 	}
 }
 
+func isRunModeLocal() bool {
+	return os.Getenv(k8sutil.ForceRunModeEnv) == string(k8sutil.LocalRunMode)
+}
+
+// GetComplianceOperatorNamespace gets the namespace that the operator is
+// currently running on.
 func GetComplianceOperatorNamespace() string {
 	return complianceOperatorNamespace
 }


### PR DESCRIPTION
This generates events for the Compliancesuite once the result is
available, and if the suite is owned by a Policy object, it generates an
event for that too.

Co-Authored-By: Jakub Hrozek <jhrozek@redhat.com>