### PR TITLE
Enable setting tolerations for scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ In the `spec`:
   responsibility of administrators to store these results elsewhere before
   rotation happens. Note that a rotation policy of '0' disables rotation
   entirely. Defaults to 3.
+* **scanTolerations**: Specifies tolerations that will be set in the scan Pods
+  for scheduling. Defaults to allowing the scan to run on master nodes. For
+  details on tolerations, see the
+  [Kubernetes documentation on this](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
 
 Regarding the `status`:
 

--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -83,6 +83,53 @@ spec:
                   for a specific rule. Note that when leaving this empty, the scan
                   will check for all the rules for a specific profile.
                 type: string
+              scanTolerations:
+                default:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/master
+                  operator: Exists
+                description: Specifies tolerations needed for the scan to run on the
+                  nodes. This is useful in case the target set of nodes have custom
+                  taints that don't allow certain workloads to run. Defaults to allowing
+                  scheduling on the master nodes.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
               scanType:
                 description: The type of Compliance scan.
                 type: string

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -98,6 +98,55 @@ spec:
                         only for a specific rule. Note that when leaving this empty,
                         the scan will check for all the rules for a specific profile.
                       type: string
+                    scanTolerations:
+                      default:
+                      - effect: NoSchedule
+                        key: node-role.kubernetes.io/master
+                        operator: Exists
+                      description: Specifies tolerations needed for the scan to run
+                        on the nodes. This is useful in case the target set of nodes
+                        have custom taints that don't allow certain workloads to run.
+                        Defaults to allowing scheduling on the master nodes.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
                     scanType:
                       description: The type of Compliance scan.
                       type: string

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -149,6 +150,11 @@ type ComplianceScanSpec struct {
 	// policy of '0' disables rotation entirely. Defaults to 3.
 	// +kubebuilder:default=3
 	RawResultStorageRotation uint16 `json:"rawResultStorageRotation,omitempty"`
+	// Specifies tolerations needed for the scan to run on the nodes. This is useful
+	// in case the target set of nodes have custom taints that don't allow certain
+	// workloads to run. Defaults to allowing scheduling on the master nodes.
+	// +kubebuilder:default={{key: "node-role.kubernetes.io/master", operator: "Exists", effect: "NoSchedule"}}
+	ScanTolerations []corev1.Toleration `json:"scanTolerations,omitempty"`
 }
 
 // ComplianceScanStatus defines the observed state of ComplianceScan

--- a/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -260,6 +261,13 @@ func (in *ComplianceScanSpec) DeepCopyInto(out *ComplianceScanSpec) {
 		in, out := &in.TailoringConfigMap, &out.TailoringConfigMap
 		*out = new(TailoringConfigMapRef)
 		**out = **in
+	}
+	if in.ScanTolerations != nil {
+		in, out := &in.ScanTolerations, &out.ScanTolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	return
 }

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -196,13 +196,7 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 					},
 				},
 			},
-			Tolerations: []corev1.Toleration{
-				{
-					Key:      "node-role.kubernetes.io/master",
-					Operator: "Exists",
-					Effect:   "NoSchedule",
-				},
-			},
+			Tolerations: scanInstance.Spec.ScanTolerations,
 			NodeSelector: map[string]string{
 				corev1.LabelHostname: node.Labels[corev1.LabelHostname],
 			},
@@ -383,13 +377,7 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 			NodeSelector: map[string]string{
 				"node-role.kubernetes.io/master": "",
 			},
