### PR TITLE
resultserver: Enable graceful termination

### DIFF
--- a/cmd/manager/resultserver.go
+++ b/cmd/manager/resultserver.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
@@ -23,6 +24,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/signal"
 	"path"
 	"path/filepath"
 	"sort"
@@ -173,6 +175,9 @@ func rotateResultDirectories(rootPath string, rotation uint16) error {
 }
 
 func server(c *resultServerConfig) {
+	exit := make(chan os.Signal, 1)
+	signal.Notify(exit, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
 	err := ensureDir(c.Path)
 	if err != nil {
 		log.Error(err, "Error ensuring result path: %s", c.Path)
@@ -235,6 +240,27 @@ func server(c *resultServerConfig) {
 		}
 		log.Info("Received file", "file-path", filePath)
 	})
+
 	log.Info("Listening...")
-	log.Error(server.ListenAndServeTLS(c.Cert, c.Key), "Error in server")
+
+	go func() {
+		err := server.ListenAndServeTLS(c.Cert, c.Key)
+		if err != nil && err != http.ErrServerClosed {
+			log.Error(err, "Error in result server")
+		}
+	}()
+
+	<-exit
+	log.Info("Server stopped.")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer func() {
+		cancel()
+	}()
+
+	if err := server.Shutdown(ctx); err != nil {
+		log.Error(err, "Server shutdown failed")
+	}
+
+	log.Info("Server exited gracefully")
 }


### PR DESCRIPTION
Now that the resultserver is scaled-down (terminated) after each scan,
graceful termination is needed so the kubelet can get rid of it faster.
This enables this by adding a signal handler and reacting on it.
Subsequently, graceful termination is attempted on the http server.