### PR TITLE
merge resultserver to main binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,8 @@
 # ==================
 export APP_NAME=compliance-operator
 RESULTSCOLLECTORBIN=resultscollector
-RESULTSERVERBIN=resultserver
 OPENSCAP_IMAGE_NAME=openscap-ocp
 RESULTSCOLLECTOR_IMAGE_NAME=$(RESULTSCOLLECTORBIN)
-RESULTSERVER_IMAGE_NAME=$(RESULTSERVERBIN)
 REMEDIATION_AGGREGATORBIN=remediation-aggregator
 REMEDIATION_AGGREGATOR_IMAGE_NAME=$(REMEDIATION_AGGREGATORBIN)
 API_RESOURCE_COLLECTORBIN=api-resource-collector
@@ -28,8 +26,6 @@ OPENSCAP_IMAGE_PATH=$(IMAGE_REPO)/$(OPENSCAP_IMAGE_NAME)
 OPENSCAP_DOCKERFILE_PATH=./images/openscap/Dockerfile
 RESULTSCOLLECTOR_IMAGE_PATH=$(IMAGE_REPO)/$(RESULTSCOLLECTOR_IMAGE_NAME)
 RESULTSCOLLECTOR_DOCKERFILE_PATH=./images/resultscollector/Dockerfile
-RESULTSERVER_IMAGE_PATH=$(IMAGE_REPO)/$(RESULTSERVER_IMAGE_NAME)
-RESULTSERVER_DOCKERFILE_PATH=./images/resultserver/Dockerfile
 REMEDIATION_AGGREGATOR_IMAGE_PATH=$(IMAGE_REPO)/$(REMEDIATION_AGGREGATOR_IMAGE_NAME)
 REMEDIATION_AGGREGATOR_DOCKERFILE_PATH=./images/remediation-aggregator/Dockerfile
 API_RESOURCE_COLLECTOR_IMAGE_PATH=$(IMAGE_REPO)/$(API_RESOURCE_COLLECTOR_IMAGE_NAME)
@@ -48,7 +44,6 @@ GOBUILD=$(GO) build
 BUILD_GOPATH=$(TARGET_DIR):$(CURPATH)/cmd
 TARGET=$(TARGET_DIR)/bin/$(APP_NAME)
 RESULTSCOLLECTOR_TARGET=$(TARGET_DIR)/bin/$(RESULTSCOLLECTORBIN)
-RESULTSERVER_TARGET=$(TARGET_DIR)/bin/$(RESULTSERVERBIN)
 AGGREGATOR_TARGET=$(TARGET_DIR)/bin/$(REMEDIATION_AGGREGATORBIN)
 API_RESOURCE_COLLECTOR_TARGET=$(TARGET_DIR)/bin/$(API_RESOURCE_COLLECTORBIN)
 MAIN_PKG=cmd/manager/main.go
@@ -110,7 +105,7 @@ help: ## Show this help screen
 
 
 .PHONY: image
-image: fmt operator-sdk operator-image resultscollector-image remediation-aggregator-image resultserver-image api-resource-collector-image ## Build the compliance-operator container image
+image: fmt operator-sdk operator-image resultscollector-image remediation-aggregator-image api-resource-collector-image ## Build the compliance-operator container image
 
 .PHONY: operator-image
 operator-image: operator-sdk
@@ -124,10 +119,6 @@ openscap-image:
 resultscollector-image:
 	$(RUNTIME) build -f $(RESULTSCOLLECTOR_DOCKERFILE_PATH) -t $(RESULTSCOLLECTOR_IMAGE_PATH):$(TAG) .
 
-.PHONY: resultserver-image
-resultserver-image:
-	$(RUNTIME) build -f $(RESULTSERVER_DOCKERFILE_PATH) -t $(RESULTSERVER_IMAGE_PATH):$(TAG) .
-
 .PHONY: remediation-aggregator-image
 remediation-aggregator-image:
 	$(RUNTIME) build -f $(REMEDIATION_AGGREGATOR_DOCKERFILE_PATH) -t $(REMEDIATION_AGGREGATOR_IMAGE_PATH):$(TAG) .
@@ -137,16 +128,13 @@ api-resource-collector-image:
 	$(RUNTIME) build -f $(API_RESOURCE_COLLECTOR_DOCKERFILE_PATH) -t $(API_RESOURCE_COLLECTOR_IMAGE_PATH):$(TAG) .
 
 .PHONY: build
