### PR TITLE
Re-introduce custom cleanup handler for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ e2e: namespace operator-sdk image-to-cluster openshift-user ## Run the end-to-en
 	@sed -i 's%$(IMAGE_REPO)/$(OPENSCAP_IMAGE_NAME):$(OPENSCAP_DEFAULT_IMAGE_TAG)%$(OPENSCAP_IMAGE_PATH):$(OPENSCAP_IMAGE_TAG)%' deploy/operator.yaml
 	@sed -i 's%$(IMAGE_REPO)/$(APP_NAME):latest%$(OPERATOR_IMAGE_PATH)%' deploy/operator.yaml
 	@echo "Running e2e tests"
-	unset GOFLAGS && CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) $(GOPATH)/bin/operator-sdk test local ./tests/e2e --skip-cleanup-error --image "$(OPERATOR_IMAGE_PATH)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
+	unset GOFLAGS && CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) $(GOPATH)/bin/operator-sdk test local ./tests/e2e --image "$(OPERATOR_IMAGE_PATH)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
 	@echo "Restoring image references in deploy/operator.yaml"
 	@sed -i 's%$(OPENSCAP_IMAGE_PATH):$(OPENSCAP_IMAGE_TAG)%$(IMAGE_REPO)/$(OPENSCAP_IMAGE_NAME):$(OPENSCAP_DEFAULT_IMAGE_TAG)%' deploy/operator.yaml
 	@sed -i 's%$(OPERATOR_IMAGE_PATH)%$(IMAGE_REPO)/$(APP_NAME):latest%' deploy/operator.yaml
@@ -199,7 +199,7 @@ e2e-local: operator-sdk ## Run the end-to-end tests on a locally running operato
 	@echo "WARNING: This will temporarily modify deploy/operator.yaml"
 	@echo "Replacing workload references in deploy/operator.yaml"
 	@sed -i 's%$(IMAGE_REPO)/$(APP_NAME):latest%$(OPERATOR_IMAGE_PATH)%' deploy/operator.yaml
-	unset GOFLAGS && CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) $(GOPATH)/bin/operator-sdk test local ./tests/e2e --up-local --skip-cleanup-error --image "$(OPERATOR_IMAGE_PATH)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
+	unset GOFLAGS && CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) $(GOPATH)/bin/operator-sdk test local ./tests/e2e --up-local --image "$(OPERATOR_IMAGE_PATH)" --go-test-flags "$(E2E_GO_TEST_FLAGS)"
 	@echo "Restoring image references in deploy/operator.yaml"
 	@sed -i 's%$(OPERATOR_IMAGE_PATH)%$(IMAGE_REPO)/$(APP_NAME):latest%' deploy/operator.yaml
 

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -145,7 +145,7 @@ func (c *mcTestCtx) createE2EPool() error {
 // executeTest sets up everything that a e2e test needs to run, and executes the test.
 func executeTests(t *testing.T, tests ...testExecution) {
 	ctx := setupTestRequirements(t)
-	defer ctx.Cleanup()
+	defer cleanupTestEnv(t, ctx)
 
 	// get global framework variables
 	f := framework.Global
@@ -192,6 +192,17 @@ func executeTests(t *testing.T, tests ...testExecution) {
 			})
 		}
 	})
+}
+
+func cleanupTestEnv(t *testing.T, ctx *framework.Context) {
+	// If the tests didn't fail, clean up. Else, leave everything
+	// there so developers can debug the issue.
+	if !t.Failed() {
+		t.Log("The tests passed. Cleaning up.")
+		ctx.Cleanup()
+	} else {
+		t.Log("The tests failed. Leaving the env there so you can debug.")
+	}
 }
 
 // setupTestRequirements Adds the items to the client's schema (So we can use our objects in the client)


### PR DESCRIPTION
The cleanup done by operator-sdk was still cleaning resources even if it
shouldn't. Let's go back to using our own custom cleanup function.