### PR TITLE
e2e: Make content image configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ E2E_SKIP_CONTAINER_BUILD?=false
 # 	make e2e E2E_GO_TEST_FLAGS="-v -run TestE2E/TestScanWithNodeSelectorFiltersCorrectly"
 E2E_GO_TEST_FLAGS?=-v -timeout 120m
 
+# Specifies the image path to use for the content in the tests
+E2E_CONTENT_IMAGE_PATH?=quay.io/complianceascode/ocp4:latest
+
 # operator-courier arguments for `make publish`.
 # Before running `make publish`, install operator-courier with `pip3 install operator-courier` and create
 # ~/.quay containing your quay.io token.
@@ -187,7 +190,7 @@ e2e: namespace operator-sdk image-to-cluster openshift-user ## Run the end-to-en
 	@sed -i 's%$(IMAGE_REPO)/$(OPENSCAP_IMAGE_NAME):$(OPENSCAP_DEFAULT_IMAGE_TAG)%$(OPENSCAP_IMAGE_PATH):$(OPENSCAP_IMAGE_TAG)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(APP_NAME):latest%$(OPERATOR_IMAGE_PATH)%' deploy/operator.yaml
 	@echo "Running e2e tests"
-	unset GOFLAGS && $(GOPATH)/bin/operator-sdk test local ./tests/e2e --skip-cleanup-error --image "$(OPERATOR_IMAGE_PATH)" --operator-namespace "$(NAMESPACE)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
+	unset GOFLAGS && CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) $(GOPATH)/bin/operator-sdk test local ./tests/e2e --skip-cleanup-error --image "$(OPERATOR_IMAGE_PATH)" --operator-namespace "$(NAMESPACE)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
 	@echo "Restoring image references in deploy/operator.yaml"
 	@sed -i 's%$(OPENSCAP_IMAGE_PATH):$(OPENSCAP_IMAGE_TAG)%$(IMAGE_REPO)/$(OPENSCAP_IMAGE_NAME):$(OPENSCAP_DEFAULT_IMAGE_TAG)%' deploy/operator.yaml
 	@sed -i 's%$(OPERATOR_IMAGE_PATH)%$(IMAGE_REPO)/$(APP_NAME):latest%' deploy/operator.yaml
@@ -196,7 +199,7 @@ e2e-local: operator-sdk ## Run the end-to-end tests on a locally running operato
 	@echo "WARNING: This will temporarily modify deploy/operator.yaml"
 	@echo "Replacing workload references in deploy/operator.yaml"
 	@sed -i 's%$(IMAGE_REPO)/$(APP_NAME):latest%$(OPERATOR_IMAGE_PATH)%' deploy/operator.yaml
-	unset GOFLAGS && $(GOPATH)/bin/operator-sdk test local ./tests/e2e --up-local --skip-cleanup-error --image "$(OPERATOR_IMAGE_PATH)" --operator-namespace "$(NAMESPACE)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
+	unset GOFLAGS && CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) $(GOPATH)/bin/operator-sdk test local ./tests/e2e --up-local --skip-cleanup-error --image "$(OPERATOR_IMAGE_PATH)" --operator-namespace "$(NAMESPACE)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
 	@echo "Restoring image references in deploy/operator.yaml"
 	@sed -i 's%$(OPERATOR_IMAGE_PATH)%$(IMAGE_REPO)/$(APP_NAME):latest%' deploy/operator.yaml
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -29,7 +29,7 @@ func TestE2E(t *testing.T) {
 						Namespace: namespace,
 					},
 					Spec: compv1alpha1.ProfileBundleSpec{
-						ContentImage: "quay.io/complianceascode/ocp4:latest",
+						ContentImage: contentImagePath,
 						ContentFile:  rhcosContentFile,
 					},
 				}
@@ -523,7 +523,7 @@ func TestE2E(t *testing.T) {
 							{
 								Name: fmt.Sprintf("%s-workers-scan", suiteName),
 								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
-									ContentImage: "quay.io/complianceascode/ocp4:latest",
+									ContentImage: contentImagePath,
 									Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 									Content:      rhcosContentFile,
 									NodeSelector: map[string]string{
@@ -573,7 +573,7 @@ func TestE2E(t *testing.T) {
 						Scans: []compv1alpha1.ComplianceScanSpecWrapper{
 							{
 								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
-									ContentImage: "quay.io/complianceascode/ocp4:latest",
+									ContentImage: contentImagePath,
 									Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 									Content:      rhcosContentFile,
 									NodeSelector: selectWorkers,
@@ -583,7 +583,7 @@ func TestE2E(t *testing.T) {
 							},
 							{
 								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
-									ContentImage: "quay.io/complianceascode/ocp4:latest",
+									ContentImage: contentImagePath,
 									Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 									Content:      rhcosContentFile,
 									NodeSelector: selectMasters,
@@ -675,7 +675,7 @@ func TestE2E(t *testing.T) {
 							{
 								Name: workerScanName,
 								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
-									ContentImage: "quay.io/complianceascode/ocp4:latest",
+									ContentImage: contentImagePath,
 									Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 									Content:      rhcosContentFile,
 									Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
@@ -730,7 +730,7 @@ func TestE2E(t *testing.T) {
 						Scans: []compv1alpha1.ComplianceScanSpecWrapper{
 							{
 								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
-									ContentImage: "quay.io/complianceascode/ocp4:latest",
+									ContentImage: contentImagePath,
 									Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 									Rule:         "xccdf_org.ssgproject.content_rule_no_direct_root_logins",
 									Content:      rhcosContentFile,
@@ -893,7 +893,7 @@ func TestE2E(t *testing.T) {
 						Scans: []compv1alpha1.ComplianceScanSpecWrapper{
 							{
 								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
-									ContentImage: "quay.io/complianceascode/ocp4:latest",
+									ContentImage: contentImagePath,
 									Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 									Content:      rhcosContentFile,
 									NodeSelector: getPoolNodeRoleSelector(),
@@ -1012,7 +1012,7 @@ func TestE2E(t *testing.T) {
 						Scans: []compv1alpha1.ComplianceScanSpecWrapper{
 							{
 								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
-									ContentImage: "quay.io/complianceascode/ocp4:latest",
+									ContentImage: contentImagePath,
 									Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 									Content:      rhcosContentFile,
 									NodeSelector: selectWorkers,
@@ -1023,7 +1023,7 @@ func TestE2E(t *testing.T) {
 							{
 								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
 									ScanType:     compv1alpha1.ScanTypePlatform,
-									ContentImage: "quay.io/complianceascode/ocp4:latest",
+									ContentImage: contentImagePath,
 									Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 									Content:      ocpContentFile,
 									Debug:        true,

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -4,6 +4,7 @@ import (
 	goctx "context"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -33,6 +34,17 @@ const (
 	rhcosContentFile = "ssg-rhcos4-ds.xml"
 	ocpContentFile   = "ssg-ocp4-ds.xml"
 )
+
+var contentImagePath string
+
+func init() {
+	contentImagePath = os.Getenv("CONTENT_IMAGE")
+
+	if contentImagePath == "" {
+		fmt.Println("Please set the 'CONTENT_IMAGE' environment variable")
+		os.Exit(1)
+	}
+}
 
 type testExecution struct {
 	Name   string


### PR DESCRIPTION
This will allow us to use custom images in order to run the e2e tests,
as opposed to the hardcoded value we currently have.

The intent is to start building our own images for tests so we can
add/modify things as needed.