### PR TITLE
Add `tear-down` target to Makefile

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: compliance-operator
       containers:
         - name: compliance-operator
-          image: "quay.io/compliance-operator/compliance-operator:latest"
+          image: "image-registry.openshift-image-registry.svc:5000/openshift-compliance/compliance-operator:latest"
           command:
           - compliance-operator
           - operator
@@ -35,7 +35,7 @@ spec:
               # Hardcoding this temporarily until its propagated to CI
               value: "quay.io/compliance-operator/openscap-ocp:1.3.3"
             - name: OPERATOR_IMAGE
-              value: "quay.io/compliance-operator/compliance-operator:latest"
+              value: "image-registry.openshift-image-registry.svc:5000/openshift-compliance/compliance-operator:latest"
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -444,6 +444,19 @@ func TestE2E(t *testing.T) {
 			Name: "TestApplyGenericRemediation",
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				remName := "test-apply-generic-remediation"
+				unstruct := &unstructured.Unstructured{}
+				unstruct.SetUnstructuredContent(map[string]interface{}{
+					"kind":       "ConfigMap",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"name":      "generic-rem-cm",
+						"namespace": namespace,
+					},
+					"data": map[string]interface{}{
+						"key": "value",
+					},
+				})
+
 				genericRem := &compv1alpha1.ComplianceRemediation{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      remName,
@@ -453,19 +466,7 @@ func TestE2E(t *testing.T) {
 						ComplianceRemediationSpecMeta: compv1alpha1.ComplianceRemediationSpecMeta{
 							Apply: true,
 						},
-						Object: &unstructured.Unstructured{
-							Object: map[string]interface{}{
-								"kind":       "ConfigMap",
-								"apiVersion": "v1",
-								"metadata": map[string]interface{}{
-									"name":      "generic-rem-cm",
-									"namespace": namespace,
-								},
-								"data": map[string]interface{}{
-									"key": "value",
-								},
-							},
-						},
+						Object: unstruct,
 					},
 				}
 				// use Context's create helper to create the object and add a cleanup function for the new object


### PR DESCRIPTION
This target ensures that the objects are removed from the deployment if
called.

This is added as a dependency for the e2e target, which enables us to
iterate quickly on testing if the test keeps failing.