### PR TITLE
Remove err argument that will always be nil

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1394,7 +1394,7 @@ func assertResultStorageHasExpectedItemsAfterRotation(t *testing.T, f *framework
 			E2ELogf(t, "Pod failed!")
 			return true, fmt.Errorf("status checker pod failed unexpectedly: %s", pod.Status.Message)
 		}
-		E2ELogf(t, "Pod not done. retrying: %s", err)
+		E2ELogf(t, "Pod not done. retrying.")
 		return false, nil
 	})
 	if timeouterr != nil {


### PR DESCRIPTION
err is checked a couple of lines above, so it doesn't make sense to
print it. If we do, we receive likes like:
    helpers.go:63: 2020-06-29T16:57:21Z: Pod not done. retrying: %!s(<nil>)
    helpers.go:63: 2020-06-29T16:57:26Z: Pod not done. retrying: %!s(<nil>)
    helpers.go:63: 2020-06-29T16:57:31Z: Pod not done. retrying: %!s(<nil>)