### PR TITLE
Standard flags for all subcommands and common way of getting kubeconfig

### DIFF
--- a/cmd/manager/resultserver.go
+++ b/cmd/manager/resultserver.go
@@ -18,6 +18,7 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -26,6 +27,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/spf13/cobra"
 
 	libgocrypto "github.com/openshift/library-go/pkg/crypto"
@@ -53,6 +55,13 @@ func defineResultServerFlags(cmd *cobra.Command) {
 	cmd.Flags().String("tls-server-cert", "", "Path to the server cert")
 	cmd.Flags().String("tls-server-key", "", "Path to the server key")
 	cmd.Flags().String("tls-ca", "", "Path to the CA certificate")
+
+	flags := cmd.Flags()
+	flags.AddFlagSet(zap.FlagSet())
+
+	// Add flags registered by imported packages (e.g. glog and
+	// controller-runtime)
+	flags.AddGoFlagSet(flag.CommandLine)
 }
 
 type resultServerConfig struct {

--- a/cmd/manager/suitererunner.go
+++ b/cmd/manager/suitererunner.go
@@ -2,17 +2,19 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 
 	backoff "github.com/cenkalti/backoff/v3"
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 const maxScanUpdateRetries = 5
@@ -37,6 +39,13 @@ type rerunnerconfig struct {
 func defineRerunnerFlags(cmd *cobra.Command) {
 	cmd.Flags().String("name", "", "The name of the ComplianceSuite to be re-run")
 	cmd.Flags().String("namespace", "", "The namespace of the ComplianceSuite to be re-run")
+
+	flags := cmd.Flags()
+	flags.AddFlagSet(zap.FlagSet())
+
+	// Add flags registered by imported packages (e.g. glog and
+	// controller-runtime)
+	flags.AddGoFlagSet(flag.CommandLine)
 }
 
 func getRerunnerConfig(cmd *cobra.Command) *rerunnerconfig {
@@ -44,13 +53,13 @@ func getRerunnerConfig(cmd *cobra.Command) *rerunnerconfig {
 	conf.Name = getValidStringArg(cmd, "name")
 	conf.Namespace = getValidStringArg(cmd, "namespace")
 
-	config, err := rest.InClusterConfig()
+	cfg, err := config.GetConfig()
 	if err != nil {
-		fmt.Printf("Can't create incluster config: %v\n", err)
+		log.Error(err, "")
 		os.Exit(1)
 	}
 
-	crclient, err := createCrClient(config)
+	crclient, err := createCrClient(cfg)
 	if err != nil {
 		fmt.Printf("Cannot create client for our types: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
This enables standard flags for all subcommands (logging configurations
and kubeconfig related flags) which will enable us to configure similar
capabilities for all of them.

With this into use, this also enables a common way of getting the
cluster/client configuration. It can now dynamically check if it's in
cluster environment or if it needs to use a kubeconfig, thus enabling us
to use all of the subcommands locally if needed.