### PR TITLE
make: Add a flag to enable make run again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ run: operator-sdk ## Run the compliance-operator locally
 	WATCH_NAMESPACE=$(NAMESPACE) \
 	KUBERNETES_CONFIG=$(KUBECONFIG) \
 	OPERATOR_NAME=compliance-operator \
-	$(GOPATH)/bin/operator-sdk run --local --watch-namespace $(NAMESPACE)
+	$(GOPATH)/bin/operator-sdk run --local --watch-namespace $(NAMESPACE) --operator-flags operator
 
 .PHONY: clean
 clean: clean-modcache clean-cache clean-output ## Clean the golang environment


### PR DESCRIPTION
Since the main operator binary now requires an argument, we need to
provide one during make run.