### PR TITLE
Fix parallel test reporting

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -168,14 +168,14 @@ func executeTests(t *testing.T, tests ...testExecution) {
 		for _, test := range tests {
 			// Don't loose test reference
 			test := test
-			t.Run(test.Name, func(tt *testing.T) {
-				if test.IsParallel {
+			if test.IsParallel {
+				t.Run(test.Name, func(tt *testing.T) {
 					tt.Parallel()
 					if err := test.TestFn(tt, f, ctx, mcTctx, ns); err != nil {
 						tt.Error(err)
 					}
-				}
-			})
+				})
+			}
 		}
 	})
 
@@ -183,13 +183,13 @@ func executeTests(t *testing.T, tests ...testExecution) {
 		for _, test := range tests {
 			// Don't loose test reference
 			test := test
-			t.Run(test.Name, func(t *testing.T) {
-				if !test.IsParallel {
+			if !test.IsParallel {
+				t.Run(test.Name, func(t *testing.T) {
 					if err := test.TestFn(t, f, ctx, mcTctx, ns); err != nil {
 						t.Error(err)
 					}
-				}
-			})
+				})
+			}
 		}
 	})
 }


### PR DESCRIPTION
Even though some tests were not being executed in practice, they were
being taken into account in a section they didn't belong
(parallel/serial). This was due to the way the parallel check was done
(which was inside of the Run statement). This fixes that to fix
reporting.