### PR TITLE
Revert 2f35eebedc69eb8ceecb3ab7746833a50e49dae6: make: Fix make run after upgrade to operator-sdk 1.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ run: operator-sdk ## Run the compliance-operator locally
 	WATCH_NAMESPACE=$(NAMESPACE) \
 	KUBERNETES_CONFIG=$(KUBECONFIG) \
 	OPERATOR_NAME=compliance-operator \
-	$(GOPATH)/bin/operator-sdk run --local --watch-namespace $(NAMESPACE) --operator-flags operator
+	$(GOPATH)/bin/operator-sdk run --local --namespace $(NAMESPACE) --operator-flags operator
 
 .PHONY: clean
 clean: clean-modcache clean-cache clean-output ## Clean the golang environment


### PR DESCRIPTION
We better support operator-sdk with all commands or none, so let's
revert that partial fix.