### PR TITLE
Release Makefile target fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ endif
 csv: deploy/olm-catalog/compliance-operator/$(COURIER_PACKAGE_VERSION) check-package-version operator-sdk ## Generate the CSV and packaging for the specific version (NOTE: Gotta specify the version with the COURIER_PACKAGE_VERSION environment variable)
 
 deploy/olm-catalog/compliance-operator/$(COURIER_PACKAGE_VERSION):
-	$(GOPATH)/bin/operator-sdk generate csv --csv-channel $(PACKAGE_CHANNEL) --csv-version "$(COURIER_PACKAGE_VERSION)" --from-version "$(OLD_COURIER_PACKAGE_VERSION)" --update-crds
+	$(GOPATH)/bin/operator-sdk generate csv --make-manifests=false --csv-channel $(PACKAGE_CHANNEL) --csv-version "$(COURIER_PACKAGE_VERSION)" --from-version "$(OLD_COURIER_PACKAGE_VERSION)" --update-crds
 
 .PHONY: publish-bundle
 publish-bundle: check-package-version

--- a/Makefile
+++ b/Makefile
@@ -333,6 +333,9 @@ deploy/olm-catalog/compliance-operator/$(COURIER_PACKAGE_VERSION):
 
 .PHONY: publish-bundle
 publish-bundle: check-package-version
+	# If the validation fails, make sure you are running operator-courier
+	# 2.1.8, but also make sure the patches from https://github.com/operator-framework/operator-courier/pull/189
+	# are included. On Fedora, feel free to use https://copr.fedorainfracloud.org/coprs/jhrozek/python-operator-courier/
 	$(COURIER_CMD) push "$(COURIER_OPERATOR_DIR)" "$(COURIER_QUAY_NAMESPACE)" "$(COURIER_PACKAGE_NAME)" "$(COURIER_PACKAGE_VERSION)" "basic $(COURIER_QUAY_TOKEN)"
 
 .PHONY: package-version-to-tag

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,6 @@ COURIER_PACKAGE_NAME=compliance-operator-bundle
 COURIER_OPERATOR_DIR=deploy/olm-catalog/compliance-operator
 COURIER_QUAY_NAMESPACE=compliance-operator
 COURIER_PACKAGE_VERSION?=
-OLD_COURIER_PACKAGE_VERSION=$(shell find deploy/olm-catalog/compliance-operator/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -r | head -1)
 COURIER_QUAY_TOKEN?= $(shell cat ~/.quay)
 PACKAGE_CHANNEL?=alpha
 
@@ -329,6 +328,7 @@ endif
 csv: deploy/olm-catalog/compliance-operator/$(COURIER_PACKAGE_VERSION) check-package-version operator-sdk ## Generate the CSV and packaging for the specific version (NOTE: Gotta specify the version with the COURIER_PACKAGE_VERSION environment variable)
 
 deploy/olm-catalog/compliance-operator/$(COURIER_PACKAGE_VERSION):
+	$(eval OLD_COURIER_PACKAGE_VERSION = $(shell python3 find_previous_version.py ./deploy/olm-catalog/compliance-operator))
 	$(GOPATH)/bin/operator-sdk generate csv --make-manifests=false --csv-channel $(PACKAGE_CHANNEL) --csv-version "$(COURIER_PACKAGE_VERSION)" --from-version "$(OLD_COURIER_PACKAGE_VERSION)" --update-crds
 
 .PHONY: publish-bundle

--- a/find_previous_version.py
+++ b/find_previous_version.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import sys
+import os
+
+NULL_VERSION = [0,0,0]
+
+MAJOR = 0
+MINOR = 1
+PATCH = 2
+
+def find_latest_version_dir(root):
+    dirs = []
+    with os.scandir(root) as it:
+        for entry in it:
+            if not entry.is_dir():
+                continue
+            dirs.append(entry.name)
+    return find_latest_version(dirs)
+
+def find_latest_version(vlist):
+    if len(vlist) < 1:
+        return ""
+    latest = ""
+    for ver in vlist:
+        if is_higher(latest, ver):
+            latest = ver
+
+    return latest
+
+def is_higher(latest, candidate):
+    latest_tuple = parse_semver(latest)
+    candidate_tuple = parse_semver(candidate)
+
+    if candidate_tuple[MAJOR] > latest_tuple[MAJOR]:
+        return True
+    if candidate_tuple[MINOR] > latest_tuple[MINOR]:
+        return True
+    if candidate_tuple[PATCH] > latest_tuple[PATCH]:
+        return True
+
+    return False
+
+def parse_semver(vstr):
+    # The operator uses a very basic subset of semver, just major.minor.patch
+    semtup = vstr.split('.')
+
+    if len(semtup) != 3:
+        return NULL_VERSION
+
+    semints = []
+    for item in semtup:
+        if item.isdigit() == False:
+            return NULL_VERSION
+        semints.append(int(item))
+
+    return semints
+
+if __name__ == "__main__":
+    if len(sys.argv) <= 1:
+        # Since the script is called from Makefile, just return nothing and let
+        # make fail
+        sys.exit(0)
+
+    latest = find_latest_version_dir(sys.argv[1])
+    print(latest)
+    sys.exit(0)


### PR DESCRIPTION
Please see the commit messages for detailed explanation, but the tl;dr is:
    - we keep using the package manifest format for now as there's no tool
      to convert the package manifests to bundle (or at least I couldn't
      find any and the operator-sdk docs say so as well)
    - to work around issues where courier couldn't validate either the CSV
      (courier-2.1.7) or the CRDs (courier-2.1.8) I built a patched courier
      package at https://copr.fedorainfracloud.org/coprs/jhrozek/python-operator-courier/
      and opened a PR to include those changes to Fedora at
      https://src.fedoraproject.org/rpms/python-operator-courier/pull-request/1
      The Makefile is "patched" with a comment informing about the courier
      issues
    - the detection of the previous version is done by a Python script instead
      of the find|sort|head pipeline

All these together fix the release process for now and give us time to migrate
to the bundle format properly.