### PR TITLE
Don't use /tmp for scan data

### DIFF
--- a/pkg/controller/compliancescan/config.go
+++ b/pkg/controller/compliancescan/config.go
@@ -41,7 +41,7 @@ const (
 	PlatformScanName                  = "api-checks"
 	PlatformScanResourceCollectorName = "api-resource-collector"
 	// This coincides with the default ocp_data_root var in CaC.
-	PlatformScanDataRoot = "/tmp"
+	PlatformScanDataRoot = "/scan_data"
 )
 
 var defaultOpenScapScriptContents = `#!/bin/bash


### PR DESCRIPTION
@JAORMX I chose "/scan_data". If we hardcode this for ocp_data_root in CaC and merge this afterwards, we should be good.