### PR TITLE
Replace reference to well-known label with kubernetes provided variable

### DIFF
--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -40,7 +40,6 @@ var (
 const (
 	// OpenSCAPScanContainerName defines the name of the contianer that will run OpenSCAP
 	OpenSCAPScanContainerName = "openscap-ocp"
-	NodeHostnameLabel         = "kubernetes.io/hostname"
 	// The default time we should wait before requeuing
 	requeueAfterDefault = 10 * time.Second
 )

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -202,7 +202,7 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 				},
 			},
 			NodeSelector: map[string]string{
-				NodeHostnameLabel: node.Labels[NodeHostnameLabel],
+				corev1.LabelHostname: node.Labels[corev1.LabelHostname],
 			},
 			RestartPolicy: corev1.RestartPolicyOnFailure,
 			Volumes: []corev1.Volume{


### PR DESCRIPTION
We were defining our own value for the well-known label for node
hostnames. This wasn't the label comes as part of kubernetes' API.