### PR TITLE
Regenerate CRDs as v1 instead of v1beta1

### DIFF
--- a/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
@@ -1,15 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: compliancecheckresults.compliance.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status
-    name: Status
-    type: string
-  - JSONPath: .severity
-    name: Severity
-    type: string
   group: compliance.openshift.io
   names:
     kind: ComplianceCheckResult
@@ -17,43 +10,49 @@ spec:
     plural: compliancecheckresults
     singular: compliancecheckresult
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: ComplianceCheckResult represent a result of a single compliance
-        "test"
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        description:
-          description: A human-readable check description, what and why it does
-          type: string
-        id:
-          description: A unique identifier of a check
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        severity:
-          description: The severity of a check status
-          type: string
-        status:
-          description: The result of a check
-          type: string
-      required:
-      - id
-      - severity
-      - status
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status
+      name: Status
+      type: string
+    - jsonPath: .severity
+      name: Severity
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          description:
+            description: A human-readable check description, what and why it does
+            type: string
+          id:
+            description: A unique identifier of a check
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          severity:
+            description: The severity of a check status
+            type: string
+          status:
+            description: The result of a check
+            type: string
+        required:
+        - id
+        - severity
+        - status
+        type: object
     served: true
     storage: true
+    subresources: {}

--- a/deploy/crds/compliance.openshift.io_complianceremediations_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_complianceremediations_crd.yaml
@@ -1,12 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: complianceremediations.compliance.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.applicationState
-    name: State
-    type: string
   group: compliance.openshift.io
   names:
     kind: ComplianceRemediation
@@ -14,59 +10,66 @@ spec:
     plural: complianceremediations
     singular: complianceremediation
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ComplianceRemediation represents a remediation that can be applied
-        to the cluster to fix the found issues.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Contains the definition of what the remediation should be
-          properties:
-            apply:
-              description: Whether the remediation should be picked up and applied
-                by the operator
-              type: boolean
-            machineConfigContents:
-              description: The actual MachineConfig remediation payload
-              type: object
-            object:
-              description: The remediation payload. This would normally be a full
-                Kubernetes object.
-              type: object
-            type:
-              description: Remediation type specifies the artifact the remediation
-                is based on. For now, only MachineConfig is supported
-              type: string
-          required:
-          - apply
-          type: object
-        status:
-          description: Contains information on the remediation (whether it's applied
-            or not)
-          properties:
-            applicationState:
-              description: Whether the remediation is already applied or not
-              type: string
-            errorMessage:
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.applicationState
+      name: State
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Contains the definition of what the remediation should be
+            properties:
+              apply:
+                description: Whether the remediation should be picked up and applied
+                  by the operator
+                type: boolean
+              machineConfigContents:
+                description: (deprecated) The actual MachineConfig remediation payload
+                type: object
+                x-kubernetes-embedded-resource: true
+                x-kubernetes-preserve-unknown-fields: true
+              object:
+                description: The remediation payload. This would normally be a full
+                  Kubernetes object.
+                type: object
+                x-kubernetes-embedded-resource: true
+                x-kubernetes-preserve-unknown-fields: true
+              type:
+                description: Remediation type specifies the artifact the remediation
+                  is based on. For now, only MachineConfig is supported
+                type: string
+            required:
+            - apply
+            type: object
+          status:
+            description: Contains information on the remediation (whether it's applied
+              or not)
+            properties:
+              applicationState:
+                description: Whether the remediation is already applied or not
+                type: string
+              errorMessage:
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -1,15 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: compliancescans.compliance.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    name: Phase
-    type: string
-  - JSONPath: .status.result
-    name: Result
-    type: string
   group: compliance.openshift.io
   names:
     kind: ComplianceScan