-			Tolerations: []corev1.Toleration{
-				{
-					Key:      "node-role.kubernetes.io/master",
-					Operator: "Exists",
-					Effect:   "NoSchedule",
-				},
-			},
+			Tolerations:   scanInstance.Spec.ScanTolerations,
 			RestartPolicy: corev1.RestartPolicyOnFailure,
 			Volumes: []corev1.Volume{
 				{

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -3,9 +3,10 @@ package e2e
 import (
 	goctx "context"
 	"fmt"
-	appsv1 "k8s.io/api/apps/v1"
 	"math/rand"
 	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
@@ -1091,6 +1092,71 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
+			Name:       "TestTolerations",
+			IsParallel: false,
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
+				workerNodes := getNodesWithSelector(f, map[string]string{
+					"node-role.kubernetes.io/worker": "",
+				})
+
+				taintedNode := &workerNodes[0]
+				taintKey := "co-e2e"
+				taintVal := "val"
+				taint := corev1.Taint{
+					Key:    taintKey,
+					Value:  taintVal,
+					Effect: corev1.TaintEffectNoSchedule,
+				}
+				if err := taintNode(t, f, taintedNode, taint); err != nil {
+					E2ELog(t, "Tainting node failed")
+					return err
+				}
+				suiteName := getObjNameFromTest(t)
+				scanName := suiteName
+				suite := &compv1alpha1.ComplianceSuite{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      suiteName,
+						Namespace: namespace,
+					},
+					Spec: compv1alpha1.ComplianceSuiteSpec{
+						Scans: []compv1alpha1.ComplianceScanSpecWrapper{
+							{
+								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
+									ContentImage: contentImagePath,
+									Profile:      "xccdf_org.ssgproject.content_profile_moderate",
+									Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
+									Content:      rhcosContentFile,
+									NodeSelector: map[string]string{
+										// Schedule scan in this specific host
+										corev1.LabelHostname: taintedNode.Labels[corev1.LabelHostname],
+									},
+									Debug: true,
+									ScanTolerations: []corev1.Toleration{
+										{
+											Key:      taintKey,
+											Operator: corev1.TolerationOpExists,
+											Effect:   corev1.TaintEffectNoSchedule,
+										},
+									},
+								},
+								Name: scanName,
+							},
+						},
+					},
+				}
+				if err := f.Client.Create(goctx.TODO(), suite, getCleanupOpts(ctx)); err != nil {
+					return err
+				}
+
+				err := waitForSuiteScansStatus(t, f, namespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultCompliant)
+				if err != nil {
+					return err
+				}
+
+				return removeNodeTaint(t, f, taintedNode.Name, taintKey)
+			},
+		},
+		testExecution{
 			Name:       "TestAutoRemediate",
 			IsParallel: false,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
@@ -1656,7 +1722,6 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
-
 
 				err = scanResultIsExpected(f, namespace, platformScanName, compv1alpha1.ResultNonCompliant)
 				if err != nil {

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"k8s.io/client-go/kubernetes"
 	"os"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/client-go/kubernetes"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
@@ -1438,16 +1439,16 @@ func privCommandTuplePodOnHost(namespace, name, nodeName, commandPre string, com
 			Namespace: namespace,
 		},
 		Spec: corev1.PodSpec{
-			InitContainers:[]corev1.Container{
+			InitContainers: []corev1.Container{
 				{
-					Name:            name + "-init",
-					Image:           "busybox",
-					Command:         []string{"/bin/sh"},
-					Args:            []string{"-c", commandPre},
-					VolumeMounts:    []corev1.VolumeMount{
+					Name:    name + "-init",
+					Image:   "busybox",
+					Command: []string{"/bin/sh"},
+					Args:    []string{"-c", commandPre},
+					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name: "hostroot",
-							MountPath:"/hostroot",
+							Name:      "hostroot",
+							MountPath: "/hostroot",
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
@@ -1458,28 +1459,28 @@ func privCommandTuplePodOnHost(namespace, name, nodeName, commandPre string, com
 			},
 			Containers: []corev1.Container{
 				{
-					Name:            name,
-					Image:           "busybox",
-					Command:         []string{"/bin/sh"},
-					Args:            []string{"-c", "sleep 3600"},
-					VolumeMounts:    []corev1.VolumeMount{
+					Name:    name,
+					Image:   "busybox",
+					Command: []string{"/bin/sh"},
+					Args:    []string{"-c", "sleep 3600"},
+					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name: "hostroot",
-							MountPath:"/hostroot",
+							Name:      "hostroot",
+							MountPath: "/hostroot",
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: &priv,
 						RunAsUser:  &runAs,
 					},
-					Lifecycle : &corev1.Lifecycle{
-						PreStop:   &corev1.Handler{
-							Exec:      &corev1.ExecAction{Command:commandPost},
+					Lifecycle: &corev1.Lifecycle{
+						PreStop: &corev1.Handler{
+							Exec: &corev1.ExecAction{Command: commandPost},
 						},
 					},
 				},
 			},
-			Volumes:            []corev1.Volume{
+			Volumes: []corev1.Volume{
 				{
 					Name: "hostroot",
 					VolumeSource: corev1.VolumeSource{
@@ -1489,7 +1490,7 @@ func privCommandTuplePodOnHost(namespace, name, nodeName, commandPre string, com
 					},
 				},
 			},
-			RestartPolicy:      "Never",
+			RestartPolicy: "Never",
 			NodeSelector: map[string]string{
 				corev1.LabelHostname: nodeName,
 			},
@@ -1564,4 +1565,33 @@ func runPod(t *testing.T, f *framework.Framework, namespace string, podToRun *co
 // object for the caller to delete at which point the pod, before exiting, removes the file
 func createAndRemoveEtcSecurettyOnNode(t *testing.T, f *framework.Framework, namespace, name, nodeName string) (*corev1.Pod, error) {
 	return runPod(t, f, namespace, createAndRemoveEtcSecurettyPod(namespace, name, nodeName))
+}
+
+func taintNode(t *testing.T, f *framework.Framework, node *corev1.Node, taint corev1.Taint) error {
+	taintedNode := node.DeepCopy()
+	if taintedNode.Spec.Taints == nil {
+		taintedNode.Spec.Taints = []corev1.Taint{}
+	}
+	taintedNode.Spec.Taints = append(taintedNode.Spec.Taints, taint)
+	E2ELogf(t, "Tainting node: %s", taintedNode.Name)
+	return f.Client.Update(goctx.TODO(), taintedNode)
+}
+
+func removeNodeTaint(t *testing.T, f *framework.Framework, nodeName, taintKey string) error {
+	taintedNode := &corev1.Node{}
+	nodeKey := types.NamespacedName{Name: nodeName}
+	if err := f.Client.Get(goctx.TODO(), nodeKey, taintedNode); err != nil {
+		E2ELogf(t, "Couldn't get node: %s", nodeName)
+		return err
+	}
+	untaintedNode := taintedNode.DeepCopy()
+	untaintedNode.Spec.Taints = []corev1.Taint{}
+	for _, taint := range taintedNode.Spec.Taints {
+		if taint.Key != taintKey {
+			untaintedNode.Spec.Taints = append(untaintedNode.Spec.Taints, taint)
+		}
+	}
+
+	E2ELogf(t, "Removing taint from node: %s", nodeName)
+	return f.Client.Update(goctx.TODO(), untaintedNode)
 }


### PR DESCRIPTION
This adds a `scanTolerations` field to the complianceScan. This, as
expected, sets tolerationsf or the scan workloads. Thus enabling users
to set this up for nodes with custom taints.

Closes: https://github.com/openshift/compliance-operator/issues/293