### PR TITLE
Add initial operator downstream Dockerfile

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,0 +1,27 @@
+# Step one: build compliance-operator
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-1.13 AS builder
+
+WORKDIR /go/src/github.com/openshift/compliance-operator
+
+ENV GOFLAGS=-mod=vendor
+
+COPY . .
+
+RUN make manager
+
+# Step two: containerize compliance-operator
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+
+ENV OPERATOR=/usr/local/bin/compliance-operator \
+    USER_UID=1001 \
+    USER_NAME=compliance-operator
+
+# install operator binary
+COPY --from=builder /go/src/github.com/openshift/compliance-operator/build/_output/bin/compliance-operator ${OPERATOR}
+
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}


### PR DESCRIPTION
Same story as https://github.com/openshift/file-integrity-operator/pull/79 . This does not include the scap build, which we will need to pull in the 1.3.3 GA version somehow. 