### PR TITLE
Stop ignoring errors in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ test-unit: fmt ## Run the unit tests
 ifndef JUNITFILE
 	@$(GO) test $(TEST_OPTIONS) $(PKGS)
 else
-	@set -o pipefail; $(GO) test $(TEST_OPTIONS) -json $(PKGS) --ginkgo.noColor | gotest2junit -v > $(JUNITFILE)
+	@set -o pipefail; $(GO) test $(TEST_OPTIONS) -json $(PKGS) | gotest2junit -v > $(JUNITFILE)
 endif
 
 .PHONY: test-benchmark

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ test-unit: fmt ## Run the unit tests
 ifndef JUNITFILE
 	@$(GO) test $(TEST_OPTIONS) $(PKGS)
 else
-	@$(GO) test $(TEST_OPTIONS) -json $(PKGS) --ginkgo.noColor | gotest2junit -v > $(JUNITFILE)
+	@set -o pipefail; $(GO) test $(TEST_OPTIONS) -json $(PKGS) --ginkgo.noColor | gotest2junit -v > $(JUNITFILE)
 endif
 
 .PHONY: test-benchmark

--- a/cmd/manager/scap_test.go
+++ b/cmd/manager/scap_test.go
@@ -10,14 +10,14 @@ func TestSCAPContentParsing(t *testing.T) {
 	debugLog = true
 	tests := map[string]struct {
 		profile  string
-		expected map[string]string
+		expected []string
 		data     string
 	}{
 		"ssg-ocp4-ds.xml(mocked) new": {
 			profile: "xccdf_org.ssgproject.content_profile_platform-moderate",
 			data:    "../../tests/data/ssg-ocp4-ds-new.xml",
-			expected: map[string]string{
-				"/apis/config.openshift.io/v1/oauths/cluster": "/idp.yml",
+			expected: []string{
+				"/apis/config.openshift.io/v1/oauths/cluster",
 			},
 		},
 	}

--- a/pkg/controller/compliancescan/compliancescan_controller_test.go
+++ b/pkg/controller/compliancescan/compliancescan_controller_test.go
@@ -30,6 +30,9 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 	)
 
 	BeforeEach(func() {
+		// Uncomment these lines if you need to debug the controller's output.
+		// dev, _ := zap.NewDevelopment()
+		// logger = zapr.NewLogger(dev)
 		logger = zapr.NewLogger(zap.NewNop())
 		objs := []runtime.Object{}
 
@@ -107,14 +110,16 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 				podName1 := getPodForNodeName(compliancescaninstance.Name, nodeinstance1.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: podName1,
+						Name:      podName1,
+						Namespace: common.GetComplianceOperatorNamespace(),
 					},
 				})
 
 				podName2 := getPodForNodeName(compliancescaninstance.Name, nodeinstance2.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: podName2,
+						Name:      podName2,
+						Namespace: common.GetComplianceOperatorNamespace(),
 					},
 				})
 
@@ -127,6 +132,11 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 
 			It("should stay in RUNNING state", func() {
 				result, err := reconciler.phaseRunningHandler(compliancescaninstance, logger)
+				pods := &corev1.PodList{}
+				reconciler.client.List(context.TODO(), pods)
+				for _, pod := range pods.Items {
+					fmt.Printf("* OZZ: Found pod: %s\n", pod.Name)
+				}
 				Expect(result).ToNot(BeNil())
 				Expect(err).To(BeNil())
 				Expect(compliancescaninstance.Status.Phase).To(Equal(compv1alpha1.PhaseRunning))
@@ -139,7 +149,8 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 				podName1 := getPodForNodeName(compliancescaninstance.Name, nodeinstance1.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: podName1,
+						Name:      podName1,
+						Namespace: common.GetComplianceOperatorNamespace(),
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
@@ -149,7 +160,8 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 				podName2 := getPodForNodeName(compliancescaninstance.Name, nodeinstance2.Name)
 				reconciler.client.Create(context.TODO(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: podName2,
+						Name:      podName2,
+						Namespace: common.GetComplianceOperatorNamespace(),
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
@@ -178,14 +190,16 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 			podName1 := fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance1.Name)
 			reconciler.client.Create(context.TODO(), &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: podName1,
+					Name:      podName1,
+					Namespace: common.GetComplianceOperatorNamespace(),
 				},
 			})
 
 			podName2 := fmt.Sprintf("%s-%s-pod", compliancescaninstance.Name, nodeinstance2.Name)
 			reconciler.client.Create(context.TODO(), &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: podName2,
+					Name:      podName2,
+					Namespace: common.GetComplianceOperatorNamespace(),
 				},
 			})
 

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -47,12 +47,12 @@ func (r *ReconcileComplianceScan) createNodeScanPods(instance *compv1alpha1.Comp
 		// ..and launch it..
 		err := r.client.Create(context.TODO(), pod)
 		if errors.IsAlreadyExists(err) {
-			logger.Info("Pod already exists. This is fine.", "Pod.Name", pod)
+			logger.Info("Pod already exists. This is fine.", "Pod.Name", pod.Name)
 		} else if err != nil {
-			log.Error(err, "Failed to launch a pod", "Pod.Name", pod)
+			log.Error(err, "Failed to launch a pod", "Pod.Name", pod.Name)
 			return err
 		} else {
-			logger.Info("Launched a pod", "Pod.Name", pod)
+			logger.Info("Launched a pod", "Pod.Name", pod.Name)
 		}
 	}
 
@@ -439,12 +439,12 @@ func (r *ReconcileComplianceScan) deleteScanPods(instance *compv1alpha1.Complian
 		// Delete it.
 		err := r.client.Delete(context.TODO(), pod)
 		if errors.IsNotFound(err) {
-			logger.Info("Pod is already gone. This is fine.", "Pod.Name", pod)
+			logger.Info("Pod is already gone. This is fine.", "Pod.Name", pod.Name)
 		} else if err != nil {
-			log.Error(err, "Failed to delete a pod", "Pod.Name", pod)
+			log.Error(err, "Failed to delete a pod", "Pod.Name", pod.Name)
 			return err
 		} else {
-			logger.Info("deleted pod", "Pod.Name", pod)
+			logger.Info("deleted pod", "Pod.Name", pod.Name)
 		}
 	}
 


### PR DESCRIPTION
The command that transformed the unit test into junit was eating up the
error the go test command was throwing.