### PR TITLE
Create some ProfileBundles by default

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -36,6 +36,8 @@ spec:
               value: "quay.io/compliance-operator/openscap-ocp:1.3.3"
             - name: OPERATOR_IMAGE
               value: "quay.io/compliance-operator/compliance-operator:latest"
+            - name: DEFAULT_PROFILE_BUNDLES_IMAGE
+              value: "quay.io/complianceascode/ocp4:latest"
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/pkg/utils/images.go
+++ b/pkg/utils/images.go
@@ -7,6 +7,7 @@ type ComplianceComponent uint
 const (
 	OPENSCAP = iota
 	OPERATOR
+	DEFAULT_PROFILE_BUNDLES
 )
 
 var componentDefaults = []struct {
@@ -15,6 +16,7 @@ var componentDefaults = []struct {
 }{
 	{"quay.io/jhrozek/openscap-ocp:latest", "OPENSCAP_IMAGE"},
 	{"quay.io/compliance-operator/compliance-operator:latest", "OPERATOR_IMAGE"},
+	{"quay.io/complianceascode/ocp4:latest", "DEFAULT_PROFILE_BUNDLES_IMAGE"},
 }
 
 // GetComponentImage returns a full image pull spec for a given component


### PR DESCRIPTION
This makes sure some default profile bundles are created by default when
the operator starts. This ensures that out of the box we already have
some profiles ready to be used.

Only bundles for the ocp4 and rhcos4 products are being created at the
moment.