### PR TITLE
Enable raw result rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ In the `spec`:
   but remediations won't be created.
 * **rawResultStorageSize**: Specifies the size of storage that should be asked
   for in order for the scan to store the raw results. (Defaults to 1Gi)
+* **rawResultStorageRotation**: Specifies the amount of scans for which the raw
+  results will be stored. Older results will get rotated, and it's the
+  responsibility of administrators to store these results elsewhere before
+  rotation happens. Note that a rotation policy of '0' disables rotation
+  entirely. Defaults to 3.
 
 Regarding the `status`:
 

--- a/cmd/manager/resultserver_test.go
+++ b/cmd/manager/resultserver_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright © 2019 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func _readDirNames(path string) []string {
+	f, err := os.Open(path)
+	Expect(err).To(BeNil())
+	list, err := f.Readdirnames(-1)
+	f.Close()
+	Expect(err).To(BeNil())
+	return list
+}
+
+var _ = Describe("Resultserver testing", func() {
+	Context("Raw result directory rotation", func() {
+		var rootDir string
+		var dir1, dir2, dir3, lostFoundDir string
+
+		BeforeEach(func() {
+			var err error
+			rootDir, err = ioutil.TempDir("", "rotate-root")
+			Expect(err).To(BeNil())
+
+			// Ensure lost+found
+			lostFoundDir = path.Join(rootDir, "lost+found")
+			os.Mkdir(lostFoundDir, 0644)
+
+			// Create temporary directories which represent what will be rotated
+			dir1, err = ioutil.TempDir(rootDir, "rotate-1")
+			Expect(err).To(BeNil())
+			ioutil.TempFile(dir1, "foo")
+			fileToBeRead, err := ioutil.TempFile(dir1, "bar")
+			Expect(err).To(BeNil())
+			ioutil.TempFile(dir1, "baz")
+
+			// Ensure next directory will have significant time difference
+			time.Sleep(5 * time.Millisecond)
+			dir2, err = ioutil.TempDir(rootDir, "rotate-2")
+			Expect(err).To(BeNil())
+			ioutil.TempFile(dir2, "foo")
+			ioutil.TempFile(dir2, "bar")
+
+			// Ensure next directory will have significant time difference
+			time.Sleep(5 * time.Millisecond)
+			dir3, err = ioutil.TempDir(rootDir, "rotate-3")
+			Expect(err).To(BeNil())
+
+			// Read a file to ensure that hierarchy doesn't change
+			_, err = ioutil.ReadAll(fileToBeRead)
+			Expect(err).To(BeNil())
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(rootDir)
+		})
+
+		It("Doesn't rotate directories if policy is disabled (3 directories with one lost+found and policy=0)", func() {
+			err := rotateResultDirectories(rootDir, 0)
+			Expect(err).To(BeNil())
+
+			files := _readDirNames(rootDir)
+
+			By("Verifying that the expected files are in the directory hierarchy")
+			Expect(len(files)).To(Equal(4))
+			Expect(path.Base(dir1)).To(BeElementOf(files))
+			Expect(path.Base(dir2)).To(BeElementOf(files))
+			Expect(path.Base(dir3)).To(BeElementOf(files))
+			Expect(path.Base(lostFoundDir)).To(BeElementOf(files))
+
+			By("Verifying that the expected files are indeed directories")
+			Expect(dir1).To(BeADirectory())
+			Expect(dir2).To(BeADirectory())
+			Expect(dir3).To(BeADirectory())
+			Expect(lostFoundDir).To(BeADirectory())
+		})
+
+		It("Doesn't rotate directories if they're within the rotation policy (3 directories with one lost+found and policy=4)", func() {
+			err := rotateResultDirectories(rootDir, 4)
+			Expect(err).To(BeNil())
+
+			files := _readDirNames(rootDir)
+
+			By("Verifying that the expected files are in the directory hierarchy")
+			Expect(len(files)).To(Equal(4))
+			Expect(path.Base(dir1)).To(BeElementOf(files))
+			Expect(path.Base(dir2)).To(BeElementOf(files))
+			Expect(path.Base(dir3)).To(BeElementOf(files))
+			Expect(path.Base(lostFoundDir)).To(BeElementOf(files))
+
+			By("Verifying that the expected files are indeed directories")
+			Expect(dir1).To(BeADirectory())
+			Expect(dir2).To(BeADirectory())
+			Expect(dir3).To(BeADirectory())
+			Expect(lostFoundDir).To(BeADirectory())
+		})
+
+		It("Doesn't rotate directories if they're within the rotation policy (3 directories with one lost+found and policy=3)", func() {
+			err := rotateResultDirectories(rootDir, 3)
+			Expect(err).To(BeNil())
+
+			files := _readDirNames(rootDir)
+
+			By("Verifying that the expected files are in the directory hierarchy")
+			Expect(len(files)).To(Equal(4))
+			Expect(path.Base(dir1)).To(BeElementOf(files))
+			Expect(path.Base(dir2)).To(BeElementOf(files))
+			Expect(path.Base(dir3)).To(BeElementOf(files))
+			Expect(path.Base(lostFoundDir)).To(BeElementOf(files))
+
+			By("Verifying that the expected files are indeed directories")
+			Expect(dir1).To(BeADirectory())
+			Expect(dir2).To(BeADirectory())
+			Expect(dir3).To(BeADirectory())
+			Expect(lostFoundDir).To(BeADirectory())
+		})
+
+		It("Rotates directories according to the rotation policy (3 directories with one lost+found and policy=2)", func() {
+			err := rotateResultDirectories(rootDir, 2)
+			Expect(err).To(BeNil())
+
+			files := _readDirNames(rootDir)
+
+			By("Verifying that the expected files are in the directory hierarchy")
+			Expect(len(files)).To(Equal(3))
+			Expect(path.Base(dir1)).ToNot(BeElementOf(files))
+			Expect(path.Base(dir2)).To(BeElementOf(files))
+			Expect(path.Base(dir3)).To(BeElementOf(files))
+			Expect(path.Base(lostFoundDir)).To(BeElementOf(files))
+
+			By("Verifying that the expected files are indeed directories")
+			Expect(dir3).To(BeADirectory())
+			Expect(dir2).To(BeADirectory())
+			Expect(lostFoundDir).To(BeADirectory())
+		})
+	})
+})

