### PR TITLE
Move command registration to their own files

### DIFF
--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -56,6 +56,7 @@ var aggregatorCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.AddCommand(aggregatorCmd)
 	defineAggregatorFlags(aggregatorCmd)
 }
 

--- a/cmd/manager/api-resource-collector.go
+++ b/cmd/manager/api-resource-collector.go
@@ -34,6 +34,7 @@ var apiResourceCollectorCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.AddCommand(apiResourceCollectorCmd)
 	defineAPIResourceCollectorFlags(apiResourceCollectorCmd)
 }
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -30,16 +30,6 @@ var rootCmd = &cobra.Command{
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
-func init() {
-	rootCmd.AddCommand(operatorCmd)
-	rootCmd.AddCommand(rerunnerCmd)
-	rootCmd.AddCommand(resultServerCmd)
-	rootCmd.AddCommand(aggregatorCmd)
-	rootCmd.AddCommand(resultcollectorCmd)
-	rootCmd.AddCommand(apiResourceCollectorCmd)
-	rootCmd.AddCommand(profileparserCmd)
-}
-
 func main() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -39,6 +39,10 @@ var operatorCmd = &cobra.Command{
 	Run:   RunOperator,
 }
 
+func init() {
+	rootCmd.AddCommand(operatorCmd)
+}
+
 // Change below variables to serve metrics on different host or port.
 var (
 	metricsHost               = "0.0.0.0"

--- a/cmd/manager/profileparser.go
+++ b/cmd/manager/profileparser.go
@@ -31,6 +31,7 @@ var profileparserCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.AddCommand(profileparserCmd)
 	defineProfileParserFlags(profileparserCmd)
 }
 

--- a/cmd/manager/resultcollector.go
+++ b/cmd/manager/resultcollector.go
@@ -58,6 +58,7 @@ var resultcollectorCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.AddCommand(resultcollectorCmd)
 	defineResultcollectorFlags(resultcollectorCmd)
 }
 

--- a/cmd/manager/resultserver.go
+++ b/cmd/manager/resultserver.go
@@ -41,6 +41,7 @@ var resultServerCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.AddCommand(resultServerCmd)
 	defineResultServerFlags(resultServerCmd)
 }
 

--- a/cmd/manager/suitererunner.go
+++ b/cmd/manager/suitererunner.go
@@ -25,6 +25,7 @@ var rerunnerCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.AddCommand(rerunnerCmd)
 	defineRerunnerFlags(rerunnerCmd)
 }
 


### PR DESCRIPTION
They used to be all in main.go. This moves them to their own files to
make them easier to find and ease maintenance.