### PR TITLE
Surface validation error to ComplianceSuite object

### DIFF
--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -117,6 +117,8 @@ spec:
             aggregatedResult:
               description: Represents the result of the compliance scan
               type: string
+            errorMessage:
+              type: string
             scanStatuses:
               items:
                 description: ComplianceScanStatusWrapper provides a ComplianceScanStatus

--- a/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
@@ -50,6 +50,7 @@ type ComplianceSuiteStatus struct {
 	ScanStatuses     []ComplianceScanStatusWrapper `json:"scanStatuses"`
 	AggregatedPhase  ComplianceScanStatusPhase     `json:"aggregatedPhase,omitempty"`
 	AggregatedResult ComplianceScanStatusResult    `json:"aggregatedResult,omitempty"`
+	ErrorMessage     string                        `json:"errorMessage,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
If the ComplianceSuite object has validation errors (e.g. the schedule
having the wrong format), instead of continuing without failing, this
makes it so that it won't schedule the ComplianceScan(s) and it'll
surface the error immediately.

This error will be shown in the logs, an event and in the
ComplianceSuite's status.