### PR TITLE
Remove check for error in aggregator

### DIFF
--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -344,11 +344,6 @@ func aggregator(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	if scan.Status.Result == compv1alpha1.ResultError {
-		fmt.Println("Not gathering results from a scan that resulted in an error")
-		os.Exit(0)
-	}
-
 	// Find all the configmaps for a scan
 	configMaps, err := getScanConfigMaps(crclient, aggregatorConf.ScanName, common.GetComplianceOperatorNamespace())
 	if err != nil {


### PR DESCRIPTION
This is handled elsewhere, and in some cases, the operator should be
able to recover from errors (e.g. such as when the tailoring config map
was missing but then is added later on)