@@ -17,102 +10,108 @@ spec:
     plural: compliancescans
     singular: compliancescan
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ComplianceScan represents a scan with a certain configuration that
-        will be applied to objects of a certain entity in the host. These could be
-        nodes that apply to a certain nodeSelector, or the cluster itself.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: The spec is the configuration for the compliance scan.
-          properties:
-            content:
-              description: Is the path to the file that contains the content (the
-                data stream). Note that the path needs to be relative to the `/` (root)
-                directory, as it is in the ContentImage
-              type: string
-            contentImage:
-              description: Is the image with the content (Data Stream), that will
-                be used to run OpenSCAP.
-              type: string
-            debug:
-              description: Disables cleaning up resources in the DONE phase, this
-                might be useful for debugging.
-              type: boolean
-            nodeSelector:
-              additionalProperties:
-                type: string
-              description: By setting this, it's possible to only run the scan on
-                certain nodes in the cluster. Note that when applying remediations
-                generated from the scan, this should match the selector of the MachineConfigPool
-                you want to apply the remediations to.
-              type: object
-            profile:
-              description: Is the profile in the data stream to be used. This is the
-                collection of rules that will be checked for.
-              type: string
-            rule:
-              description: A Rule can be specified if the scan should check only for
-                a specific rule. Note that when leaving this empty, the scan will
-                check for all the rules for a specific profile.
-              type: string
-            scanType:
-              description: The type of Compliance scan.
-              type: string
-            tailoringConfigMap:
-              description: Is a reference to a ConfigMap that contains the tailoring
-                file. It assumes a key called `tailoring.xml` which will have the
-                tailoring contents.
-              properties:
-                name:
-                  description: Name of the ConfigMap being referenced
-                  type: string
-              required:
-              - name
-              type: object
-          type: object
-        status:
-          description: The status will give valuable information on what's going on
-            with the scan; and, more importantly, if the scan is successful (compliant)
-            or not (non-compliant)
-          properties:
-            currentIndex:
-              description: Specifies the current index of the scan. Given multiple
-                scans, this marks the amount that have been executed.
-              format: int64
-              type: integer
-            errormsg:
-              description: If there are issues on the scan, this will be filled up
-                with an error message.
-              type: string
-            phase:
-              description: Is the phase where the scan is at. Normally, one must wait
-                for the scan to reach the phase DONE.
-              type: string
-            result:
-              description: Once the scan reaches the phase DONE, this will contain
-                the result of the scan. Where COMPLIANT means that the scan succeeded;
-                NON-COMPLIANT means that there were rule violations; and ERROR means
-                that the scan couldn't complete due to an issue.
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.result
+      name: Result
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: The spec is the configuration for the compliance scan.
+            properties:
+              content:
+                description: Is the path to the file that contains the content (the
+                  data stream). Note that the path needs to be relative to the `/`
+                  (root) directory, as it is in the ContentImage
+                type: string
+              contentImage:
+                description: Is the image with the content (Data Stream), that will
+                  be used to run OpenSCAP.
+                type: string
+              debug:
+                description: Disables cleaning up resources in the DONE phase, this
+                  might be useful for debugging.
+                type: boolean
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: By setting this, it's possible to only run the scan on
+                  certain nodes in the cluster. Note that when applying remediations
+                  generated from the scan, this should match the selector of the MachineConfigPool
+                  you want to apply the remediations to.
+                type: object
+              profile:
+                description: Is the profile in the data stream to be used. This is
+                  the collection of rules that will be checked for.
+                type: string
+              rule:
+                description: A Rule can be specified if the scan should check only
+                  for a specific rule. Note that when leaving this empty, the scan
+                  will check for all the rules for a specific profile.
+                type: string
+              scanType:
+                description: The type of Compliance scan.
+                type: string
+              tailoringConfigMap:
+                description: Is a reference to a ConfigMap that contains the tailoring
+                  file. It assumes a key called `tailoring.xml` which will have the
+                  tailoring contents.
+                properties:
+                  name:
+                    description: Name of the ConfigMap being referenced
+                    type: string
+                required:
+                - name
+                type: object
+            type: object
+          status:
+            description: The status will give valuable information on what's going
+              on with the scan; and, more importantly, if the scan is successful (compliant)
+              or not (non-compliant)
+            properties:
+              currentIndex:
+                description: Specifies the current index of the scan. Given multiple
+                  scans, this marks the amount that have been executed.
+                format: int64
+                type: integer
+              errormsg:
+                description: If there are issues on the scan, this will be filled
+                  up with an error message.
+                type: string
+              phase:
+                description: Is the phase where the scan is at. Normally, one must
+                  wait for the scan to reach the phase DONE.
+                type: string
+              result:
+                description: Once the scan reaches the phase DONE, this will contain
+                  the result of the scan. Where COMPLIANT means that the scan succeeded;
+                  NON-COMPLIANT means that there were rule violations; and ERROR means
+                  that the scan couldn't complete due to an issue.
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -1,15 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: compliancesuites.compliance.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.aggregatedPhase
-    name: Phase
-    type: string
-  - JSONPath: .status.aggregatedResult
-    name: Result
-    type: string
   group: compliance.openshift.io
   names:
     kind: ComplianceSuite
