### PR TITLE
Add friendly rule name as annotation to check result

### DIFF
--- a/cmd/remediation-aggregator/main.go
+++ b/cmd/remediation-aggregator/main.go
@@ -277,9 +277,6 @@ func createResults(crClient *complianceCrClient, scan *compv1alpha1.ComplianceSc
 		}
 
 		checkResultLabels := getCheckResultLabels(pr.CheckResult, scan)
-		if checkResultLabels == nil {
-			return fmt.Errorf("cannot create checkResult labels")
-		}
 		checkResultAnnotations := getCheckResultAnnotations(pr.CheckResult, scan)
 
 		crkey := getObjKey(pr.CheckResult.GetName(), pr.CheckResult.GetNamespace())

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -11,6 +13,10 @@ type ComplianceCheckStatus string
 // way.
 const ComplianceCheckResultStatusLabel = "compliance.openshift.io/check-status"
 const ComplianceCheckResultSeverityLabel = "compliance.openshift.io/check-severity"
+
+// ComplianceCheckResultRuleAnnotation exposes the DNS-friendly name of a rule as a label.
+// This provides a way to link a result to a Rule object.
+const ComplianceCheckResultRuleAnnotation = "compliance.openshift.io/rule"
 
 const (
 	// The check ran to completion and passed
@@ -55,6 +61,15 @@ type ComplianceCheckResult struct {
 	Severity ComplianceCheckResultSeverity `json:"severity"`
 	// A human-readable check description, what and why it does
 	Description string `json:"description,omitempty"`
+}
+
+// IDToDNSFriendlyName gets the ID from the scan and returns a DNS
+// friendly name
+func (ccr *ComplianceCheckResult) IDToDNSFriendlyName() string {
+	const rulePrefix = "xccdf_org.ssgproject.content_rule_"
+	ruleName := strings.TrimPrefix(ccr.ID, rulePrefix)
+	dnsFriendlyFixID := strings.ReplaceAll(ruleName, "_", "-")
+	return strings.ToLower(dnsFriendlyFixID)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
This is an attempt at correlating check results with profile rules. Both
objects will contain the same annotations that indicate the same name.

The reason they're set as annotations and not labels is because the
length that the IDs may have may be more than what labels can handle.

Also, remove useless nil check from remediation-aggregator
Add friendly rule name as annotation to check result