### PR TITLE
Add test-content image that matches any version of OpenShift

### DIFF
--- a/images/testcontent/Dockerfile.ci
+++ b/images/testcontent/Dockerfile.ci
@@ -1,0 +1,4 @@
+FROM quay.io/complianceascode/ocp4:latest
+
+# Force matching any version
+RUN sed -i 's%pattern match">4.\.\.\*%pattern match">.*%' /ssg-ocp4-ds.xml


### PR DESCRIPTION
in CI, the version format is different than in production... so just for
testing in CI, we can carry an image with modified content that will
match any version.