-build: fmt manager resultscollector remediation-aggregator resultserver api-resource-collector ## Build the compliance-operator binary
+build: fmt manager resultscollector remediation-aggregator api-resource-collector ## Build the compliance-operator binary
 
 manager:
 	$(GO) build -o $(TARGET) github.com/openshift/compliance-operator/cmd/manager
 
 resultscollector:
 	$(GO) build -o $(RESULTSCOLLECTOR_TARGET) github.com/openshift/compliance-operator/cmd/resultscollector
-
-resultserver:
-	$(GO) build -o $(RESULTSERVER_TARGET) github.com/openshift/compliance-operator/cmd/resultserver
 
 remediation-aggregator:
 	$(GO) build -o $(AGGREGATOR_TARGET) github.com/openshift/compliance-operator/cmd/remediation-aggregator
@@ -233,7 +221,6 @@ e2e: namespace operator-sdk image-to-cluster openshift-user ## Run the end-to-en
 	@echo "Replacing workload references in deploy/operator.yaml"
 	@sed -i 's%$(IMAGE_REPO)/$(RESULTSCOLLECTOR_IMAGE_NAME):latest%$(RESULTSCOLLECTOR_IMAGE_PATH)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(OPENSCAP_IMAGE_NAME):$(OPENSCAP_DEFAULT_IMAGE_TAG)%$(OPENSCAP_IMAGE_PATH):$(OPENSCAP_IMAGE_TAG)%' deploy/operator.yaml
-	@sed -i 's%$(IMAGE_REPO)/$(RESULTSERVER_IMAGE_NAME):latest%$(RESULTSERVER_IMAGE_PATH)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(REMEDIATION_AGGREGATOR_IMAGE_NAME):latest%$(REMEDIATION_AGGREGATOR_IMAGE_PATH)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(API_RESOURCE_COLLECTOR_IMAGE_NAME):latest%$(API_RESOURCE_COLLECTOR_IMAGE_PATH)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(APP_NAME):latest%$(OPERATOR_IMAGE_PATH)%' deploy/operator.yaml
@@ -242,7 +229,6 @@ e2e: namespace operator-sdk image-to-cluster openshift-user ## Run the end-to-en
 	@echo "Restoring image references in deploy/operator.yaml"
 	@sed -i 's%$(RESULTSCOLLECTOR_IMAGE_PATH)%$(IMAGE_REPO)/$(RESULTSCOLLECTOR_IMAGE_NAME):latest%' deploy/operator.yaml
 	@sed -i 's%$(OPENSCAP_IMAGE_PATH):$(OPENSCAP_IMAGE_TAG)%$(IMAGE_REPO)/$(OPENSCAP_IMAGE_NAME):$(OPENSCAP_DEFAULT_IMAGE_TAG)%' deploy/operator.yaml
-	@sed -i 's%$(RESULTSERVER_IMAGE_PATH)%$(IMAGE_REPO)/$(RESULTSERVER_IMAGE_NAME):latest%' deploy/operator.yaml
 	@sed -i 's%$(REMEDIATION_AGGREGATOR_IMAGE_PATH)%$(IMAGE_REPO)/$(REMEDIATION_AGGREGATOR_IMAGE_NAME):latest%' deploy/operator.yaml
 	@sed -i 's%$(API_RESOURCE_COLLECTOR_IMAGE_PATH)%$(IMAGE_REPO)/$(API_RESOURCE_COLLECTOR_IMAGE_NAME):latest%' deploy/operator.yaml
 	@sed -i 's%$(OPERATOR_IMAGE_PATH)%$(IMAGE_REPO)/$(APP_NAME):latest%' deploy/operator.yaml
@@ -251,14 +237,12 @@ e2e-local: operator-sdk ## Run the end-to-end tests on a locally running operato
 	@echo "WARNING: This will temporarily modify deploy/operator.yaml"
 	@echo "Replacing workload references in deploy/operator.yaml"
 	@sed -i 's%$(IMAGE_REPO)/$(RESULTSCOLLECTOR_IMAGE_NAME):latest%$(RESULTSCOLLECTOR_IMAGE_PATH)%' deploy/operator.yaml
