### PR TITLE
Decouple resources from CRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./
 # ====================
 KUBECONFIG?=$(HOME)/.kube/config
 export NAMESPACE?=openshift-compliance
+export OPERATOR_NAMESPACE?=openshift-compliance
 
 # Operator-sdk variables
 # ======================

--- a/cmd/remediation-aggregator/main.go
+++ b/cmd/remediation-aggregator/main.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/openshift/compliance-operator/pkg/controller/common"
 	"github.com/openshift/compliance-operator/pkg/utils"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
@@ -187,7 +188,7 @@ func annotateParsedConfigMap(clientset *kubernetes.Clientset, cm *v1.ConfigMap) 
 	cmCopy.Annotations[configMapRemediationsProcessed] = ""
 
 	err := backoff.Retry(func() error {
-		_, err := clientset.CoreV1().ConfigMaps(cmCopy.Namespace).Update(cmCopy)
+		_, err := clientset.CoreV1().ConfigMaps(common.GetComplianceOperatorNamespace()).Update(cmCopy)
 		return err
 	}, backoff.WithMaxRetries(backoff.NewExponentialBackOff(), maxRetries))
 	return err
@@ -391,7 +392,7 @@ func aggregator(cmd *cobra.Command, args []string) {
 	}
 
 	// Find all the configmaps for a scan
-	configMaps, err := getScanConfigMaps(clientset, aggregatorConf.ScanName, aggregatorConf.Namespace)
+	configMaps, err := getScanConfigMaps(clientset, aggregatorConf.ScanName, common.GetComplianceOperatorNamespace())
 	if err != nil {
 		fmt.Printf("getScanConfigMaps failed: %v\n", err)
 		os.Exit(1)

--- a/cmd/resultscollector/main.go
+++ b/cmd/resultscollector/main.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/openshift/compliance-operator/pkg/controller/common"
 )
 
 const (
@@ -232,14 +233,6 @@ func getConfigMap(owner *unstructured.Unstructured, configMapName, filename stri
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        configMapName,
 			Annotations: annotations,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: owner.GetAPIVersion(),
-					Kind:       owner.GetKind(),
-					Name:       owner.GetName(),
-					UID:        owner.GetUID(),
-				},
-			},
 			Labels: map[string]string{
 				compv1alpha1.ComplianceScanIndicatorLabel: owner.GetName(),
 			},
@@ -293,7 +286,7 @@ func uploadResultConfigMap(xccdfContents *resultFileContents, exitcode string,
 			return err
 		}
 		confMap := getConfigMap(openscapScan, scapresultsconf.ConfigMapName, "results", xccdfContents.contents, xccdfContents.compressed, exitcode)