@@ -17,144 +10,155 @@ spec:
     plural: compliancesuites
     singular: compliancesuite
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ComplianceSuite represents a set of scans that will be applied
-        to the cluster. These should help deployers achieve a certain compliance target.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Contains the definition of the suite
-          properties:
-            autoApplyRemediations:
-              description: Defines whether or not the remediations should be applied
-                automatically
-              type: boolean
-            scans:
-              description: Contains a list of the scans to execute on the cluster
-              items:
-                description: ComplianceScanSpecWrapper provides a ComplianceScanSpec
-                  and a Name
-                properties:
-                  content:
-                    description: Is the path to the file that contains the content
-                      (the data stream). Note that the path needs to be relative to
-                      the `/` (root) directory, as it is in the ContentImage
-                    type: string
-                  contentImage:
-                    description: Is the image with the content (Data Stream), that
-                      will be used to run OpenSCAP.
-                    type: string
-                  debug:
-                    description: Disables cleaning up resources in the DONE phase,
-                      this might be useful for debugging.
-                    type: boolean
-                  name:
-                    description: Contains a human readable name for the scan. This
-                      is to identify the objects that it creates.
-                    type: string
-                  nodeSelector:
-                    additionalProperties:
-                      type: string
-                    description: By setting this, it's possible to only run the scan
-                      on certain nodes in the cluster. Note that when applying remediations
-                      generated from the scan, this should match the selector of the
-                      MachineConfigPool you want to apply the remediations to.
-                    type: object
-                  profile:
-                    description: Is the profile in the data stream to be used. This
-                      is the collection of rules that will be checked for.
-                    type: string
-                  rule:
-                    description: A Rule can be specified if the scan should check
-                      only for a specific rule. Note that when leaving this empty,
-                      the scan will check for all the rules for a specific profile.
-                    type: string
-                  scanType:
-                    description: The type of Compliance scan.
-                    type: string
-                  tailoringConfigMap:
-                    description: Is a reference to a ConfigMap that contains the tailoring
-                      file. It assumes a key called `tailoring.xml` which will have
-                      the tailoring contents.
-                    properties:
-                      name:
-                        description: Name of the ConfigMap being referenced
-                        type: string
-                    required:
-                    - name
-                    type: object
-                type: object
-              type: array
-            schedule:
-              description: Defines a schedule for the scans to run. This is in cronjob
-                format. Note the scan will still be triggered immediately, and the
-                scheduled scans will start running only after the initial results
-                are ready.
-              type: string
-          required:
-          - scans
-          type: object
-        status:
-          description: Contains the current state of the suite
-          properties:
-            aggregatedPhase:
-              description: Represents the status of the compliance scan run.
-              type: string
-            aggregatedResult:
-              description: Represents the result of the compliance scan
-              type: string
-            errorMessage:
-              type: string
-            scanStatuses:
-              items:
-                description: ComplianceScanStatusWrapper provides a ComplianceScanStatus
-                  and a Name
-                properties:
-                  currentIndex:
-                    description: Specifies the current index of the scan. Given multiple
-                      scans, this marks the amount that have been executed.
-                    format: int64
-                    type: integer
-                  errormsg:
-                    description: If there are issues on the scan, this will be filled
-                      up with an error message.
-                    type: string
-                  name:
-                    description: Contains a human readable name for the scan. This
-                      is to identify the objects that it creates.
-                    type: string
-                  phase:
-                    description: Is the phase where the scan is at. Normally, one
-                      must wait for the scan to reach the phase DONE.
-                    type: string
-                  result:
-                    description: Once the scan reaches the phase DONE, this will contain
-                      the result of the scan. Where COMPLIANT means that the scan
-                      succeeded; NON-COMPLIANT means that there were rule violations;
-                      and ERROR means that the scan couldn't complete due to an issue.
-                    type: string
-                type: object
-              type: array
-          required:
-          - scanStatuses
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.aggregatedPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.aggregatedResult
+      name: Result
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Contains the definition of the suite
+            properties:
+              autoApplyRemediations:
+                description: Defines whether or not the remediations should be applied
+                  automatically
+                type: boolean
+              scans:
+                description: Contains a list of the scans to execute on the cluster
+                items:
+                  description: ComplianceScanSpecWrapper provides a ComplianceScanSpec
+                    and a Name
+                  properties:
+                    content:
+                      description: Is the path to the file that contains the content
+                        (the data stream). Note that the path needs to be relative
+                        to the `/` (root) directory, as it is in the ContentImage
+                      type: string
+                    contentImage:
+                      description: Is the image with the content (Data Stream), that
+                        will be used to run OpenSCAP.
+                      type: string
+                    debug:
+                      description: Disables cleaning up resources in the DONE phase,
+                        this might be useful for debugging.
+                      type: boolean
+                    name:
+                      description: Contains a human readable name for the scan. This
+                        is to identify the objects that it creates.
+                      type: string
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: By setting this, it's possible to only run the
+                        scan on certain nodes in the cluster. Note that when applying
+                        remediations generated from the scan, this should match the
+                        selector of the MachineConfigPool you want to apply the remediations
+                        to.
+                      type: object
+                    profile:
+                      description: Is the profile in the data stream to be used. This
+                        is the collection of rules that will be checked for.
+                      type: string
+                    rule:
+                      description: A Rule can be specified if the scan should check
+                        only for a specific rule. Note that when leaving this empty,
+                        the scan will check for all the rules for a specific profile.
+                      type: string
+                    scanType:
+                      description: The type of Compliance scan.
+                      type: string
+                    tailoringConfigMap:
+                      description: Is a reference to a ConfigMap that contains the
+                        tailoring file. It assumes a key called `tailoring.xml` which
+                        will have the tailoring contents.
+                      properties:
+                        name:
+                          description: Name of the ConfigMap being referenced
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              schedule:
+                description: Defines a schedule for the scans to run. This is in cronjob
+                  format. Note the scan will still be triggered immediately, and the
+                  scheduled scans will start running only after the initial results
+                  are ready.
+                type: string
+            required:
+            - scans
+            type: object
+          status:
+            description: Contains the current state of the suite
+            properties:
+              aggregatedPhase:
+                description: Represents the status of the compliance scan run.
+                type: string
+              aggregatedResult:
+                description: Represents the result of the compliance scan
+                type: string
+              errorMessage:
+                type: string
+              scanStatuses:
+                items:
+                  description: ComplianceScanStatusWrapper provides a ComplianceScanStatus
+                    and a Name
+                  properties:
+                    currentIndex:
+                      description: Specifies the current index of the scan. Given
+                        multiple scans, this marks the amount that have been executed.
+                      format: int64
+                      type: integer
+                    errormsg:
+                      description: If there are issues on the scan, this will be filled
+                        up with an error message.
+                      type: string
+                    name:
+                      description: Contains a human readable name for the scan. This
+                        is to identify the objects that it creates.
+                      type: string
+                    phase:
+                      description: Is the phase where the scan is at. Normally, one
+                        must wait for the scan to reach the phase DONE.
+                      type: string
+                    result:
+                      description: Once the scan reaches the phase DONE, this will
+                        contain the result of the scan. Where COMPLIANT means that
+                        the scan succeeded; NON-COMPLIANT means that there were rule
+                        violations; and ERROR means that the scan couldn't complete
+                        due to an issue.
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - scanStatuses
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/deploy/crds/compliance.openshift.io_profilebundles_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_profilebundles_crd.yaml
@@ -1,15 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: profilebundles.compliance.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.contentImage
-    name: ContentImage
-    type: string
-  - JSONPath: .status.dataStreamStatus
-    name: Status
-    type: string
   group: compliance.openshift.io
   names:
     kind: ProfileBundle
