### PR TITLE
Debug flag no longer cleans up resources

### DIFF
--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -50,8 +50,7 @@ spec:
                   be used to run OpenSCAP.
                 type: string
               debug:
-                description: Disables cleaning up resources in the DONE phase, this
-                  might be useful for debugging.
+                description: Enable debug logging of workloads and OpenSCAP
                 type: boolean
               nodeSelector:
                 additionalProperties:

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -60,8 +60,7 @@ spec:
                         will be used to run OpenSCAP.
                       type: string
                     debug:
-                      description: Disables cleaning up resources in the DONE phase,
-                        this might be useful for debugging.
+                      description: Enable debug logging of workloads and OpenSCAP
                       type: boolean
                     name:
                       description: Contains a human readable name for the scan. This

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -129,7 +129,7 @@ type ComplianceScanSpec struct {
 	// tailoring file. It assumes a key called `tailoring.xml` which will
 	// have the tailoring contents.
 	TailoringConfigMap *TailoringConfigMapRef `json:"tailoringConfigMap,omitempty"`
-	// Disables cleaning up resources in the DONE phase, this might be useful for debugging.
+	// Enable debug logging of workloads and OpenSCAP
 	Debug bool `json:"debug,omitempty"`
 }
 


### PR DESCRIPTION
While at first glance it seemed like a good idea. It turns out that it's
useful to keep resources around to be able to debug and diagnose
deployments.

So, this changes the debug flag to no longer clean up pods and
resources. Instead it just enables debug logging of workloads and
OpenSCAP.