### PR TITLE
Platform scan follow-ups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,13 @@ IMAGE_REPO?=quay.io/compliance-operator
 RUNTIME?=podman
 
 # Temporary
-OPENSCAP_IMAGE_REPO?=quay.io/mrogers950
-OPENSCAP_IMAGE_TAG?=yamlprobe
+OPENSCAP_IMAGE_TAG?=1.3.3
 
 # Image path to use. Set this if you want to use a specific path for building
 # or your e2e tests. This is overwritten if we bulid the image and push it to
 # the cluster or if we're on CI.
 OPERATOR_IMAGE_PATH?=$(IMAGE_REPO)/$(APP_NAME)
-OPENSCAP_IMAGE_PATH=$(OPENSCAP_IMAGE_REPO)/$(OPENSCAP_IMAGE_NAME)
+OPENSCAP_IMAGE_PATH=$(IMAGE_REPO)/$(OPENSCAP_IMAGE_NAME)
 OPENSCAP_DOCKERFILE_PATH=./images/openscap/Dockerfile
 RESULTSCOLLECTOR_IMAGE_PATH=$(IMAGE_REPO)/$(RESULTSCOLLECTOR_IMAGE_NAME)
 RESULTSCOLLECTOR_DOCKERFILE_PATH=./images/resultscollector/Dockerfile

--- a/cmd/api-resource-collector/scap.go
+++ b/cmd/api-resource-collector/scap.go
@@ -260,7 +260,7 @@ func saveResources(rootDir string, data map[string][]byte) error {
 		if err != nil {
 			return err
 		}
-		err = os.MkdirAll(saveDir, os.ModePerm)
+		err = os.MkdirAll(saveDir, 0700)
 		if err != nil {
 			return err
 		}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -32,8 +32,8 @@ spec:
             - name: OPERATOR_NAME
               value: "compliance-operator"
             - name: OPENSCAP_IMAGE
-              # Trying hardcoding this temporarily until its propagated to CI
-              value: "quay.io/mrogers950/openscap-ocp:latest"
+              # Hardcoding this temporarily until its propagated to CI
+              value: "quay.io/compliance-operator/openscap-ocp:1.3.3"
             - name: LOG_COLLECTOR_IMAGE
               value: "quay.io/compliance-operator/resultscollector:latest"
             - name: RESULT_SERVER_IMAGE

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -53,11 +53,23 @@ metadata:
   name: api-resource-collector
 subjects:
 - kind: ServiceAccount
-  name: resultscollector
+  name: api-resource-collector
   namespace: openshift-compliance
 roleRef:
   kind: ClusterRole
   name: cluster-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: api-resource-collector-logging
+subjects:
+- kind: ServiceAccount
+  name: api-resource-collector
+roleRef:
+  kind: Role
+  name: resultscollector
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: RoleBinding

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -17,3 +17,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rerunner
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: api-resource-collector

--- a/images/api-resource-collector/Dockerfile.ci
+++ b/images/api-resource-collector/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Step one: build fetcher
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
 
 WORKDIR /go/src/github.com/openshift/compliance-operator
 

--- a/images/openscap/Dockerfile.maint-1.3
+++ b/images/openscap/Dockerfile.maint-1.3
@@ -8,7 +8,7 @@ LABEL \
     io.openshift.tags="compliance openscap scan" \
     io.openshift.wants="scap-content"
 
-# The repo is only for testing. Used to create quay.io/mrogers950/openscap-ocp:yamlprobe
+# The repo is only for testing. Used to create quay.io/compliance-operator/openscap-ocp:1.3.3
 COPY \
     mrogers-openscap-with-yaml-epel-8.repo /etc/yum.repos.d/
 

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	resultscollectorSA    = "resultscollector"
-	tailoringCMVolumeName = "tailoring"
+	resultscollectorSA     = "resultscollector"
+	apiResourceCollectorSA = "api-resource-collector"
+	tailoringCMVolumeName  = "tailoring"
 )
 
 func (r *ReconcileComplianceScan) createScanPods(instance *compv1alpha1.ComplianceScan, nodes corev1.NodeList, logger logr.Logger) error {
@@ -274,7 +275,7 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 			Labels:    podLabels,
 		},
 		Spec: corev1.PodSpec{
-			ServiceAccountName: resultscollectorSA,
+			ServiceAccountName: apiResourceCollectorSA,
 			InitContainers: []corev1.Container{
 				{
 					Name:  "content-container",

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -948,7 +948,7 @@ func TestE2E(t *testing.T) {
 						Scans: []compv1alpha1.ComplianceScanSpecWrapper{
 							{
 								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
-									ContentImage: "quay.io/jhrozek/ocp4-openscap-content:ignition_remediation",
+									ContentImage: "quay.io/complianceascode/ocp4:latest",
 									Profile:      "xccdf_org.ssgproject.content_profile_coreos-ncp",
 									Content:      "ssg-ocp4-ds.xml",
 									NodeSelector: selectWorkers,
@@ -958,7 +958,7 @@ func TestE2E(t *testing.T) {
 							{
 								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
 									ScanType:     compv1alpha1.ScanTypePlatform,
-									ContentImage: "quay.io/mrogers950/ocp4-openscap-content:platform",
+									ContentImage: "quay.io/compliance-operator/ocp4-openscap-content:platform_test",
 									Profile:      "xccdf_org.ssgproject.content_profile_platform-moderate",
 									Content:      "ssg-ocp4-ds.xml",
 								},


### PR DESCRIPTION
- Use new SA for api-resource-collector.
- Use golang-1.13 builder for api-resource-collector image.
- Remove personal repo use.
- Don't use 777 for staging directories.

(note, I pushed some extra images to quay.io/compliance-operator to get rid of my own repos: openscap-ocp:1.3.3 and ocp4-openscap-content:platform_test)