@@ -17,54 +10,60 @@ spec:
     plural: profilebundles
     singular: profilebundle
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ProfileBundle is the Schema for the profilebundles API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Defines the desired state of ProfileBundle
-          properties:
-            contentFile:
-              description: Is the path for the file in the image that contains the
-                content for this bundle.
-              type: string
-            contentImage:
-              description: Is the path for the image that contains the content for
-                this bundle.
-              type: string
-          required:
-          - contentFile
-          - contentImage
-          type: object
-        status:
-          description: Defines the observed state of ProfileBundle
-          properties:
-            dataStreamStatus:
-              description: Presents the current status for the datastream for this
-                bundle
-              type: string
-            errorMessage:
-              description: If there's an error in the datastream, it'll be presented
-                here
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.contentImage
+      name: ContentImage
+      type: string
+    - jsonPath: .status.dataStreamStatus
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ProfileBundle is the Schema for the profilebundles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Defines the desired state of ProfileBundle
+            properties:
+              contentFile:
+                description: Is the path for the file in the image that contains the
+                  content for this bundle.
+                type: string
+              contentImage:
+                description: Is the path for the image that contains the content for
+                  this bundle.
+                type: string
+            required:
+            - contentFile
+            - contentImage
+            type: object
+          status:
+            description: Defines the observed state of ProfileBundle
+            properties:
+              dataStreamStatus:
+                description: Presents the current status for the datastream for this
+                  bundle
+                type: string
+              errorMessage:
+                description: If there's an error in the datastream, it'll be presented
+                  here
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/deploy/crds/compliance.openshift.io_profiles_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_profiles_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: profiles.compliance.openshift.io
@@ -10,47 +10,47 @@ spec:
     plural: profiles
     singular: profile
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: Profile is the Schema for the profiles API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        description:
-          type: string
-        id:
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        rules:
-          items:
-            description: ProfileRule defines the name of a specific rule in the profile
-            type: string
-          nullable: true
-          type: array
-        title:
-          type: string
-        values:
-          items:
-            description: ProfileValue defines a value for a setting in the profile
-            type: string
-          nullable: true
-          type: array
-      required:
-      - description
-      - id
-      - title
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Profile is the Schema for the profiles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          description:
+            type: string
+          id:
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          rules:
+            items:
+              description: ProfileRule defines the name of a specific rule in the
+                profile
+              type: string
+            nullable: true
+            type: array
+          title:
+            type: string
+          values:
+            items:
+              description: ProfileValue defines a value for a setting in the profile
+              type: string
+            nullable: true
+            type: array
+        required:
+        - description
+        - id
+        - title
+        type: object
     served: true
     storage: true

