### PR TITLE
tear-down: tear-down CRDs before operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ deploy-crds:
 	done
 
 .PHONY: tear-down
-tear-down: tear-down-operator tear-down-crds ## Tears down all objects required for the operator except the namespace
+tear-down: tear-down-crds tear-down-operator ## Tears down all objects required for the operator except the namespace
 
 
 .PHONY: tear-down-crds


### PR DESCRIPTION
This way the operator gets some time to clean up resources before it's
deleted.