-		_, err = clientset.CoreV1().ConfigMaps(scapresultsconf.Namespace).Create(confMap)
+		_, err = clientset.CoreV1().ConfigMaps(common.GetComplianceOperatorNamespace()).Create(confMap)
 
 		if errors.IsAlreadyExists(err) {
 			return nil
@@ -311,7 +304,7 @@ func uploadErrorConfigMap(errorMsg *resultFileContents, exitcode string,
 			return err
 		}
 		confMap := getConfigMap(openscapScan, scapresultsconf.ConfigMapName, "error-msg", errorMsg.contents, errorMsg.compressed, exitcode)
-		_, err = clientset.CoreV1().ConfigMaps(scapresultsconf.Namespace).Create(confMap)
+		_, err = clientset.CoreV1().ConfigMaps(common.GetComplianceOperatorNamespace()).Create(confMap)
 
 		if errors.IsAlreadyExists(err) {
 			return nil

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -137,6 +137,13 @@ rules:
   - watch
   - update
   - delete
+- apiGroups:
+  - compliance.openshift.io
+  resources:
+  - compliancesuites
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -17,6 +17,10 @@ const ComplianceScanIndicatorLabel = "compliance-scan"
 // ScriptLabel defines that the object is a script for a scan object
 const ScriptLabel = "complianceoperator.openshift.io/scan-script"
 
+// ScanFinalizer is a finalizer for ComplianceScans. It gets automatically
+// added by the ComplianceScan controller in order to delete resources.
+const ScanFinalizer = "scan.finalizers.compliance.openshift.io"
+
 // Represents the status of the compliance scan run.
 type ComplianceScanStatusPhase string
 

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -14,6 +14,9 @@ const ComplianceScanRescanAnnotation = "compliance.openshift.io/rescan"
 // owns the referenced object
 const ComplianceScanIndicatorLabel = "compliance-scan"
 
+// ScriptLabel defines that the object is a script for a scan object
+const ScriptLabel = "complianceoperator.openshift.io/scan-script"
+
 // Represents the status of the compliance scan run.
 type ComplianceScanStatusPhase string
 

--- a/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
@@ -9,6 +9,10 @@ import (
 // This is an easy way to filter them.
 const SuiteLabel = "compliance.openshift.io/suite"
 
+// SuiteFinalizer is a finalizer for ComplianceSuites. It gets automatically
+// added by the ComplianceSuite controller in order to delete resources.
+const SuiteFinalizer = "suite.finalizers.compliance.openshift.io"
+
 // ComplianceScanSpecWrapper provides a ComplianceScanSpec and a Name
 // +k8s:openapi-gen=true
 type ComplianceScanSpecWrapper struct {

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -10,9 +10,14 @@ var complianceOperatorNamespace = "openshift-compliance"
 
 func init() {
 	if isRunModeLocal() {
-		ns, ok := os.LookupEnv("WATCH_NAMESPACE")
+		ns, ok := os.LookupEnv("OPERATOR_NAMESPACE")
 		if ok {
 			complianceOperatorNamespace = ns
+		} else {
+			ns, ok := os.LookupEnv("WATCH_NAMESPACE")
+			if ok {
+				complianceOperatorNamespace = ns
+			}
 		}
 	} else {
 		ns, err := k8sutil.GetOperatorNamespace()

--- a/pkg/controller/common/finalizers.go
+++ b/pkg/controller/common/finalizers.go
@@ -1,0 +1,24 @@
+package common
+
+// ContainsFinalizer checks if the given finalizer `f` is in the
+// given list of finalizers
+func ContainsFinalizer(slice []string, f string) bool {
+	for _, item := range slice {
+		if item == f {
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveFinalizer removes the given finalizer `f` from the
+// given list of finalizers
+func RemoveFinalizer(slice []string, f string) (result []string) {
+	for _, item := range slice {
+		if item == f {
+			continue
+		}
+		result = append(result, item)
+	}
+	return
+}

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/openshift/compliance-operator/pkg/controller/common"
 	"github.com/openshift/compliance-operator/pkg/utils"
 )
 
@@ -30,7 +31,7 @@ func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Log
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
-			Namespace: scanInstance.Namespace,
+			Namespace: common.GetComplianceOperatorNamespace(),
 			Labels:    podLabels,
 		},
 		Spec: corev1.PodSpec{
@@ -111,5 +112,5 @@ func isAggregatorRunning(r *ReconcileComplianceScan, scanInstance *compv1alpha1.
 	logger.Info("Checking aggregator pod for scan", "ComplianceScan.Name", scanInstance.Name)
 
 	podName := getAggregatorPodName(scanInstance.Name)
-	return isPodRunning(r, podName, scanInstance.Namespace, logger)
+	return isPodRunning(r, podName, common.GetComplianceOperatorNamespace(), logger)
 }

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -272,7 +272,7 @@ func (r *ReconcileComplianceScan) phaseRunningHandler(instance *compv1alpha1.Com
 
 		if running {
 			// The platform scan pod is still running, go back to queue.
-			return reconcile.Result{}, err
+			return reconcile.Result{Requeue: true, RequeueAfter: requeueAfterDefault}, err
 		}
 	default: // ScanTypeNode
 		if nodes, err = getTargetNodes(r, instance); err != nil {

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -286,7 +286,7 @@ func (r *ReconcileComplianceScan) phaseRunningHandler(instance *compv1alpha1.Com
 			}
 			if running {
 				// at least one pod is still running, just go back to the queue
-				return reconcile.Result{}, err
+				return reconcile.Result{Requeue: true, RequeueAfter: requeueAfterDefault}, err
 			}
 		}
 	}

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -69,16 +69,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// TODO(user): Modify this to be the types you create that are owned by the primary resource
-	// Watch for changes to secondary resource Pods and requeue the owner ComplianceScan
-	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &compv1alpha1.ComplianceScan{},
-	})
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -452,6 +452,10 @@ func (r *ReconcileComplianceScan) scanDeleteHandler(instance *compv1alpha1.Compl
 			delete(scanToBeDeleted.Annotations, compv1alpha1.ComplianceScanRescanAnnotation)
 		}
 		// Force debug to be false so we actually remove dependent objects
+		// NOTE(jaosorior): When we're in debug mode, objects don't get deleted
+		// to aide in debugging. if we're actually going through a deletion as
+		// is the case in this code-path, then we REALLY want to make sure everything
+		// gets deleted.
 		scanToBeDeleted.Spec.Debug = false
 
 		// remove objects by forcing handling of phase DONE

--- a/pkg/controller/compliancescan/config.go
+++ b/pkg/controller/compliancescan/config.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/openshift/compliance-operator/pkg/controller/common"
 	"github.com/openshift/compliance-operator/pkg/utils"
 )
 
@@ -136,7 +137,7 @@ func createConfigMaps(r *ReconcileComplianceScan, scriptCmName, envCmName, platf
 
 	if err := r.client.Get(context.TODO(), types.NamespacedName{
 		Name:      scriptCmName,
-		Namespace: scan.Namespace,
+		Namespace: common.GetComplianceOperatorNamespace(),
 	}, cm); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
@@ -148,7 +149,7 @@ func createConfigMaps(r *ReconcileComplianceScan, scriptCmName, envCmName, platf
 
 	if err := r.client.Get(context.TODO(), types.NamespacedName{
 		Name:      envCmName,
-		Namespace: scan.Namespace,
+		Namespace: common.GetComplianceOperatorNamespace(),
 	}, cm); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
@@ -160,7 +161,7 @@ func createConfigMaps(r *ReconcileComplianceScan, scriptCmName, envCmName, platf
 
 	if err := r.client.Get(context.TODO(), types.NamespacedName{
 		Name:      platformEnvCmName,
-		Namespace: scan.Namespace,
+		Namespace: common.GetComplianceOperatorNamespace(),
 	}, cm); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
@@ -177,9 +178,10 @@ func defaultOpenScapScriptCm(name string, scan *compv1alpha1.ComplianceScan) *co
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: scan.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				asOwner(scan),
+			Namespace: common.GetComplianceOperatorNamespace(),
+			Labels: map[string]string{
+				compv1alpha1.ScanLabel:   scan.Name,
+				compv1alpha1.ScriptLabel: "",
 			},
 		},
 		Data: map[string]string{
@@ -192,9 +194,10 @@ func platformOpenScapScriptCm(name string, scan *compv1alpha1.ComplianceScan) *c
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: scan.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				asOwner(scan),
+			Namespace: common.GetComplianceOperatorNamespace(),
+			Labels: map[string]string{
+				compv1alpha1.ScanLabel:   scan.Name,
+				compv1alpha1.ScriptLabel: "",
 			},
 		},
 		Data: map[string]string{
@@ -209,9 +212,10 @@ func defaultOpenScapEnvCm(name string, scan *compv1alpha1.ComplianceScan) *corev
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: scan.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				asOwner(scan),
+			Namespace: common.GetComplianceOperatorNamespace(),
+			Labels: map[string]string{
+				compv1alpha1.ScanLabel:   scan.Name,
+				compv1alpha1.ScriptLabel: "",
 			},
 		},
 		Data: map[string]string{
@@ -245,9 +249,10 @@ func platformOpenScapEnvCm(name string, scan *compv1alpha1.ComplianceScan) *core
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: scan.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				asOwner(scan),
+			Namespace: common.GetComplianceOperatorNamespace(),
+			Labels: map[string]string{
+				compv1alpha1.ScanLabel:   scan.Name,
+				compv1alpha1.ScriptLabel: "",
 			},
 		},
 		Data: map[string]string{
@@ -279,16 +284,4 @@ func envCmForScan(scan *compv1alpha1.ComplianceScan) string {
 
 func envCmForPlatformScan(scan *compv1alpha1.ComplianceScan) string {
 	return utils.DNSLengthName("scap-env-", "%s-%s", scan.Name, OpenScapPlatformEnvConfigMapName)
-}
-
-func asOwner(scan *compv1alpha1.ComplianceScan) metav1.OwnerReference {
-	bTrue := true
-
-	return metav1.OwnerReference{
-		APIVersion: scan.APIVersion,
-		Kind:       scan.Kind,
-		Name:       scan.Name,
-		UID:        scan.UID,
-		Controller: &bTrue,
-	}
 }

--- a/pkg/controller/compliancescan/pki.go
+++ b/pkg/controller/compliancescan/pki.go
@@ -6,13 +6,13 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/openshift/compliance-operator/pkg/controller/common"
 )
 
 func (r *ReconcileComplianceScan) handleRootCASecret(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
-	exist, err := secretExists(r.client, RootCAPrefix+instance.Name, instance.GetNamespace())
+	exist, err := secretExists(r.client, RootCAPrefix+instance.Name, common.GetComplianceOperatorNamespace())
 	if err != nil {
 		return err
 	}
@@ -21,12 +21,8 @@ func (r *ReconcileComplianceScan) handleRootCASecret(instance *compv1alpha1.Comp
 	}
 
 	logger.Info("creating CA", "ComplianceScan.Name", instance.Name)
-	secret, err := makeCASecret(instance, instance.GetNamespace())
+	secret, err := makeCASecret(instance, common.GetComplianceOperatorNamespace())
 	if err != nil {
-		return err
-	}
-
-	if err = controllerutil.SetControllerReference(instance, secret, r.scheme); err != nil {
 		return err
 	}
 
@@ -40,7 +36,7 @@ func (r *ReconcileComplianceScan) handleRootCASecret(instance *compv1alpha1.Comp
 }
 
 func (r *ReconcileComplianceScan) handleResultServerSecret(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
-	exist, err := secretExists(r.client, ServerCertPrefix+instance.Name, instance.GetNamespace())
+	exist, err := secretExists(r.client, ServerCertPrefix+instance.Name, common.GetComplianceOperatorNamespace())
 	if err != nil {
 		return err
 	}
@@ -49,12 +45,8 @@ func (r *ReconcileComplianceScan) handleResultServerSecret(instance *compv1alpha
 	}
 
 	logger.Info("creating server cert", "ComplianceScan.Name", instance.Name)
-	secret, err := makeServerCertSecret(r.client, instance, instance.GetNamespace())
+	secret, err := makeServerCertSecret(r.client, instance, common.GetComplianceOperatorNamespace())
 	if err != nil {
-		return err
-	}
-
-	if err = controllerutil.SetControllerReference(instance, secret, r.scheme); err != nil {
 		return err
 	}
 
@@ -67,7 +59,7 @@ func (r *ReconcileComplianceScan) handleResultServerSecret(instance *compv1alpha
 }
 
 func (r *ReconcileComplianceScan) handleResultClientSecret(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
-	exist, err := secretExists(r.client, ClientCertPrefix+instance.Name, instance.GetNamespace())
+	exist, err := secretExists(r.client, ClientCertPrefix+instance.Name, common.GetComplianceOperatorNamespace())
 	if err != nil {
 		return err
 	}
@@ -76,12 +68,8 @@ func (r *ReconcileComplianceScan) handleResultClientSecret(instance *compv1alpha
 	}
 
 	logger.Info("creating client cert", "ComplianceScan.Name", instance.Name)
-	secret, err := makeClientCertSecret(r.client, instance, instance.GetNamespace())
+	secret, err := makeClientCertSecret(r.client, instance, common.GetComplianceOperatorNamespace())
 	if err != nil {
-		return err
-	}
-
-	if err = controllerutil.SetControllerReference(instance, secret, r.scheme); err != nil {
 		return err
 	}
 
@@ -96,21 +84,21 @@ func (r *ReconcileComplianceScan) handleResultClientSecret(instance *compv1alpha
 
 func (r *ReconcileComplianceScan) deleteRootCASecret(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
 	logger.Info("deleting CA", "ComplianceScan.Name", instance.Name)
-	ns := instance.GetNamespace()
+	ns := common.GetComplianceOperatorNamespace()
 	secret := certSecret(getCASecretName(instance), ns, []byte{}, []byte{}, []byte{})
 	return r.deleteSecret(secret)
 }
 
 func (r *ReconcileComplianceScan) deleteResultServerSecret(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
 	logger.Info("deleting server cert", "ComplianceScan.Name", instance.Name)
-	ns := instance.GetNamespace()
+	ns := common.GetComplianceOperatorNamespace()
 	secret := certSecret(getServerCertSecretName(instance), ns, []byte{}, []byte{}, []byte{})
 	return r.deleteSecret(secret)
 }
 
 func (r *ReconcileComplianceScan) deleteResultClientSecret(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
 	logger.Info("deleting client cert", "ComplianceScan.Name", instance.Name)
-	ns := instance.GetNamespace()
+	ns := common.GetComplianceOperatorNamespace()
 	secret := certSecret(getClientCertSecretName(instance), ns, []byte{}, []byte{}, []byte{})
 	return r.deleteSecret(secret)
 }

--- a/pkg/controller/compliancesuite/suitererunner.go
+++ b/pkg/controller/compliancesuite/suitererunner.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-logr/logr"
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/openshift/compliance-operator/pkg/controller/common"
 	"github.com/robfig/cron"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -12,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/openshift/compliance-operator/pkg/utils"
 )
@@ -23,11 +23,6 @@ func (r *ReconcileComplianceSuite) reconcileScanRerunnerCronJob(suite *compv1alp
 	rerunner := getRerunner(suite)
 	if suite.Spec.Schedule == "" {
 		return r.handleDelete(rerunner, logger)
-	}
-
-	if err := controllerutil.SetControllerReference(suite, rerunner, r.scheme); err != nil {
-		log.Error(err, "Failed to set pod ownership", "CronJob.Name", rerunner.GetName())
-		return err
 	}
 	return r.handleCreate(rerunner, logger)
 }
@@ -83,7 +78,7 @@ func getRerunner(suite *compv1alpha1.ComplianceSuite) *batchv1beta1.CronJob {
 	return &batchv1beta1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getRerunnerName(suite),
-			Namespace: suite.Namespace,
+			Namespace: common.GetComplianceOperatorNamespace(),
 		},
 		Spec: batchv1beta1.CronJobSpec{
 			Schedule: suite.Spec.Schedule,


### PR DESCRIPTION
this decouples the resources the operator creates with the resources it tracks. Now the operator can listen to whatever namespace(s) are specified by the `WATCH_NAMESPACE` environment variable, and it'll be able to react to those changes.

The operator's namespace is enforced as part of the `WATCH_NAMESPACE` set in order to get the cached client to track the operator's resources as well.

resource cleanup is now handled via finalizers for both the `ComplianceSuite` and `ComplianceScan` resources. This way, deletion is blocked until the resources as cleaned up, and then the finalizer is removed.