### PR TITLE
aggregator: Don't fail if remediations can't be created

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -198,6 +198,16 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get


### PR DESCRIPTION
We used to fail the aggregator if a remediation couldn't be created. This would normally be because we can't figure out what role to apply the remediation to (which should match a MachineConfigPool).

Let's not do that, and instead skip that remediation and continue. We should just log a warning and issue an event.