### PR TITLE
Parse out profile name and type

### DIFF
--- a/pkg/apis/compliance/v1alpha1/profile_types.go
+++ b/pkg/apis/compliance/v1alpha1/profile_types.go
@@ -4,6 +4,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ProductTypeAnnotation specifies what kind of platform (node,platform)
+// this Profile or a TailoredProfile targets
+const ProductTypeAnnotation = "compliance.openshift.io/product-type"
+
+// ProductAnnotation specifies the name of the platform this Profile
+// or TailoredProfile is targetting. Example: ocp4, rhcos4, ...
+const ProductAnnotation = "compliance.openshift.io/product"
+
 // ProfileRule defines the name of a specific rule in the profile
 type ProfileRule string
 

--- a/pkg/profileparser/profileparser_test.go
+++ b/pkg/profileparser/profileparser_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Testing parse profiles", func() {
 				profHaveId(e8Id),
 				profHaveId(moderateId),
 				profHaveId(ncpId),
-				))
+			))
 		})
 	})
 
@@ -132,9 +132,14 @@ var _ = Describe("Testing parse profiles", func() {
 				cmpv1alpha1.NewProfileRule("test-profile-audit-rules-time-stime"),
 				cmpv1alpha1.NewProfileRule("test-profile-sysctl-net-core-bpf-jit-harden"),
 				cmpv1alpha1.NewProfileRule("test-profile-wireless-disable-in-bios"),
-				))
+			))
 		})
 
+		It("Has the platform annotations", func() {
+			Expect(moderateProfile.Annotations).ToNot(BeNil())
+			Expect(moderateProfile.Annotations).To(HaveKeyWithValue(cmpv1alpha1.ProductTypeAnnotation, string(cmpv1alpha1.ScanTypePlatform)))
+			Expect(moderateProfile.Annotations).To(HaveKeyWithValue(cmpv1alpha1.ProductAnnotation, "redhat_openshift_container_platform_4.1"))
+		})
 	})
 })
 

--- a/pkg/profileparser/profileparser_test.go
+++ b/pkg/profileparser/profileparser_test.go
@@ -15,6 +15,20 @@ func varHaveID(id string) gomegatypes.GomegaMatcher {
 	return WithTransform(func(p cmpv1alpha1.Variable) string { return p.ID }, Equal(id))
 }
 
