### PR TITLE
Remove divergence in content in testcontent image

### DIFF
--- a/images/testcontent/Dockerfile.ci
+++ b/images/testcontent/Dockerfile.ci
@@ -1,4 +1,1 @@
 FROM quay.io/complianceascode/ocp4:latest
-
-# Force matching any version
-RUN sed -i 's%pattern match">4.\.\.\*%pattern match">.*%' /ssg-ocp4-ds.xml


### PR DESCRIPTION
The versioning issue was recently fixed, and so we no longer need this
hack. I intend to keep the testcontent image though, as it ensures that
content is available in CI without having to do multiple calls to quay
(just the initial image build)