### PR TITLE
Fix platform scans

### DIFF
--- a/pkg/controller/compliancescan/config.go
+++ b/pkg/controller/compliancescan/config.go
@@ -41,7 +41,7 @@ const (
 	PlatformScanName                  = "api-checks"
 	PlatformScanResourceCollectorName = "api-resource-collector"
 	// This coincides with the default ocp_data_root var in CaC.
-	PlatformScanDataRoot = "/tmp"
+	PlatformScanDataRoot = "/kubernetes-api-resources"
 )
 
 var defaultOpenScapScriptContents = `#!/bin/bash

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -952,7 +952,7 @@ func TestE2E(t *testing.T) {
 								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
 									ContentImage: "quay.io/complianceascode/ocp4:latest",
 									Profile:      "xccdf_org.ssgproject.content_profile_moderate",
-									Content:      ocpContentFile,
+									Content:      rhcosContentFile,
 									NodeSelector: selectWorkers,
 								},
 								Name: workerScanName,

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -115,7 +115,7 @@ func TestE2E(t *testing.T) {
 						Namespace: namespace,
 					},
 					Spec: compv1alpha1.ComplianceScanSpec{
-						Profile: "xccdf_org.ssgproject.content_profile_moderate",
+						Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 						Content:      rhcosContentFile,
 						Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
 						NodeSelector: selectWorkers,
@@ -960,7 +960,7 @@ func TestE2E(t *testing.T) {
 							{
 								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
 									ScanType:     compv1alpha1.ScanTypePlatform,
-									ContentImage: "quay.io/compliance-operator/ocp4-openscap-content:platform_test",
+									ContentImage: "quay.io/complianceascode/ocp4:latest",
 									Profile:      "xccdf_org.ssgproject.content_profile_platform-moderate",
 									Content:      ocpContentFile,
 								},

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -931,7 +931,6 @@ func TestE2E(t *testing.T) {
 		testExecution{
 			Name: "TestPlatformAndNodeSuiteScan",
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, mcTctx *mcTestCtx, namespace string) error {
-				t.Skip("Skipping this test temporarily as we fix the OCP4 content")
 				suiteName := "test-suite-two-scans-with-platform"
 
 				workerScanName := fmt.Sprintf("%s-workers-scan", suiteName)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -961,7 +961,7 @@ func TestE2E(t *testing.T) {
 								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
 									ScanType:     compv1alpha1.ScanTypePlatform,
 									ContentImage: "quay.io/complianceascode/ocp4:latest",
-									Profile:      "xccdf_org.ssgproject.content_profile_platform-moderate",
+									Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 									Content:      ocpContentFile,
 								},
 								Name: platformScanName,


### PR DESCRIPTION
This takes @mrogers950's PR (https://github.com/openshift/compliance-operator/pull/282) into use which gets the necessary resource to detect if OCP is being used.

Subsequently, this introduces the hardcoded path `/kubernetes-api-resources` as the place to put the fetched resources before scanning. Matching what we introduced in the content in https://github.com/ComplianceAsCode/content/pull/5824

Finally, this removes the `Skip` statement so we actually start testing platform checks again.
