### PR TITLE
Migrate scap_test to ginkgo and re-introduce gingko.noColor flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ test-unit: fmt ## Run the unit tests
 ifndef JUNITFILE
 	@$(GO) test $(TEST_OPTIONS) $(PKGS)
 else
-	@set -o pipefail; $(GO) test $(TEST_OPTIONS) -json $(PKGS) | gotest2junit -v > $(JUNITFILE)
+	@set -o pipefail; $(GO) test $(TEST_OPTIONS) -json $(PKGS) --ginkgo.noColor | gotest2junit -v > $(JUNITFILE)
 endif
 
 .PHONY: test-benchmark

--- a/cmd/manager/manager_suite_test.go
+++ b/cmd/manager/manager_suite_test.go
@@ -1,0 +1,13 @@
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Manager Suite")
+}

--- a/cmd/manager/scap_test.go
+++ b/cmd/manager/scap_test.go
@@ -49,8 +49,8 @@ var _ = Describe("Testing SCAP parsing and storage", func() {
 		})
 	})
 
-	Context("Storing files in their appropriate directories", func() {
-		It("Stores the file in the right place with the root being '/tmp'", func() {
+	Context("Parses the save path appropriately", func() {
+		It("Parses correctly with the root being '/tmp'", func() {
 			root := "/tmp"
 			path := "/apis/foo"
 			expectedDir := "/tmp/apis"
@@ -62,7 +62,7 @@ var _ = Describe("Testing SCAP parsing and storage", func() {
 			Expect(file).To(Equal(expectedFile))
 		})
 
-		It("Stores the file in the right place with the root being '/'", func() {
+		It("Parses correctly with the root being '/'", func() {
 			root := "/"
 			path := "/apis/foo/bar"
 			expectedDir := "/apis/foo"
@@ -74,7 +74,7 @@ var _ = Describe("Testing SCAP parsing and storage", func() {
 			Expect(file).To(Equal(expectedFile))
 		})
 
-		It("Stores the file in the right place with the root being '/tmp/foo'", func() {
+		It("Parses correctly with the root being '/tmp/foo'", func() {
 			root := "/tmp/foo"
 			path := "/apis/foo/bar/baz"
 			expectedDir := "/tmp/foo/apis/foo/bar"

--- a/cmd/manager/scap_test.go
+++ b/cmd/manager/scap_test.go
@@ -2,105 +2,88 @@ package main
 
 import (
 	"os"
-	"reflect"
-	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/compliance-operator/pkg/utils"
 )
 
-func TestSCAPContentParsing(t *testing.T) {
-	debugLog = true
-	tests := map[string]struct {
-		profile  string
-		expected []string
-		data     string
-	}{
-		"ssg-ocp4-ds.xml(mocked) new": {
-			profile: "xccdf_org.ssgproject.content_profile_platform-moderate",
-			data:    "../../tests/data/ssg-ocp4-ds-new.xml",
-			expected: []string{
-				"/apis/config.openshift.io/v1/oauths/cluster",
-			},
-		},
-	}
-	for n, tc := range tests {
-		t.Run(n, func(t *testing.T) {
-			f, err := os.Open(tc.data)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer f.Close()
-			c, err := parseContent(f)
-			if err != nil {
-				t.Fatal(err)
-			}
+var _ = Describe("Testing SCAP parsing and storage", func() {
+	// Turn to `true` if debugging
+	debugLog = false
 
-			got := getResourcePaths(c, tc.profile)
-			if !reflect.DeepEqual(tc.expected, got) {
-				t.Errorf("expected %v, got %v", tc.expected, got)
-			}
-		})
-	}
-}
+	Context("Parsing SCAP Content", func() {
+		var dataStreamFile *os.File
+		var contentDS *utils.XMLDocument
 
-func TestParseWarning(t *testing.T) {
-	debugLog = true
-	tests := map[string]struct {
-		input           string
-		expectedAPIPath string
-	}{
-		"first": {
-			input:           `<warning category="general" lang="en-US"><code class="ocp-api-endpoint">/apis/config.openshift.io/v1/oauths/cluster</code><code class="ocp-dump-location"><sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy" />/idp.yml</code>file.</warning>`,
-			expectedAPIPath: "/apis/config.openshift.io/v1/oauths/cluster",
-		},
-	}
-	for n, tc := range tests {
-		t.Run(n, func(t *testing.T) {
-			api := getPathFromWarningXML(tc.input)
-			if api != tc.expectedAPIPath {
-				t.Errorf("expected API path %s, got %s", tc.expectedAPIPath, api)
-			}
+		BeforeEach(func() {
+			var err error
+			dataStreamFile, err = os.Open("../../tests/data/ssg-ocp4-ds-new.xml")
+			Expect(err).To(BeNil())
 		})
-	}
-}
+		AfterEach(func() {
+			dataStreamFile.Close()
+		})
 
-func TestSaveDirectoryAndFile(t *testing.T) {
-	debugLog = true
-	tests := map[string]struct {
-		root         string
-		path         string
-		expectedDir  string
-		expectedFile string
-	}{
-		"1": {
-			root:         "/tmp",
-			path:         "/apis/foo",
-			expectedDir:  "/tmp/apis",
-			expectedFile: "foo",
-		},
-		"2": {
-			root:         "/",
-			path:         "/apis/foo/bar",
-			expectedDir:  "/apis/foo",
-			expectedFile: "bar",
-		},
-		"3": {
-			root:         "/tmp/foo",
-			path:         "/apis/foo/bar/baz",
-			expectedDir:  "/tmp/foo/apis/foo/bar",
-			expectedFile: "baz",
-		},
-	}
-	for n, tc := range tests {
-		t.Run(n, func(t *testing.T) {
-			dir, file, err := getSaveDirectoryAndFileName(tc.root, tc.path)
-			if err != nil {
-				t.Error(err)
-			}
-			if dir != tc.expectedDir {
-				t.Errorf("expected dir %s, got %s", tc.expectedDir, dir)
-			}
-			if file != tc.expectedFile {
-				t.Errorf("expected file %s, got %s", tc.expectedFile, file)
-			}
+		It("Parses content without errors", func() {
+			var err error
+			contentDS, err = parseContent(dataStreamFile)
+			Expect(err).To(BeNil())
 		})
-	}
-}
+
+		It("Gets the appropriate resource URIs", func() {
+			expected := []string{"/apis/config.openshift.io/v1/oauths/cluster"}
+			got := getResourcePaths(contentDS, "xccdf_org.ssgproject.content_profile_platform-moderate")
+			Expect(got).To(Equal(expected))
+		})
+	})
+
+	Context("Parsing warnings", func() {
+		It("Gets an appropriate path from the datastream", func() {
+			expectedAPIPath := "/apis/config.openshift.io/v1/oauths/cluster"
+
+			warning := `<warning category="general" lang="en-US"><code class="ocp-api-endpoint">/apis/config.openshift.io/v1/oauths/cluster</code><code class="ocp-dump-location"><sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy" />/idp.yml</code>file.</warning>`
+			api := getPathFromWarningXML(warning)
+			Expect(api).To(Equal(expectedAPIPath))
+		})
+	})
+
+	Context("Storing files in their appropriate directories", func() {
+		It("Stores the file in the right place with the root being '/tmp'", func() {
+			root := "/tmp"
+			path := "/apis/foo"
+			expectedDir := "/tmp/apis"
+			expectedFile := "foo"
+
+			dir, file, err := getSaveDirectoryAndFileName(root, path)
+			Expect(err).To(BeNil())
+			Expect(dir).To(Equal(expectedDir))
+			Expect(file).To(Equal(expectedFile))
+		})
+
+		It("Stores the file in the right place with the root being '/'", func() {
+			root := "/"
+			path := "/apis/foo/bar"
+			expectedDir := "/apis/foo"
+			expectedFile := "bar"
+
+			dir, file, err := getSaveDirectoryAndFileName(root, path)
+			Expect(err).To(BeNil())
+			Expect(dir).To(Equal(expectedDir))
+			Expect(file).To(Equal(expectedFile))
+		})
+
+		It("Stores the file in the right place with the root being '/tmp/foo'", func() {
+			root := "/tmp/foo"
+			path := "/apis/foo/bar/baz"
+			expectedDir := "/tmp/foo/apis/foo/bar"
+			expectedFile := "baz"
+
+			dir, file, err := getSaveDirectoryAndFileName(root, path)
+			Expect(err).To(BeNil())
+			Expect(dir).To(Equal(expectedDir))
+			Expect(file).To(Equal(expectedFile))
+		})
+	})
+})


### PR DESCRIPTION
* Migrating that test ensures that all our unit tests are in sync using the
  same framework

* Re-introducing that flag ensures that test failures are readable in CI.