-	@sed -i 's%$(IMAGE_REPO)/$(RESULTSERVER_IMAGE_NAME):latest%$(RESULTSERVER_IMAGE_PATH)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(API_RESOURCE_COLLECTOR_IMAGE_NAME):latest%$(API_RESOURCE_COLLECTOR_IMAGE_PATH)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(API_RESOURCE_COLLECTOR_IMAGE_NAME):latest%$(API_RESOURCE_COLLECTOR_IMAGE_PATH)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(APP_NAME):latest%$(OPERATOR_IMAGE_PATH)%' deploy/operator.yaml
 	unset GOFLAGS && $(GOPATH)/bin/operator-sdk test local ./tests/e2e --up-local --skip-cleanup-error --image "$(OPERATOR_IMAGE_PATH)" --namespace "$(NAMESPACE)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
 	@echo "Restoring image references in deploy/operator.yaml"
 	@sed -i 's%$(RESULTSCOLLECTOR_IMAGE_PATH)%$(IMAGE_REPO)/$(RESULTSCOLLECTOR_IMAGE_NAME):latest%' deploy/operator.yaml
-	@sed -i 's%$(RESULTSERVER_IMAGE_PATH)%$(IMAGE_REPO)/$(RESULTSERVER_IMAGE_NAME):latest%' deploy/operator.yaml
 	@sed -i 's%$(API_RESOURCE_COLLECTOR_IMAGE_PATH)%$(IMAGE_REPO)/$(API_RESOURCE_COLLECTOR_IMAGE_NAME):latest%' deploy/operator.yaml
 	@sed -i 's%$(API_RESOURCE_COLLECTOR_IMAGE_PATH)%$(IMAGE_REPO)/$(API_RESOURCE_COLLECTOR_IMAGE_NAME):latest%' deploy/operator.yaml
 	@sed -i 's%$(OPERATOR_IMAGE_PATH)%$(IMAGE_REPO)/$(APP_NAME):latest%' deploy/operator.yaml
@@ -293,8 +277,6 @@ image-to-cluster:
 	$(eval OPERATOR_IMAGE_PATH = $(IMAGE_FORMAT))
 	$(eval component = compliance-resultscollector)
 	$(eval RESULTSCOLLECTOR_IMAGE_PATH = $(IMAGE_FORMAT))
-	$(eval component = compliance-resultserver)
-	$(eval RESULTSERVER_IMAGE_PATH = $(IMAGE_FORMAT))
 	$(eval component = compliance-remediation-aggregator)
 	$(eval REMEDIATION_AGGREGATOR_IMAGE_PATH = $(IMAGE_FORMAT))
 else ifeq ($(E2E_USE_DEFAULT_IMAGES), true)
@@ -305,7 +287,6 @@ image-to-cluster:
 	@echo "E2E_SKIP_CONTAINER_PUSH variable detected. Using previously pushed images."
 	$(eval OPERATOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(APP_NAME):$(TAG))
 	$(eval RESULTSCOLLECTOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(RESULTSCOLLECTOR_IMAGE_NAME):$(TAG))
-	$(eval RESULTSERVER_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(RESULTSERVER_IMAGE_NAME):$(TAG))
 	$(eval REMEDIATION_AGGREGATOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(REMEDIATION_AGGREGATOR_IMAGE_NAME):$(TAG))
 	$(eval API_RESOURCE_COLLECTOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(API_RESOURCE_COLLECTOR_IMAGE_NAME):$(TAG))
 else ifeq ($(E2E_SKIP_CONTAINER_BUILD), true)
@@ -325,14 +306,12 @@ cluster-image-push: namespace openshift-user
 		$(RUNTIME) login --tls-verify=false -u $(OPENSHIFT_USER) -p $(shell oc whoami -t) $${IMAGE_REGISTRY_HOST}; \
 		$(RUNTIME) push --tls-verify=false $(OPERATOR_IMAGE_PATH):$(TAG) $${IMAGE_REGISTRY_HOST}/$(NAMESPACE)/$(APP_NAME):$(TAG); \
 		$(RUNTIME) push --tls-verify=false $(RESULTSCOLLECTOR_IMAGE_PATH):$(TAG) $${IMAGE_REGISTRY_HOST}/$(NAMESPACE)/$(RESULTSCOLLECTOR_IMAGE_NAME):$(TAG); \
