### PR TITLE
e2e: Extend the platform test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-logr/zapr v0.1.1
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
+	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/library-go v0.0.0-20200320155611-2a351bebf158
 	github.com/openshift/machine-config-operator v4.2.0-alpha.0.0.20190917115525-033375cbe820+incompatible
 	github.com/operator-framework/operator-sdk v0.18.1

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/compliance-operator/pkg/apis"
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
 	compsuitectrl "github.com/openshift/compliance-operator/pkg/controller/compliancesuite"
@@ -212,6 +213,18 @@ func setupTestRequirements(t *testing.T) *framework.Context {
 			t.Fatalf("TEST SETUP: failed to add custom resource scheme to framework: %v", err)
 		}
 	}
+
+	// Additional testing objects
+	testObjs := [1]runtime.Object{
+		&configv1.OAuth{},
+	}
+	for _, obj := range testObjs {
+		err := framework.AddToFrameworkScheme(configv1.Install, obj)
+		if err != nil {
+			t.Fatalf("TEST SETUP: failed to add configv1 resource scheme to framework: %v", err)
+		}
+	}
+
 	// MCO objects
 	mcoObjs := [2]runtime.Object{
 		&mcfgv1.MachineConfigPoolList{},


### PR DESCRIPTION
Previously we just tested the default state of the cluster for a compliant
platform result. This follows it up by installing an HTPasswd IDP and expecting
a non-compliant result.