--- a/deploy/crds/compliance.openshift.io_rules_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_rules_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: rules.compliance.openshift.io
@@ -10,65 +10,66 @@ spec:
     plural: rules
     singular: rule
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: Rule is the Schema for the rules API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        availableFixes:
-          description: The Available fixes
-          items:
-            description: FixDefinition Specifies a fix or remediation that applies
-              to a rule
-            properties:
-              disruption:
-                description: An estimate of the potential disruption or operational
-                  degradation that this fix will impose in the target system
-                type: string
-              fixObject:
-                description: an object that should bring the rule into compliance
-                type: object
-              platform:
-                description: The platform that the fix applies to
-                type: string
-            type: object
-          nullable: true
-          type: array
-        description:
-          description: The description of the Rule
-          type: string
-        id:
-          description: The XCCDF ID
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        rationale:
-          description: The rationale of the Rule
-          type: string
-        severity:
-          description: The severity level
-          type: string
-        title:
-          description: The title of the Rule
-          type: string
-        warning:
-          description: A discretionary warning about the of the Rule
-          type: string
-      required:
-      - id
-      - title
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Rule is the Schema for the rules API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          availableFixes:
+            description: The Available fixes
+            items:
+              description: FixDefinition Specifies a fix or remediation that applies
+                to a rule
+              properties:
+                disruption:
+                  description: An estimate of the potential disruption or operational
+                    degradation that this fix will impose in the target system
+                  type: string
+                fixObject:
+                  description: an object that should bring the rule into compliance
+                  type: object
+                  x-kubernetes-embedded-resource: true
+                  x-kubernetes-preserve-unknown-fields: true
+                platform:
+                  description: The platform that the fix applies to
+                  type: string
+              type: object
+            nullable: true
+            type: array
+          description:
+            description: The description of the Rule
+            type: string
+          id:
+            description: The XCCDF ID
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          rationale:
+            description: The rationale of the Rule
+            type: string
+          severity:
+            description: The severity level
+            type: string
+          title:
+            description: The title of the Rule
+            type: string
+          warning:
+            description: A discretionary warning about the of the Rule
+            type: string
+        required:
+        - id
+        - title
+        type: object
     served: true
     storage: true

