### PR TITLE
Only mark scan as COMPLIANT if there is at least one passing result

### DIFF
--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -152,7 +152,60 @@ func parseResultRemediations(scheme *runtime.Scheme, scanName, namespace string,
 	return utils.ParseResultsFromContentAndXccdf(scheme, scanName, namespace, content, scanReader)
 }
 
-func annotateParsedConfigMap(crClient *complianceCrClient, cm *v1.ConfigMap) error {
+func getScanResult(cm *v1.ConfigMap) (compv1alpha1.ComplianceScanStatusResult, string) {
+	exitcode, ok := cm.Data["exit-code"]
+	if ok {
+		switch exitcode {
+		case "0":
+			return compv1alpha1.ResultCompliant, ""
+		case "2":
+			return compv1alpha1.ResultNonCompliant, ""
+		default:
+			errorMsg, ok := cm.Data["error-msg"]
+			if ok {
+				return compv1alpha1.ResultError, errorMsg
+			}
+			return compv1alpha1.ResultError, fmt.Sprintf("The ConfigMap '%s' was missing 'error-msg'", cm.Name)
+		}
+	}
+	return compv1alpha1.ResultError, fmt.Sprintf("The ConfigMap '%s' was missing 'exit-code'", cm.Name)
+}
+
+func annotateCMWithScanResult(cm *v1.ConfigMap, cmParsedResults []*utils.ParseResult) *v1.ConfigMap {
+	scanResult, errMsg := getScanResult(cm)
+	if scanResult == compv1alpha1.ResultCompliant {
+		// Special case: If the OS didn't match at all and SCAP skipped all the tests,
+		// then we would have gotten COMPLIANT. Let's make sure that at least one
+		// rule passed in this case
+		gotPass := false
+		for i := range cmParsedResults {
+			if cmParsedResults[i] == nil || cmParsedResults[i].CheckResult == nil {
+				continue
+			}
+
+			if cmParsedResults[i].CheckResult.Status == compv1alpha1.CheckResultPass {
+				gotPass = true
+				break
+			}
+		}
+
+		if gotPass == false {
+			scanResult = compv1alpha1.ResultNotApplicable
+			errMsg = "The scan did not produce any results, maybe an OS/platform mismatch?"
+		}
+	}
+
+	// Finally annotate the CM with the result. The CM will be deep-copied prior to the
+	// update anyway
+	if cm.Annotations == nil {
+		cm.Annotations = make(map[string]string)
+	}
+	cm.Annotations[compv1alpha1.CmScanResultAnnotation] = string(scanResult)
+	cm.Annotations[compv1alpha1.CmScanResultErrMsg] = errMsg
+	return cm.DeepCopy()
+}
+
+func markConfigMapAsProcessed(crClient *complianceCrClient, cm *v1.ConfigMap) error {
 	cmCopy := cm.DeepCopy()
 
 	if cmCopy.Annotations == nil {
@@ -371,10 +424,11 @@ func aggregator(cmd *cobra.Command, args []string) {
 	}
 
 	// For each configmap, create a list of remediations
-	for _, cm := range configMaps {
+	for i := range configMaps {
+		cm := &configMaps[i]
 		fmt.Printf("processing CM: %s\n", cm.Name)
 
-		cmParsedResults, err := parseResultRemediations(crclient.scheme, aggregatorConf.ScanName, aggregatorConf.Namespace, contentDom, &cm)
+		cmParsedResults, err := parseResultRemediations(crclient.scheme, aggregatorConf.ScanName, aggregatorConf.Namespace, contentDom, cm)
 		if err != nil {
 			fmt.Printf("Cannot parse CM %s into remediations, err: %v\n", cm.Name, err)
 		} else if cmParsedResults == nil {
@@ -397,6 +451,9 @@ func aggregator(cmd *cobra.Command, args []string) {
 				os.Exit(1)
 			}
 		}
+
+		// If the CM was processed, annotate it with the result
+		annotateCMWithScanResult(&configMaps[i], cmParsedResults)
 	}
 
 	// At this point either scanRemediations is nil or contains a list
@@ -411,7 +468,7 @@ func aggregator(cmd *cobra.Command, args []string) {
 	// Annotate configMaps, so we don't need to re-parse them
 	fmt.Println("Annotating ConfigMaps")
 	for _, cm := range configMaps {
-		err = annotateParsedConfigMap(crclient, &cm)
+		err = markConfigMapAsProcessed(crclient, &cm)
 		if err != nil {
 			fmt.Printf("Cannot annotate the CM: %v\n", err)
 			os.Exit(1)

--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -397,11 +397,6 @@ func aggregator(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	if scan.Status.Result == compv1alpha1.ResultError {
-		fmt.Println("Not gathering results from a scan that resulted in an error")
-		os.Exit(0)
-	}
-
 	// Find all the configmaps for a scan
 	configMaps, err := getScanConfigMaps(crclient, aggregatorConf.ScanName, common.GetComplianceOperatorNamespace())
 	if err != nil {

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -54,11 +54,19 @@ func stateCompare(lowPhase ComplianceScanStatusPhase, scanPhase ComplianceScanSt
 // Represents the result of the compliance scan
 type ComplianceScanStatusResult string
 
+// CmScanResultAnnotation holds the processed scanner result
+const CmScanResultAnnotation = "compliance.openshift.io/scan-result"
+
+// CmScanResultErrMsg holds the processed scanner error message
+const CmScanResultErrMsg = "compliance.openshift.io/scan-error-msg"
+
 const (
-	// ResultCompliant represents the compliance scan having succeeded
+	// ResultNot available represents the compliance scan not having finished yet
 	ResultNotAvailable ComplianceScanStatusResult = "NOT-AVAILABLE"
 	// ResultCompliant represents the compliance scan having succeeded
 	ResultCompliant ComplianceScanStatusResult = "COMPLIANT"
+	// ResultNotApplicable represents the compliance scan having no useful results after finished
+	ResultNotApplicable ComplianceScanStatusResult = "NOT-APPLICABLE"
 	// ResultError represents a compliance scan pod having failed to run the scan or encountered an error
 	ResultError ComplianceScanStatusResult = "ERROR"
 	// ResultNonCompliant represents the compliance scan having found a gap
@@ -72,7 +80,8 @@ func resultCompare(lowResult ComplianceScanStatusResult, scanResult ComplianceSc
 	orderedResults[ResultNotAvailable] = 0
 	orderedResults[ResultError] = 1
 	orderedResults[ResultNonCompliant] = 2
-	orderedResults[ResultCompliant] = 3
+	orderedResults[ResultNotApplicable] = 3
+	orderedResults[ResultCompliant] = 4
 
 	if orderedResults[lowResult] > orderedResults[scanResult] {
 		return scanResult

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -714,6 +714,46 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
+			Name: "TestSuiteWithContentThatDoesNotMatch",
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
+				suiteName := "test-suite-with-non-matching-content"
+				testSuite := &compv1alpha1.ComplianceSuite{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      suiteName,
+						Namespace: namespace,
+					},
+					Spec: compv1alpha1.ComplianceSuiteSpec{
+						AutoApplyRemediations: false,
+						Scans: []compv1alpha1.ComplianceScanSpecWrapper{
+							{
+								Name: fmt.Sprintf("%s-workers-scan", suiteName),
+								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
+									ContentImage: "quay.io/jhrozek/ocp4-openscap-content:broken_os_detection",
+									Profile:      "xccdf_org.ssgproject.content_profile_moderate",
+									Content:      "ssg-rhcos4-ds.xml",
+									NodeSelector: map[string]string{
+										"node-role.kubernetes.io/worker": "",
+									},
+									Debug: true,
+								},
+							},
+						},
+					},
+				}
+				// use Context's create helper to create the object and add a cleanup function for the new object
+				err := f.Client.Create(goctx.TODO(), testSuite, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+				if err != nil {
+					return err
+				}
+
+				err = waitForSuiteScansStatus(t, f, namespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultNotApplicable)
+				if err != nil {
+					return err
+				}
+				return suiteErrorMessageMatchesRegex(t, f, namespace, suiteName, "The suite result is not applicable.*")
+			},
+		},
+		testExecution{
 			Name: "TestAutoRemediate",
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				// FIXME, maybe have a func that returns a struct with suite name and scan names?


### PR DESCRIPTION
This protects against cases where we can't for some reason detect the
platform we are running on.

In order to base the overall scan result on the individual rule results,
the patch also moves evaluating the scan result from the controller to
the aggregator. The aggregator now adds an annotation with the result
and an error instead. In case the scanner returned compliant but not a
single rule passed, the overall result is NotApplicable. In addition, an
event and a Suite error message are generated.