--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -64,6 +64,14 @@ spec:
                 description: Is the profile in the data stream to be used. This is
                   the collection of rules that will be checked for.
                 type: string
+              rawResultStorageRotation:
+                default: 3
+                description: Specifies the amount of scans for which the raw results
+                  will be stored. Older results will get rotated, and it's the responsibility
+                  of administrators to store these results elsewhere before rotation
+                  happens. Note that a rotation policy of '0' disables rotation entirely.
+                  Defaults to 3.
+                type: integer
               rawResultStorageSize:
                 default: 1Gi
                 description: Specifies the amount of storage to ask for storing the

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -79,6 +79,14 @@ spec:
                       description: Is the profile in the data stream to be used. This
                         is the collection of rules that will be checked for.
                       type: string
+                    rawResultStorageRotation:
+                      default: 3
+                      description: Specifies the amount of scans for which the raw
+                        results will be stored. Older results will get rotated, and
+                        it's the responsibility of administrators to store these results
+                        elsewhere before rotation happens. Note that a rotation policy
+                        of '0' disables rotation entirely. Defaults to 3.
+                      type: integer
                     rawResultStorageSize:
                       default: 1Gi
                       description: Specifies the amount of storage to ask for storing

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -140,6 +140,12 @@ type ComplianceScanSpec struct {
 	// +kubebuilder:validation:Default=1Gi
 	// +kubebuilder:default="1Gi"
 	RawResultStorageSize string `json:"rawResultStorageSize,omitempty"`
+	// Specifies the amount of scans for which the raw results will be stored.
+	// Older results will get rotated, and it's the responsibility of administrators
+	// to store these results elsewhere before rotation happens. Note that a rotation
+	// policy of '0' disables rotation entirely. Defaults to 3.
+	// +kubebuilder:default=3
+	RawResultStorageRotation uint16 `json:"rawResultStorageRotation,omitempty"`
 }
 
 // ComplianceScanStatus defines the observed state of ComplianceScan

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -105,6 +105,7 @@ func resultServer(scanInstance *compv1alpha1.ComplianceScan, labels map[string]s
 								"--address=0.0.0.0",
 								fmt.Sprintf("--port=%d", ResultServerPort),
 								fmt.Sprintf("--scan-index=%d", scanInstance.Status.CurrentIndex),
+								fmt.Sprintf("--rotation=%d", scanInstance.Spec.RawResultStorageRotation),
 								"--tls-server-cert=/etc/pki/tls/tls.crt",
 								"--tls-server-key=/etc/pki/tls/tls.key",
 								"--tls-ca=/etc/pki/tls/ca.crt",


### PR DESCRIPTION
This adds a flag called `rawResultStorageRotation` which, allows users to
configure the rotation for the result directories in the PVC.

It defaults to '3' and will skip the `lost+found` directory if it's
present.

It works by checking the creation date for the directories and making
the rotation decision based on that. This way we don't have to think
about the indexing names and rotation of indexes.

A rotation policy of 0 disables the rotation entirely.