### PR TITLE
Make tailoring profiles work cross-namespaces

### DIFF
--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -63,6 +63,12 @@ func (r *ReconcileComplianceScan) createPlatformScanPod(instance *compv1alpha1.C
 	logger.Info("Creating a Platform scan pod")
 	pod := newPlatformScanPod(instance, logger)
 
+	if instance.Spec.TailoringConfigMap != nil {
+		if err := r.reconcileTailoring(instance, pod, logger); err != nil {
+			return err
+		}
+	}
+
 	err := r.client.Create(context.TODO(), pod)
 	if errors.IsAlreadyExists(err) {
 		logger.Info("Pod already exists. This is fine.", "pod", pod)


### PR DESCRIPTION
If the watch-namespace is another one other than the operator's
namespace, the tailoring profiles wouldn't work as we couldn't bind them
to the scan pods.

So this copies over the tailoring namespace in order to take it into
use.