### PR TITLE
e2e: Save container logs to ARTIFACT_DIR

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -108,7 +108,7 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
-				err = scanResultIsExpected(f, namespace, scanName, compv1alpha1.ResultCompliant)
+				err = scanResultIsExpected(t, f, namespace, scanName, compv1alpha1.ResultCompliant)
 				if err != nil {
 					return err
 				}
@@ -145,7 +145,7 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
-				err = scanResultIsExpected(f, namespace, scanName, compv1alpha1.ResultCompliant)
+				err = scanResultIsExpected(t, f, namespace, scanName, compv1alpha1.ResultCompliant)
 				if err != nil {
 					return err
 				}
@@ -203,7 +203,7 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
-				err = scanResultIsExpected(f, namespace, scanName, compv1alpha1.ResultError)
+				err = scanResultIsExpected(t, f, namespace, scanName, compv1alpha1.ResultError)
 				if err != nil {
 					return err
 				}
@@ -262,7 +262,7 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
-				err = scanResultIsExpected(f, namespace, scanName, compv1alpha1.ResultError)
+				err = scanResultIsExpected(t, f, namespace, scanName, compv1alpha1.ResultError)
 				if err != nil {
 					return err
 				}
@@ -328,7 +328,7 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
-				return scanResultIsExpected(f, namespace, "test-single-tailored-scan-succeeds", compv1alpha1.ResultCompliant)
+				return scanResultIsExpected(t, f, namespace, "test-single-tailored-scan-succeeds", compv1alpha1.ResultCompliant)
 			},
 		},
 		testExecution{
@@ -369,7 +369,7 @@ func TestE2E(t *testing.T) {
 						"The number of reports doesn't match the number of selected nodes: "+
 							"%d reports / %d nodes", len(configmaps), len(nodes))
 				}
-				return scanResultIsExpected(f, namespace, "test-filtered-scan", compv1alpha1.ResultCompliant)
+				return scanResultIsExpected(t, f, namespace, "test-filtered-scan", compv1alpha1.ResultCompliant)
 			},
 		},
 		testExecution{
@@ -398,7 +398,7 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				return scanResultIsExpected(f, namespace, "test-scan-w-invalid-content", compv1alpha1.ResultError)
+				return scanResultIsExpected(t, f, namespace, "test-scan-w-invalid-content", compv1alpha1.ResultError)
 			},
 		},
 		testExecution{
@@ -427,7 +427,7 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				return scanResultIsExpected(f, namespace, "test-scan-w-invalid-profile", compv1alpha1.ResultError)
+				return scanResultIsExpected(t, f, namespace, "test-scan-w-invalid-profile", compv1alpha1.ResultError)
 			},
 		},
 		testExecution{
@@ -486,7 +486,7 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				return scanResultIsExpected(f, namespace, "test-malformed-tailored-scan-fails", compv1alpha1.ResultError)
+				return scanResultIsExpected(t, f, namespace, "test-malformed-tailored-scan-fails", compv1alpha1.ResultError)
 			},
 		},
 		testExecution{
@@ -516,7 +516,7 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				return scanResultIsExpected(f, namespace, "test-scan-w-empty-tailoring-cm", compv1alpha1.ResultError)
+				return scanResultIsExpected(t, f, namespace, "test-scan-w-empty-tailoring-cm", compv1alpha1.ResultError)
 			},
 		},
 		testExecution{
@@ -555,7 +555,7 @@ func TestE2E(t *testing.T) {
 				// The status might still be NOT-AVAILABLE... we can wait a bit
 				// for the reconciliation to update it.
 				_ = wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
-					if resultErr = scanResultIsExpected(f, namespace, scanName, compv1alpha1.ResultError); resultErr != nil {
+					if resultErr = scanResultIsExpected(t, f, namespace, scanName, compv1alpha1.ResultError); resultErr != nil {
 						return false, nil
 					}
 					return true, nil
@@ -592,7 +592,7 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
-				return scanResultIsExpected(f, namespace, scanName, compv1alpha1.ResultCompliant)
+				return scanResultIsExpected(t, f, namespace, scanName, compv1alpha1.ResultCompliant)
 			},
 		},
 		testExecution{
@@ -641,7 +641,7 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				return scanResultIsExpected(f, namespace, "test-missing-pod-scan", compv1alpha1.ResultCompliant)
+				return scanResultIsExpected(t, f, namespace, "test-missing-pod-scan", compv1alpha1.ResultCompliant)
 			},
 		},
 		testExecution{
@@ -849,11 +849,11 @@ func TestE2E(t *testing.T) {
 				}
 
 				// At this point, both scans should be non-compliant given our current content
-				err = scanResultIsExpected(f, namespace, workerScanName, compv1alpha1.ResultNonCompliant)
+				err = scanResultIsExpected(t, f, namespace, workerScanName, compv1alpha1.ResultNonCompliant)
 				if err != nil {
 					return err
 				}
-				err = scanResultIsExpected(f, namespace, masterScanName, compv1alpha1.ResultNonCompliant)
+				err = scanResultIsExpected(t, f, namespace, masterScanName, compv1alpha1.ResultNonCompliant)
 				if err != nil {
 					return err
 				}
@@ -1732,13 +1732,13 @@ func TestE2E(t *testing.T) {
 				}
 
 				// At this point, both scans should be non-compliant given our current content
-				err = scanResultIsExpected(f, namespace, workerScanName, compv1alpha1.ResultNonCompliant)
+				err = scanResultIsExpected(t, f, namespace, workerScanName, compv1alpha1.ResultNonCompliant)
 				if err != nil {
 					return err
 				}
 
 				// The profile should find one check for an htpasswd IDP, so we should be compliant.
-				err = scanResultIsExpected(f, namespace, platformScanName, compv1alpha1.ResultCompliant)
+				err = scanResultIsExpected(t, f, namespace, platformScanName, compv1alpha1.ResultCompliant)
 				if err != nil {
 					return err
 				}
@@ -1873,7 +1873,7 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
-				err = scanResultIsExpected(f, namespace, platformScanName, compv1alpha1.ResultNonCompliant)
+				err = scanResultIsExpected(t, f, namespace, platformScanName, compv1alpha1.ResultNonCompliant)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This saves per-test container logs to ARTIFACT_DIR at the end of waitFor* functions.