### PR TITLE
Add parallelism to e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ e2e: namespace operator-sdk image-to-cluster openshift-user ## Run the end-to-en
 	@sed -i 's%$(IMAGE_REPO)/$(OPENSCAP_IMAGE_NAME):$(OPENSCAP_DEFAULT_IMAGE_TAG)%$(OPENSCAP_IMAGE_PATH):$(OPENSCAP_IMAGE_TAG)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(APP_NAME):latest%$(OPERATOR_IMAGE_PATH)%' deploy/operator.yaml
 	@echo "Running e2e tests"
-	unset GOFLAGS && CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) $(GOPATH)/bin/operator-sdk test local ./tests/e2e --skip-cleanup-error --image "$(OPERATOR_IMAGE_PATH)" --operator-namespace "$(NAMESPACE)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
+	unset GOFLAGS && CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) $(GOPATH)/bin/operator-sdk test local ./tests/e2e --skip-cleanup-error --image "$(OPERATOR_IMAGE_PATH)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
 	@echo "Restoring image references in deploy/operator.yaml"
 	@sed -i 's%$(OPENSCAP_IMAGE_PATH):$(OPENSCAP_IMAGE_TAG)%$(IMAGE_REPO)/$(OPENSCAP_IMAGE_NAME):$(OPENSCAP_DEFAULT_IMAGE_TAG)%' deploy/operator.yaml
 	@sed -i 's%$(OPERATOR_IMAGE_PATH)%$(IMAGE_REPO)/$(APP_NAME):latest%' deploy/operator.yaml
@@ -199,7 +199,7 @@ e2e-local: operator-sdk ## Run the end-to-end tests on a locally running operato
 	@echo "WARNING: This will temporarily modify deploy/operator.yaml"
 	@echo "Replacing workload references in deploy/operator.yaml"
 	@sed -i 's%$(IMAGE_REPO)/$(APP_NAME):latest%$(OPERATOR_IMAGE_PATH)%' deploy/operator.yaml
-	unset GOFLAGS && CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) $(GOPATH)/bin/operator-sdk test local ./tests/e2e --up-local --skip-cleanup-error --image "$(OPERATOR_IMAGE_PATH)" --operator-namespace "$(NAMESPACE)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
+	unset GOFLAGS && CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) $(GOPATH)/bin/operator-sdk test local ./tests/e2e --up-local --skip-cleanup-error --image "$(OPERATOR_IMAGE_PATH)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
 	@echo "Restoring image references in deploy/operator.yaml"
 	@sed -i 's%$(OPERATOR_IMAGE_PATH)%$(IMAGE_REPO)/$(APP_NAME):latest%' deploy/operator.yaml
 
@@ -239,7 +239,7 @@ image-to-cluster:
 else ifeq ($(E2E_SKIP_CONTAINER_PUSH), true)
 image-to-cluster:
 	@echo "E2E_SKIP_CONTAINER_PUSH variable detected. Using previously pushed images."
-	$(eval OPERATOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(APP_NAME):$(TAG))
+	$(eval OPERATOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/openshift/$(APP_NAME):$(TAG))
 else ifeq ($(E2E_SKIP_CONTAINER_BUILD), true)
 image-to-cluster: namespace cluster-image-push
 	@echo "E2E_SKIP_CONTAINER_BUILD variable detected. Using previously built local images."
@@ -255,10 +255,10 @@ cluster-image-push: namespace openshift-user
 	@echo "Pushing image $(OPERATOR_IMAGE_PATH):$(TAG) to the image registry"
 	IMAGE_REGISTRY_HOST=$$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}'); \
 		$(RUNTIME) login --tls-verify=false -u $(OPENSHIFT_USER) -p $(shell oc whoami -t) $${IMAGE_REGISTRY_HOST}; \
-		$(RUNTIME) push --tls-verify=false $(OPERATOR_IMAGE_PATH):$(TAG) $${IMAGE_REGISTRY_HOST}/$(NAMESPACE)/$(APP_NAME):$(TAG)
+		$(RUNTIME) push --tls-verify=false $(OPERATOR_IMAGE_PATH):$(TAG) $${IMAGE_REGISTRY_HOST}/openshift/$(APP_NAME):$(TAG)
 	@echo "Removing the route from the image registry"
 	@oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":false}}' --type=merge
-	$(eval OPERATOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/$(NAMESPACE)/$(APP_NAME):$(TAG))
+	$(eval OPERATOR_IMAGE_PATH = image-registry.openshift-image-registry.svc:5000/openshift/$(APP_NAME):$(TAG))
 
 .PHONY: namespace
 namespace:

--- a/tests/e2e/constants.go
+++ b/tests/e2e/constants.go
@@ -2,9 +2,13 @@ package e2e
 
 import "time"
 
