### PR TITLE
Handle ProfileBundle content image updates

### DIFF
--- a/cmd/manager/profileparser.go
+++ b/cmd/manager/profileparser.go
@@ -126,7 +126,7 @@ func updateProfileBundleStatus(pcfg *profileparser.ParserConfig, pb *cmpv1alpha1
 }
 
 func runProfileParser(cmd *cobra.Command, args []string) {
-	exitSignal := make(chan os.Signal)
+	exitSignal := make(chan os.Signal, 1)
 	signal.Notify(exitSignal, syscall.SIGINT, syscall.SIGTERM)
 	pcfg := newParserConfig(cmd)
 

--- a/cmd/manager/profileparser.go
+++ b/cmd/manager/profileparser.go
@@ -6,6 +6,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -124,6 +126,8 @@ func updateProfileBundleStatus(pcfg *profileparser.ParserConfig, pb *cmpv1alpha1
 }
 
 func runProfileParser(cmd *cobra.Command, args []string) {
+	exitSignal := make(chan os.Signal)
+	signal.Notify(exitSignal, syscall.SIGINT, syscall.SIGTERM)
 	pcfg := newParserConfig(cmd)
 
 	pb, err := getProfileBundle(pcfg)
@@ -250,4 +254,6 @@ func runProfileParser(cmd *cobra.Command, args []string) {
 	// The err variable might be nil, this is fine, it'll just update the status
 	// to valid
 	updateProfileBundleStatus(pcfg, pb, err)
+
+	<-exitSignal
 }

--- a/deploy/crds/compliance.openshift.io_profilebundles_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_profilebundles_crd.yaml
@@ -54,6 +54,7 @@ spec:
             description: Defines the observed state of ProfileBundle
             properties:
               dataStreamStatus:
+                default: PENDING
                 description: Presents the current status for the datastream for this
                   bundle
                 type: string

--- a/pkg/apis/compliance/v1alpha1/profilebundle_types.go
+++ b/pkg/apis/compliance/v1alpha1/profilebundle_types.go
@@ -36,6 +36,7 @@ type ProfileBundleSpec struct {
 // Defines the observed state of ProfileBundle
 type ProfileBundleStatus struct {
 	// Presents the current status for the datastream for this bundle
+	// +kubebuilder:default=PENDING
 	DataStreamStatus DataStreamStatusType `json:"dataStreamStatus,omitempty"`
 	// If there's an error in the datastream, it'll be presented here
 	ErrorMessage string `json:"errorMessage,omitempty"`

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -54,16 +53,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Watch for changes to primary resource ProfileBundle
 	err = c.Watch(&source.Kind{Type: &compliancev1alpha1.ProfileBundle{}}, &handler.EnqueueRequestForObject{})
-	if err != nil {
-		return err
-	}
-
-	// TODO(user): Modify this to be the types you create that are owned by the primary resource
-	// Watch for changes to secondary resource Pods and requeue the owner ProfileBundle
-	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &compliancev1alpha1.ProfileBundle{},
-	})
 	if err != nil {
 		return err
 	}
@@ -124,11 +113,6 @@ func (r *ReconcileProfileBundle) Reconcile(request reconcile.Request) (reconcile
 
 	// Define a new Pod object
 	depl := newWorkloadForBundle(instance)
-
-	// Set ProfileBundle instance as the owner and controller
-	if err := controllerutil.SetControllerReference(instance, depl, r.scheme); err != nil {
-		return reconcile.Result{}, err
-	}
 
 	// Check if this Pod already exists
 	found := &appsv1.Deployment{}


### PR DESCRIPTION
This changes the profile bundle controller to detect if a new image has
been set, if so, it'll attempt to update a Deployment which actually
creates the profileparser.

This way we could address updates in the long run, by asking folks to
point to a specific hash and subsequent updates would merely update the
image's digest for the bundles.