+func profHaveId(id string) gomegatypes.GomegaMatcher {
+	return WithTransform(func(p cmpv1alpha1.Profile) string { return p.ID }, Equal(id))
+}
+
+func getProfileById(id string, profList []cmpv1alpha1.Profile) *cmpv1alpha1.Profile {
+	for _, profile := range profList {
+		if id == profile.ID {
+			return &profile
+		}
+	}
+
+	return nil
+}
+
 func getVariableById(id string, varList []cmpv1alpha1.Variable) *cmpv1alpha1.Variable {
 	for _, variable := range varList {
 		if id == variable.ID {
@@ -25,8 +39,8 @@ func getVariableById(id string, varList []cmpv1alpha1.Variable) *cmpv1alpha1.Var
 	return nil
 }
 
-func getRuleById(id string, varList []cmpv1alpha1.Rule) *cmpv1alpha1.Rule {
-	for _, rule := range varList {
+func getRuleById(id string, ruleList []cmpv1alpha1.Rule) *cmpv1alpha1.Rule {
+	for _, rule := range ruleList {
 		if id == rule.ID {
 			return &rule
 		}
@@ -53,6 +67,76 @@ func init() {
 
 	contentDom, _ = xmldom.ParseFile(pcfg.DataStreamPath)
 }
+
+var _ = Describe("Testing parse profiles", func() {
+	var (
+		profileList []cmpv1alpha1.Profile
+	)
+
+	BeforeEach(func() {
+		// make sure init() did its job
+		Expect(contentDom).NotTo(BeNil())
+
+		profileList = make([]cmpv1alpha1.Profile, 0)
+		profileAdder := func(r *cmpv1alpha1.Profile) error {
+			profileList = append(profileList, *r)
+			return nil
+		}
+
+		err := ParseProfilesAndDo(contentDom, pcfg, profileAdder)
+		Expect(err).To(BeNil())
+	})
+
+	Context("All profiles are parsed", func() {
+		const moderateId = "xccdf_org.ssgproject.content_profile_moderate"
+		const platModerateId = "xccdf_org.ssgproject.content_profile_platform-moderate"
+		const ncpId = "xccdf_org.ssgproject.content_profile_coreos-ncp"
+		const e8Id = "xccdf_org.ssgproject.content_profile_e8"
+		const ocisNode = "xccdf_org.ssgproject.content_profile_opencis-node"
+		const ocisMaster = "xccdf_org.ssgproject.content_profile_opencis-master"
+
+		It("Contains the expected variable", func() {
+			Expect(profileList).Should(ConsistOf(
+				profHaveId(platModerateId),
+				profHaveId(ocisMaster),
+				profHaveId(ocisNode),
+				profHaveId(e8Id),
+				profHaveId(moderateId),
+				profHaveId(ncpId),
+				))
+		})
+	})
+
+	Context("A profile has the expected metadata", func() {
+		var moderateProfile *cmpv1alpha1.Profile
+
+		BeforeEach(func() {
+			const expectedID = "xccdf_org.ssgproject.content_profile_moderate"
+
+			moderateProfile = getProfileById(expectedID, profileList)
+			Expect(moderateProfile).ToNot(BeNil())
+		})
+
+		It("Has the expected name", func() {
+			const expectedName = "moderate"
+			Expect(moderateProfile.Name).To(BeEquivalentTo(expectedName))
+		})
+
+		It("Has the expected title", func() {
+			const expectedTitle = "NIST 800-53 Moderate-Impact Baseline for Red Hat Enterprise Linux CoreOS"
+			Expect(moderateProfile.Title).To(BeEquivalentTo(expectedTitle))
+		})
+
+		It("Has some expected rules", func() {
+			Expect(moderateProfile.Rules).To(ContainElements(
+				cmpv1alpha1.NewProfileRule("test-profile-audit-rules-time-stime"),
+				cmpv1alpha1.NewProfileRule("test-profile-sysctl-net-core-bpf-jit-harden"),
+				cmpv1alpha1.NewProfileRule("test-profile-wireless-disable-in-bios"),
+				))
+		})
+
+	})
+})
 
 var _ = Describe("Testing parse variables", func() {
 	var (
@@ -138,12 +222,12 @@ var _ = Describe("Testing parse rules", func() {
 		Expect(contentDom).NotTo(BeNil())
 
 		ruleList = make([]cmpv1alpha1.Rule, 0)
-		variableAdder := func(r *cmpv1alpha1.Rule) error {
+		ruleAdder := func(r *cmpv1alpha1.Rule) error {
 			ruleList = append(ruleList, *r)
 			return nil
 		}
 
-		err := ParseRulesAndDo(contentDom, pcfg, variableAdder)
+		err := ParseRulesAndDo(contentDom, pcfg, ruleAdder)
 		Expect(err).To(BeNil())
 	})
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -43,7 +43,7 @@ func TestE2E(t *testing.T) {
 				if err := waitForProfileBundleStatus(t, f, namespace, pbName, compv1alpha1.DataStreamValid); err != nil {
 					return err
 				}
-				if err := assertMustHaveParsedProfiles(t, f, namespace, pbName); err != nil {
+				if err := assertMustHaveParsedProfiles(f, pbName,  string(compv1alpha1.ScanTypeNode), "redhat_enterprise_linux_coreos_4"); err != nil {
 					return err
 				}
 

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1223,7 +1223,7 @@ func getPoolNodeRoleSelector() map[string]string {
 	return utils.GetNodeRoleSelector(testPoolName)
 }
 
-func assertMustHaveParsedProfiles(t *testing.T, f *framework.Framework, namespace, name string) error {
+func assertMustHaveParsedProfiles(f *framework.Framework, name string, productType, productName string) error {
 	var pl compv1alpha1.ProfileList
 	lo := &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{
@@ -1236,6 +1236,17 @@ func assertMustHaveParsedProfiles(t *testing.T, f *framework.Framework, namespac
 	if len(pl.Items) <= 0 {
 		return fmt.Errorf("Profiles weren't parsed from the ProfileBundle. Expected more than one, got %d", len(pl.Items))
 	}
+
+	for _, prof := range pl.Items {
+		if prof.Annotations[compv1alpha1.ProductTypeAnnotation] != productType {
+			return fmt.Errorf("expected %s to be %s, got %s instead", compv1alpha1.ProductTypeAnnotation, productType, prof.Annotations[compv1alpha1.ProductTypeAnnotation])
+		}
+
+		if prof.Annotations[compv1alpha1.ProductAnnotation] != productName {
+			return fmt.Errorf("expected %s to be %s, got %s instead", compv1alpha1.ProductAnnotation, productName, prof.Annotations[compv1alpha1.ProductAnnotation])
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Parses the CPE string into components and parses out the product type, 
either node or platform and the product name. For the product type, the
"part" piece of the CPE URI which can either be "a" for "application" or
"o" for operating system.