-var (
+const (
 	retryInterval        = time.Second * 5
 	timeout              = time.Minute * 15
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Minute * 5
+	workerPoolName       = "worker"
+	testPoolName         = "e2e"
+	rhcosContentFile     = "ssg-rhcos4-ds.xml"
+	ocpContentFile       = "ssg-ocp4-ds.xml"
 )

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -20,7 +20,8 @@ import (
 func TestE2E(t *testing.T) {
 	executeTests(t,
 		testExecution{
-			Name: "TestProfileParsingWorks",
+			Name:       "TestProfileParsingWorks",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				pbName := getObjNameFromTest(t)
 				testPB := &compv1alpha1.ProfileBundle{
@@ -50,7 +51,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestPBWithWrongFile",
+			Name:       "TestPBWithWrongFile",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				pbName := getObjNameFromTest(t)
 				testPB := &compv1alpha1.ProfileBundle{
@@ -73,7 +75,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestSingleScanSucceeds",
+			Name:       "TestSingleScanSucceeds",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				exampleComplianceScan := &compv1alpha1.ComplianceScan{
 					ObjectMeta: metav1.ObjectMeta{
@@ -101,7 +104,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestSingleTailoredScanSucceeds",
+			Name:       "TestSingleTailoredScanSucceeds",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				tailoringCM := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -156,7 +160,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestScanWithNodeSelectorFiltersCorrectly",
+			Name:       "TestScanWithNodeSelectorFiltersCorrectly",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				selectWorkers := map[string]string{
 					"node-role.kubernetes.io/worker": "",
@@ -194,7 +199,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestScanWithInvalidContentFails",
+			Name:       "TestScanWithInvalidContentFails",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				exampleComplianceScan := &compv1alpha1.ComplianceScan{
 					ObjectMeta: metav1.ObjectMeta{
@@ -220,7 +226,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestScanWithInvalidProfileFails",
+			Name:       "TestScanWithInvalidProfileFails",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				exampleComplianceScan := &compv1alpha1.ComplianceScan{
 					ObjectMeta: metav1.ObjectMeta{
@@ -246,7 +253,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestMalformedTailoredScanFails",
+			Name:       "TestMalformedTailoredScanFails",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				tailoringCM := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -302,7 +310,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestScanWithEmptyTailoringCMNameFails",
+			Name:       "TestScanWithEmptyTailoringCMNameFails",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				exampleComplianceScan := &compv1alpha1.ComplianceScan{
 					ObjectMeta: metav1.ObjectMeta{
@@ -331,7 +340,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestScanWithMissingTailoringCMFailsAndRecovers",
+			Name:       "TestScanWithMissingTailoringCMFailsAndRecovers",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				scanName := "test-scan-w-missing-tailoring-cm"
 				exampleComplianceScan := &compv1alpha1.ComplianceScan{
@@ -395,7 +405,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestMissingPodInRunningState",
+			Name:       "TestMissingPodInRunningState",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				exampleComplianceScan := &compv1alpha1.ComplianceScan{
 					ObjectMeta: metav1.ObjectMeta{
@@ -441,7 +452,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestApplyGenericRemediation",
+			Name:       "TestApplyGenericRemediation",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				remName := "test-apply-generic-remediation"
 				genericRem := &compv1alpha1.ComplianceRemediation{
@@ -491,7 +503,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestGenericRemediationFailsWithUnkownType",
+			Name:       "TestGenericRemediationFailsWithUnkownType",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				remName := "test-generic-remediation-fails-unkown"
 				genericRem := &compv1alpha1.ComplianceRemediation{
@@ -531,7 +544,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestSuiteWithInvalidScheduleShowsError",
+			Name:       "TestSuiteWithInvalidScheduleShowsError",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				suiteName := "test-suite-with-invalid-schedule"
 				testSuite := &compv1alpha1.ComplianceSuite{
@@ -572,7 +586,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestSuiteScan",
+			Name:       "TestSuiteScan",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				suiteName := "test-suite-two-scans"
 
@@ -677,7 +692,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestScheduledSuite",
+			Name:       "TestScheduledSuite",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				suiteName := "test-scheduled-suite"
 
@@ -737,7 +753,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestSuiteWithContentThatDoesNotMatch",
+			Name:       "TestSuiteWithContentThatDoesNotMatch",
+			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				suiteName := "test-suite-with-non-matching-content"
 				testSuite := &compv1alpha1.ComplianceSuite{
@@ -777,7 +794,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestAutoRemediate",
+			Name:       "TestAutoRemediate",
+			IsParallel: false,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				// FIXME, maybe have a func that returns a struct with suite name and scan names?
 				suiteName := "test-remediate"
@@ -939,7 +957,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestUnapplyRemediation",
+			Name:       "TestUnapplyRemediation",
+			IsParallel: false,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				// FIXME, maybe have a func that returns a struct with suite name and scan names?
 				suiteName := "test-unapply-remediation"
@@ -1054,7 +1073,8 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
-			Name: "TestPlatformAndNodeSuiteScan",
+			Name:       "TestPlatformAndNodeSuiteScan",
+			IsParallel: false,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, mcTctx *mcTestCtx, namespace string) error {
 				suiteName := "test-suite-two-scans-with-platform"
 


### PR DESCRIPTION
This makes the e2e tests run in parallel.

This has several implications

* We no longer run the tests in the openshift-compliance namespace.
  Instead, we rely on the namespace created by the operator-sdk test
  framework. This is because specifying the namespace made the framework
  disable parallelism

* We also no longer push the images to the `openshift-compliance`
  namespace. This is because we can no longer predict the namespace
  where the tests will run. Instead we push the images to the
  `openshift` namespace, where any pod can pull images from.

To be able to use the cluster role bindings on the appropriate
namespace, we edit the "namespaced manifest" created by the framework
before the test executes, since this is the only place where we know the
namespace the test will run in.