### PR TITLE
Make raw result storage size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ In the `spec`:
   remediation will be created for. Note that if this parameter is not
   specified or doesn't match a `MachineConfigPool`, a scan will still be run,
   but remediations won't be created.
+* **rawResultStorageSize**: Specifies the size of storage that should be asked
+  for in order for the scan to store the raw results. (Defaults to 1Gi)
 
 Regarding the `status`:
 

--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -65,9 +65,10 @@ spec:
                   the collection of rules that will be checked for.
                 type: string
               rawResultStorageSize:
+                default: 1Gi
                 description: Specifies the amount of storage to ask for storing the
                   raw results. Note that if re-scans happen, the new results will
-                  also need to be stored.
+                  also need to be stored. Defaults to 1Gi.
                 type: string
               rule:
                 description: A Rule can be specified if the scan should check only

--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -64,6 +64,11 @@ spec:
                 description: Is the profile in the data stream to be used. This is
                   the collection of rules that will be checked for.
                 type: string
+              rawResultStorageSize:
+                description: Specifies the amount of storage to ask for storing the
+                  raw results. Note that if re-scans happen, the new results will
+                  also need to be stored.
+                type: string
               rule:
                 description: A Rule can be specified if the scan should check only
                   for a specific rule. Note that when leaving this empty, the scan

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -79,6 +79,11 @@ spec:
                       description: Is the profile in the data stream to be used. This
                         is the collection of rules that will be checked for.
                       type: string
+                    rawResultStorageSize:
+                      description: Specifies the amount of storage to ask for storing
+                        the raw results. Note that if re-scans happen, the new results
+                        will also need to be stored.
+                      type: string
                     rule:
                       description: A Rule can be specified if the scan should check
                         only for a specific rule. Note that when leaving this empty,

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -80,9 +80,10 @@ spec:
                         is the collection of rules that will be checked for.
                       type: string
                     rawResultStorageSize:
+                      default: 1Gi
                       description: Specifies the amount of storage to ask for storing
                         the raw results. Note that if re-scans happen, the new results
-                        will also need to be stored.
+                        will also need to be stored. Defaults to 1Gi.
                       type: string
                     rule:
                       description: A Rule can be specified if the scan should check

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -138,6 +138,7 @@ type ComplianceScanSpec struct {
 	// Specifies the amount of storage to ask for storing the raw results. Note that
 	// if re-scans happen, the new results will also need to be stored. Defaults to 1Gi.
 	// +kubebuilder:validation:Default=1Gi
+	// +kubebuilder:default="1Gi"
 	RawResultStorageSize string `json:"rawResultStorageSize,omitempty"`
 }
 

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -21,6 +21,10 @@ const ScriptLabel = "complianceoperator.openshift.io/scan-script"
 // added by the ComplianceScan controller in order to delete resources.
 const ScanFinalizer = "scan.finalizers.compliance.openshift.io"
 
+// DefaultRawStorageSize specifies the default storage size where the raw
+// results will be stored at
+const DefaultRawStorageSize = "1Gi"
+
 // Represents the status of the compliance scan run.
 type ComplianceScanStatusPhase string
 
@@ -131,6 +135,10 @@ type ComplianceScanSpec struct {
 	TailoringConfigMap *TailoringConfigMapRef `json:"tailoringConfigMap,omitempty"`
 	// Enable debug logging of workloads and OpenSCAP
 	Debug bool `json:"debug,omitempty"`
+	// Specifies the amount of storage to ask for storing the raw results. Note that
+	// if re-scans happen, the new results will also need to be stored. Defaults to 1Gi.
+	// +kubebuilder:validation:Default=1Gi
+	RawResultStorageSize string `json:"rawResultStorageSize,omitempty"`
 }
 
 // ComplianceScanStatus defines the observed state of ComplianceScan

--- a/pkg/controller/compliancescan/rawresults.go
+++ b/pkg/controller/compliancescan/rawresults.go
@@ -12,6 +12,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	rawStorageAllocationErrorPrefix = "Couldn't allocate raw storage: "
+)
+
 // handles the necessary things to store and expose the raw results from the scan. This implies
 // that the PVC gets created, and, if necessary, the scan instance will get updated too.
 // Returns whether the reconcile loop should continue or not, and an error if encountered.
@@ -20,6 +24,14 @@ func (r *ReconcileComplianceScan) handleRawResultsForScan(instance *compv1alpha1
 	pvc := getPVCForScan(instance)
 	logger.Info("Creating PVC for scan", "PersistentVolumeClaim.Name", pvc.Name, "PersistentVolumeClaim.Namespace", pvc.Namespace)
 	if err := r.client.Create(context.TODO(), pvc); err != nil && !errors.IsAlreadyExists(err) {
+		// Handle resource limit issues
+		if errors.IsForbidden(err) {
+			scanCopy := instance.DeepCopy()
+			scanCopy.Status.Phase = compv1alpha1.PhaseDone
+			scanCopy.Status.Result = compv1alpha1.ResultError
+			scanCopy.Status.ErrorMessage = rawStorageAllocationErrorPrefix + err.Error()
+			return false, r.client.Status().Update(context.TODO(), scanCopy)
+		}
 		return false, err
 	}
 	if instanceNeedsResultStorageReference(instance, pvc) {

--- a/pkg/controller/compliancescan/rawresults.go
+++ b/pkg/controller/compliancescan/rawresults.go
@@ -61,8 +61,7 @@ func getPVCForScan(instance *compv1alpha1.ComplianceScan) *corev1.PersistentVolu
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					// TODO(jaosorior): Make this configurable
-					corev1.ResourceStorage: resource.MustParse("1Gi"),
+					corev1.ResourceStorage: resource.MustParse(instance.Spec.RawResultStorageSize),
 				},
 			},
 		},


### PR DESCRIPTION
The ComplianceScan stores the raw reslults in a PVC. As of now, the size
was hardcoded to 1Gi. This introduces a parameter in the scan to be able
to set it. The aforementioned parameter is called
`rawResultStorageSize`, and it defaults to 1Gi.