--- a/deploy/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
@@ -1,13 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tailoredprofiles.compliance.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.state
-    description: State of the tailored profile
-    name: State
-    type: string
   group: compliance.openshift.io
   names:
     kind: TailoredProfile
@@ -15,131 +10,135 @@ spec:
     plural: tailoredprofiles
     singular: tailoredprofile
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: TailoredProfile is the Schema for the tailoredprofiles API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TailoredProfileSpec defines the desired state of TailoredProfile
-          properties:
-            description:
-              description: Overwrites the description of the extended profile (optional)
-              type: string
-            disableRules:
-              description: Disables the referenced rules
-              items:
-                description: RuleReferenceSpec specifies a rule to be selected/deselected,
-                  as well as the reason why
-                properties:
-                  name:
-                    description: Name of the rule that's being referenced
-                    type: string
-                  rationale:
-                    description: Rationale of why this rule is being selected/deselected
-                    type: string
-                required:
-                - name
-                - rationale
-                type: object
-              nullable: true
-              type: array
-            enableRules:
-              description: Enables the referenced rules
-              items:
-                description: RuleReferenceSpec specifies a rule to be selected/deselected,
-                  as well as the reason why
-                properties:
-                  name:
-                    description: Name of the rule that's being referenced
-                    type: string
-                  rationale:
-                    description: Rationale of why this rule is being selected/deselected
-                    type: string
-                required:
-                - name
-                - rationale
-                type: object
-              nullable: true
-              type: array
-            extends:
-              description: Points to the name of the profile to extend
-              type: string
-            outputType:
-              description: Defines the type of output that the tailored profile will
-                do.
-              enum:
-              - ConfigMap
-              - Policy
-              type: string
-            setValues:
-              description: Sets the referenced variables to selected values
-              items:
-                description: ValueReferenceSpec specifies a value to be set for a
-                  variable with a reason why
-                properties:
-                  name:
-                    description: Name of the variable that's being referenced
-                    type: string
-                  rationale:
-                    description: Rationale of why this value is being tailored
-                    type: string
-                  value:
-                    description: Rationale of why this value is being tailored
-                    type: string
-                required:
-                - name
-                - rationale
-                - value
-                type: object
-              nullable: true
-              type: array
-            title:
-              description: Overwrites the title of the extended profile (optional)
-              type: string
-          required:
-          - extends
-          type: object
-        status:
-          description: TailoredProfileStatus defines the observed state of TailoredProfile
-          properties:
-            errorMessagae:
-              type: string
-            id:
-              description: The XCCDF ID of the tailored profile
-              type: string
-            outputRef:
-              description: Points to the generated resource of the type specified
-                in "outputType"
-              properties:
-                name:
-                  type: string
-                namespace:
-                  type: string
-              required:
-              - name
-              - namespace
-              type: object
-            state:
-              description: The current state of the tailored profile
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: State of the tailored profile
+      jsonPath: .status.state
+      name: State
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TailoredProfile is the Schema for the tailoredprofiles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TailoredProfileSpec defines the desired state of TailoredProfile
+            properties:
+              description:
+                description: Overwrites the description of the extended profile (optional)
+                type: string
+              disableRules:
+                description: Disables the referenced rules
+                items:
+                  description: RuleReferenceSpec specifies a rule to be selected/deselected,
+                    as well as the reason why
+                  properties:
+                    name:
+                      description: Name of the rule that's being referenced
+                      type: string
+                    rationale:
+                      description: Rationale of why this rule is being selected/deselected
+                      type: string
+                  required:
+                  - name
+                  - rationale
+                  type: object
+                nullable: true
+                type: array
+              enableRules:
+                description: Enables the referenced rules
+                items:
+                  description: RuleReferenceSpec specifies a rule to be selected/deselected,
+                    as well as the reason why
+                  properties:
+                    name:
+                      description: Name of the rule that's being referenced
+                      type: string
+                    rationale:
+                      description: Rationale of why this rule is being selected/deselected
+                      type: string
+                  required:
+                  - name
+                  - rationale
+                  type: object
+                nullable: true
+                type: array
+              extends:
+                description: Points to the name of the profile to extend
+                type: string
+              outputType:
+                description: Defines the type of output that the tailored profile
+                  will do.
+                enum:
+                - ConfigMap
+                - Policy
+                type: string
+              setValues:
+                description: Sets the referenced variables to selected values
+                items:
+                  description: ValueReferenceSpec specifies a value to be set for
+                    a variable with a reason why
+                  properties:
+                    name:
+                      description: Name of the variable that's being referenced
+                      type: string
+                    rationale:
+                      description: Rationale of why this value is being tailored
+                      type: string
+                    value:
+                      description: Rationale of why this value is being tailored
+                      type: string
+                  required:
+                  - name
+                  - rationale
+                  - value
+                  type: object
+                nullable: true
+                type: array
+              title:
+                description: Overwrites the title of the extended profile (optional)
+                type: string
+            required:
+            - extends
+            type: object
+          status:
+            description: TailoredProfileStatus defines the observed state of TailoredProfile
+            properties:
+              errorMessagae:
+                type: string
+              id:
+                description: The XCCDF ID of the tailored profile
+                type: string
+              outputRef:
+                description: Points to the generated resource of the type specified
+                  in "outputType"
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              state:
+                description: The current state of the tailored profile
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/deploy/crds/compliance.openshift.io_variables_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_variables_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: variables.compliance.openshift.io
@@ -10,62 +10,61 @@ spec:
     plural: variables
     singular: variable
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: Variable describes a tunable in the XCCDF profile
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        description:
-          description: The description of the Variable
-          type: string
-        id:
-          description: the ID of the variable
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        selections:
-          description: Enumerates what values are allowed for this variable. Can be
-            empty.
-          items:
-            properties:
-              description:
-                description: The string description of the selection
-                type: string
-              value:
-                description: The value of the variable
-                type: string
-            type: object
-          nullable: true
-          type: array
-        title:
-          description: The title of the Variable
-          type: string
-        type:
-          description: The type of the variable
-          enum:
-          - number
-          - bool
-          - string
-          type: string
-        value:
-          description: The value of the variable
-          type: string
-      required:
-      - id
-      - title
-      - type
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Variable describes a tunable in the XCCDF profile
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          description:
+            description: The description of the Variable
+            type: string
+          id:
+            description: the ID of the variable
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          selections:
+            description: Enumerates what values are allowed for this variable. Can
+              be empty.
+            items:
+              properties:
+                description:
+                  description: The string description of the selection
+                  type: string
+                value:
+                  description: The value of the variable
+                  type: string
+              type: object
+            nullable: true
+            type: array
+          title:
+            description: The title of the Variable
+            type: string
+          type:
+            description: The type of the variable
+            enum:
+            - number
+            - bool
+            - string
+            type: string
+          value:
+            description: The value of the variable
+            type: string
+        required:
+        - id
+        - title
+        - type
+        type: object
     served: true
     storage: true