-		$(RUNTIME) push --tls-verify=false $(RESULTSERVER_IMAGE_PATH):$(TAG) $${IMAGE_REGISTRY_HOST}/$(NAMESPACE)/$(RESULTSERVER_IMAGE_NAME):$(TAG); \
 		$(RUNTIME) push --tls-verify=false $(REMEDIATION_AGGREGATOR_IMAGE_PATH):$(TAG) $${IMAGE_REGISTRY_HOST}/$(NAMESPACE)/$(REMEDIATION_AGGREGATOR_IMAGE_NAME):$(TAG); \
 		$(RUNTIME) push --tls-verify=false $(API_RESOURCE_COLLECTOR_IMAGE_PATH):$(TAG) $${IMAGE_REGISTRY_HOST}/$(NAMESPACE)/$(API_RESOURCE_COLLECTOR_IMAGE_NAME):$(TAG)
 	@echo "Removing the route from the image registry"
 	@oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":false}}' --type=merge
 	$(eval OPERATOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(APP_NAME):$(TAG))
 	$(eval RESULTSCOLLECTOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(RESULTSCOLLECTOR_IMAGE_NAME):$(TAG))
-	$(eval RESULTSERVER_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(RESULTSERVER_IMAGE_NAME):$(TAG))
 	$(eval REMEDIATION_AGGREGATOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(REMEDIATION_AGGREGATOR_IMAGE_NAME):$(TAG))
 	$(eval API_RESOURCE_COLLECTOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(API_RESOURCE_COLLECTOR_IMAGE_NAME):$(TAG))
 
@@ -355,8 +334,6 @@ push: image
 	$(RUNTIME) push $(OPERATOR_IMAGE_PATH):$(TAG)
 	# resultscollector
 	$(RUNTIME) push $(RESULTSCOLLECTOR_IMAGE_PATH):$(TAG)
-	# resultserver
-	$(RUNTIME) push $(RESULTSERVER_IMAGE_PATH):$(TAG)
 	# remediation-aggregator
 	$(RUNTIME) push $(REMEDIATION_AGGREGATOR_IMAGE_PATH):$(TAG)
 	# api-resource-collector
@@ -391,7 +368,6 @@ release-tag-image: package-version-to-tag
 	@echo "Temporarily overriding image tags in deploy/operator.yaml"
 	@sed -i 's%$(IMAGE_REPO)/$(APP_NAME):latest%$(OPERATOR_IMAGE_PATH):$(TAG)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(RESULTSCOLLECTOR_IMAGE_NAME):latest%$(RESULTSCOLLECTOR_IMAGE_PATH):$(TAG)%' deploy/operator.yaml
-	@sed -i 's%$(IMAGE_REPO)/$(RESULTSERVER_IMAGE_NAME):latest%$(RESULTSERVER_IMAGE_PATH):$(TAG)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(REMEDIATION_AGGREGATOR_IMAGE_NAME):latest%$(REMEDIATION_AGGREGATOR_IMAGE_PATH):$(TAG)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(API_RESOURCE_COLLECTOR_IMAGE_NAME):latest%$(API_RESOURCE_COLLECTOR_IMAGE_PATH):$(TAG)%' deploy/operator.yaml
 
@@ -400,7 +376,6 @@ undo-deploy-tag-image: package-version-to-tag
 	@echo "Restoring image tags in deploy/operator.yaml"
 	@sed -i 's%$(OPERATOR_IMAGE_PATH):$(TAG)%$(IMAGE_REPO)/$(APP_NAME):latest%' deploy/operator.yaml
 	@sed -i 's%$(RESULTSCOLLECTOR_IMAGE_PATH):$(TAG)%$(IMAGE_REPO)/$(RESULTSCOLLECTOR_IMAGE_NAME):latest%' deploy/operator.yaml
-	@sed -i 's%$(RESULTSERVER_IMAGE_PATH):$(TAG)%$(IMAGE_REPO)/$(RESULTSERVER_IMAGE_NAME):latest%' deploy/operator.yaml
 	@sed -i 's%$(REMEDIATION_AGGREGATOR_IMAGE_PATH):$(TAG)%$(IMAGE_REPO)/$(REMEDIATION_AGGREGATOR_IMAGE_NAME):latest%' deploy/operator.yaml
 	@sed -i 's%$(API_RESOURCE_COLLECTOR_IMAGE_PATH):$(TAG)%$(IMAGE_REPO)/$(API_RESOURCE_COLLECTOR_IMAGE_NAME):latest%' deploy/operator.yaml
 

