### PR TITLE
e2e: Make sure ComplianceCheckResult has the expected labels

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -580,6 +580,7 @@ func TestE2E(t *testing.T) {
 					},
 					ID:     "xccdf_org.ssgproject.content_rule_wireless_disable_in_bios",
 					Status: compv1alpha1.CheckResultInfo,
+					Severity: compv1alpha1.CheckResultSeverityUnknown, // yes, it's really uknown in the DS
 				}
 
 				err = assertHasCheck(f, suiteName, workerScanName, checkWifiInBios)
@@ -756,6 +757,7 @@ func TestE2E(t *testing.T) {
 					},
 					ID:     "xccdf_org.ssgproject.content_rule_no_direct_root_logins",
 					Status: compv1alpha1.CheckResultPass,
+					Severity:compv1alpha1.CheckResultSeverityMedium,
 				}
 				err = assertHasCheck(f, suiteName, workerScanName, checkNoDirectRootLogins)
 				if err != nil {

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -501,6 +501,15 @@ func assertHasCheck(f *framework.Framework, suiteName, scanName string, check co
 	if getCheck.Labels[compv1alpha1.ScanLabel] != scanName {
 		return fmt.Errorf("Did not find expected suite name label %s, found %s", suiteName, getCheck.Labels[compv1alpha1.SuiteLabel])
 	}
+
+	if getCheck.Labels[compv1alpha1.ComplianceCheckResultSeverityLabel] != string(getCheck.Severity) {
+		return fmt.Errorf("did not find expected severity name label %s, found %s", suiteName, getCheck.Labels[compv1alpha1.ComplianceCheckResultSeverityLabel])
+	}
+
+	if getCheck.Labels[compv1alpha1.ComplianceCheckResultStatusLabel] != string(getCheck.Status) {
+		return fmt.Errorf("did not find expected status name label %s, found %s", suiteName, getCheck.Labels[compv1alpha1.ComplianceCheckResultStatusLabel])
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Turns out we already did store the labels we wanted to have per CMP-633 so I just added a test to ensure the labels stay this way﻿
