### PR TITLE
Label Profiles and Rules; and test

### DIFF
--- a/cmd/manager/profileparser.go
+++ b/cmd/manager/profileparser.go
@@ -225,6 +225,12 @@ func runProfileParser(cmd *cobra.Command, args []string) {
 	err = parseProfilesAndDo(contentDom, pcfg, func(p *cmpv1alpha1.Profile) error {
 		pCopy := p.DeepCopy()
 		profileName := pCopy.Name
+
+		if pCopy.Labels == nil {
+			pCopy.Labels = make(map[string]string)
+		}
+		pCopy.Labels[cmpv1alpha1.ProfileBundleOwnerLabel] = pb.Name
+
 		// overwrite name
 		pCopy.SetName(getPrefixedName(pb.Name, profileName))
 
@@ -254,6 +260,12 @@ func runProfileParser(cmd *cobra.Command, args []string) {
 		ruleName := r.Name
 		// overwrite name
 		r.SetName(getPrefixedName(pb.Name, ruleName))
+
+		if r.Labels == nil {
+			r.Labels = make(map[string]string)
+		}
+		r.Labels[cmpv1alpha1.ProfileBundleOwnerLabel] = pb.Name
+
 		if r.Annotations == nil {
 			r.Annotations = make(map[string]string)
 		}
@@ -285,6 +297,11 @@ func runProfileParser(cmd *cobra.Command, args []string) {
 		varName := v.Name
 		// overwrite name
 		v.SetName(getPrefixedName(pb.Name, varName))
+
+		if v.Labels == nil {
+			v.Labels = make(map[string]string)
+		}
+		v.Labels[cmpv1alpha1.ProfileBundleOwnerLabel] = pb.Name
 
 		if err := controllerutil.SetControllerReference(pb, v, pcfg.Scheme); err != nil {
 			return err

--- a/pkg/apis/compliance/v1alpha1/profilebundle_types.go
+++ b/pkg/apis/compliance/v1alpha1/profilebundle_types.go
@@ -8,6 +8,10 @@ import (
 // added by the ProfileBundle controller in order to delete resources.
 const ProfileBundleFinalizer = "profilebundle.finalizers.compliance.openshift.io"
 
+// ProfileBundleOwnerLabel marks a profile or rule as owned by a profile bundle
+// and helps users filter such objects
+const ProfileBundleOwnerLabel = "compliance.openshift.io/profile-bundle"
+
 // DataStreamStatusType is the type for the data stream status
 type DataStreamStatusType string
 


### PR DESCRIPTION
In order to easily differentiate between what ProfileBundle owns what
profiles and rules, a label has been created.

This is tested in an e2e test that tests both that the profiles and
rules were correctly parsed (the data stream being correct) and that the
objects were labeled and we can filter them.