### PR TITLE
Remove unused container manifests

### DIFF
--- a/images/api-resource-collector/Dockerfile
+++ b/images/api-resource-collector/Dockerfile
@@ -1,1 +1,0 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/images/api-resource-collector/Dockerfile.ci
+++ b/images/api-resource-collector/Dockerfile.ci
@@ -1,1 +1,0 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/images/remediation-aggregator/Dockerfile
+++ b/images/remediation-aggregator/Dockerfile
@@ -1,1 +1,0 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/images/remediation-aggregator/Dockerfile.ci
+++ b/images/remediation-aggregator/Dockerfile.ci
@@ -1,1 +1,0 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/images/resultscollector/Dockerfile
+++ b/images/resultscollector/Dockerfile
@@ -1,1 +1,0 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/images/resultscollector/Dockerfile.ci
+++ b/images/resultscollector/Dockerfile.ci
@@ -1,1 +1,0 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/images/resultserver/Dockerfile
+++ b/images/resultserver/Dockerfile
@@ -1,1 +1,0 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/images/resultserver/Dockerfile.ci
+++ b/images/resultserver/Dockerfile.ci
@@ -1,1 +1,0 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest


### PR DESCRIPTION
These are no longer used as we have everything as part of the main
binary.