### PR TITLE
Parse out profile name and type

### DIFF
--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -190,7 +190,7 @@ func parseProductTypeAndName(idref string, defaultType cmpv1alpha1.ComplianceSca
 	// Now we know it begins with cpePrefix
 	idref = strings.TrimPrefix(idref, cpePrefix)
 	cpePieces := strings.Split(idref, ":")
-	if len(cpePieces) == 0 {
+	if len(cpePieces) == 0 || (len(cpePieces) == 1 && cpePieces[0] == idref) {
 		log.Info("The CPE ID is too short")
 		return defaultType, defaultName
 	}
@@ -205,7 +205,10 @@ func parseProductTypeAndName(idref string, defaultType cmpv1alpha1.ComplianceSca
 		productType = cmpv1alpha1.ScanTypePlatform
 	}
 
-	productName := strings.Join(cpePieces[1:], "_")
+	var productName string
+	if len(cpePieces) > 2 {
+		productName = strings.Join(cpePieces[1:], "_")
+	}
 	return productType, productName
 }
 

--- a/pkg/profileparser/profileparser_test.go
+++ b/pkg/profileparser/profileparser_test.go
@@ -260,3 +260,25 @@ var _ = Describe("Testing parse rules", func() {
 		})
 	})
 })
+
+var _ = Describe("Testing CPE string parsing in isolation", func() {
+	Context("Malformed CPE string", func() {
+		It("Returns the defaults if the CPE uri does not start with cpe://", func() {
+			pType, pName := parseProductTypeAndName("xxx:/a:redhat:enterprise_linux_coreos:4", cmpv1alpha1.ScanTypeNode, "default")
+			Expect(pType).To(BeEquivalentTo(cmpv1alpha1.ScanTypeNode))
+			Expect(pName).To(BeEquivalentTo("default"))
+		})
+
+		It("Returns the defaults if the CPE uri is too short", func() {
+			pType, pName := parseProductTypeAndName("cpe:/", cmpv1alpha1.ScanTypeNode, "default")
+			Expect(pType).To(BeEquivalentTo(cmpv1alpha1.ScanTypeNode))
+			Expect(pName).To(BeEquivalentTo("default"))
+		})
+
+		It("Does not crash with with a CPE string without platform information", func() {
+			pType, pName := parseProductTypeAndName("cpe:/a:", cmpv1alpha1.ScanTypeNode, "unusedDefault")
+			Expect(pType).To(BeEquivalentTo(cmpv1alpha1.ScanTypePlatform))
+			Expect(pName).To(BeEquivalentTo(""))
+		})
+	})
+})


### PR DESCRIPTION
Parses the CPE string into components and parses out the product type, 
either node or platform and the product name. For the product type, the
"part" piece of the CPE URI which can either be "a" for "application" or
"o" for operating system.