--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -38,10 +38,16 @@ type ComplianceRemediationSpecMeta struct {
 // +k8s:openapi-gen=true
 type ComplianceRemediationSpec struct {
 	ComplianceRemediationSpecMeta `json:",inline"`
-	// The actual MachineConfig remediation payload
+	// (deprecated) The actual MachineConfig remediation payload
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:EmbeddedResource
+	// +kubebuilder:validation:nullable
 	MachineConfigContents *unstructured.Unstructured `json:"machineConfigContents,omitempty"`
 	// The remediation payload. This would normally be a full Kubernetes
 	// object.
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:EmbeddedResource
+	// +kubebuilder:validation:nullable
 	Object *unstructured.Unstructured `json:"object,omitempty"`
 }
 

--- a/pkg/apis/compliance/v1alpha1/rule_types.go
+++ b/pkg/apis/compliance/v1alpha1/rule_types.go
@@ -46,6 +46,9 @@ type FixDefinition struct {
 	// degradation that this fix will impose in the target system
 	Disruption string `json:"disruption,omitempty"`
 	// an object that should bring the rule into compliance
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:EmbeddedResource
+	// +kubebuilder:validation:nullable
 	FixObject *unstructured.Unstructured `json:"fixObject,omitempty"`
 }
 


### PR DESCRIPTION
operator-sdk v0.18.X now generates CRDs using the v1 version instead of
v1beta1. This takes it into account.