--- a/cmd/manager/common.go
+++ b/cmd/manager/common.go
@@ -10,9 +10,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	compapis "github.com/openshift/compliance-operator/pkg/apis"
 )
+
+var log = logf.Log.WithName("cmd")
 
 type complianceCrClient struct {
 	client runtimeclient.Client

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -33,6 +33,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(operatorCmd)
 	rootCmd.AddCommand(rerunnerCmd)
+	rootCmd.AddCommand(resultServerCmd)
 }
 
 func main() {

--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -44,7 +44,6 @@ var (
 	metricsPort         int32 = 8383
 	operatorMetricsPort int32 = 8686
 )
-var log = logf.Log.WithName("cmd")
 
 func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))

--- a/cmd/manager/suitererunner.go
+++ b/cmd/manager/suitererunner.go
@@ -25,7 +25,7 @@ var rerunnerCmd = &cobra.Command{
 }
 
 func init() {
-	defineFlags(rerunnerCmd)
+	defineRerunnerFlags(rerunnerCmd)
 }
 
 type rerunnerconfig struct {
@@ -34,7 +34,7 @@ type rerunnerconfig struct {
 	client    *complianceCrClient
 }
 
-func defineFlags(cmd *cobra.Command) {
+func defineRerunnerFlags(cmd *cobra.Command) {
 	cmd.Flags().String("name", "", "The name of the ComplianceSuite to be re-run")
 	cmd.Flags().String("namespace", "", "The namespace of the ComplianceSuite to be re-run")
 }

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -36,8 +36,6 @@ spec:
               value: "quay.io/compliance-operator/openscap-ocp:1.3.3"
             - name: LOG_COLLECTOR_IMAGE
               value: "quay.io/compliance-operator/resultscollector:latest"
-            - name: RESULT_SERVER_IMAGE
-              value: "quay.io/compliance-operator/resultserver:latest"
             - name: REMEDIATION_AGGREGATOR_IMAGE
               value: "quay.io/compliance-operator/remediation-aggregator:latest"
             - name: API_RESOURCE_COLLECTOR_IMAGE

--- a/images/resultserver/Dockerfile
+++ b/images/resultserver/Dockerfile
@@ -1,18 +1,1 @@
-# Step one: build resultserver
-FROM registry.access.redhat.com/ubi8/go-toolset as builder
-
-WORKDIR /go/src/github.com/openshift/compliance-operator
-
-ENV GOFLAGS=-mod=vendor
-COPY . .
-RUN make resultserver 
-
-# Step two: containerize resultserver
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-
-USER root
-
-# build resultserver
-COPY --from=builder /go/src/github.com/openshift/compliance-operator/build/_output/bin/resultserver /usr/local/bin/resultserver
-
-ENTRYPOINT ["/usr/local/bin/resultserver"]

--- a/images/resultserver/Dockerfile.ci
+++ b/images/resultserver/Dockerfile.ci
@@ -1,18 +1,1 @@
-# Step one: build resultserver
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
-
-WORKDIR /go/src/github.com/openshift/compliance-operator
-
-ENV GOFLAGS=-mod=vendor
-COPY . .
-RUN make resultserver
-
-# Step two: containerize resultserver
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-
-USER root
-
-# build resultserver
-COPY --from=builder /go/src/github.com/openshift/compliance-operator/build/_output/bin/resultserver /usr/local/bin/resultserver
-
-ENTRYPOINT ["/usr/local/bin/resultserver"]

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -113,9 +113,10 @@ func resultServer(scanInstance *compv1alpha1.ComplianceScan, labels map[string]s
 					Containers: []corev1.Container{
 						{
 							Name:            "result-server",
-							Image:           utils.GetComponentImage(utils.RESULT_SERVER),
+							Image:           utils.GetComponentImage(utils.OPERATOR),
 							ImagePullPolicy: corev1.PullAlways,
-							Args: []string{
+							Command: []string{
+								"compliance-operator", "resultserver",
 								"--path=/reports/",
 								"--address=0.0.0.0",
 								fmt.Sprintf("--port=%d", ResultServerPort),


### PR DESCRIPTION
This removes the resultserver binary to be included as a subcommand of
the main binary.

The remaining images are still there but are empty, and will be removed
in a subsequent PR.