### PR TITLE
Always use the default RawStorageSize if scan.Spec.RawResultStorage.Size is undefined

### DIFF
--- a/pkg/controller/compliancescan/rawresults.go
+++ b/pkg/controller/compliancescan/rawresults.go
@@ -55,6 +55,11 @@ func (r *ReconcileComplianceScan) deleteRawResultsForScan(instance *compv1alpha1
 }
 
 func getPVCForScan(instance *compv1alpha1.ComplianceScan) *corev1.PersistentVolumeClaim {
+	storageSize := instance.Spec.RawResultStorage.Size
+	if storageSize == "" {
+		storageSize = compv1alpha1.DefaultRawStorageSize
+	}
+
 	return &corev1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -77,7 +82,7 @@ func getPVCForScan(instance *compv1alpha1.ComplianceScan) *corev1.PersistentVolu
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse(instance.Spec.RawResultStorage.Size),
+					corev1.ResourceStorage: resource.MustParse(storageSize),
 				},
 			},
 		},


### PR DESCRIPTION
We've seen some crashes with the following backtrace:
```
k8s.io/apimachinery/pkg/api/resource.MustParse(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/api/resource/quantity.go:127 +0x23d
github.com/openshift/compliance-operator/pkg/controller/compliancescan.getPVCForScan(0xc0008a0900, 0x0)
	/go/src/github.com/openshift/compliance-operator/pkg/controller/compliancescan/rawresults.go:80 +0x1a3
github.com/openshift/compliance-operator/pkg/controller/compliancescan.(*ReconcileComplianceScan).deleteRawResultsForScan(0xc00066a8a0, 0xc0008a0900, 0x2753160, 0xc0005a0f20)
	/go/src/github.com/openshift/compliance-operator/pkg/controller/compliancescan/rawresults.go:50 +0x40
github.com/openshift/compliance-operator/pkg/controller/compliancescan.(*ReconcileComplianceScan).scanDeleteHandler(0xc00066a8a0, 0xc000806b40, 0x2753160, 0xc0005a0f20, 0x14, 0xc000e14b44, 0xc, 0x270d060)
	/go/src/github.com/openshift/compliance-operator/pkg/controller/compliancescan/compliancescan_controller.go:522 +0x23e
github.com/openshift/compliance-operator/pkg/controller/compliancescan.(*ReconcileComplianceScan).Reconcile(0xc00066a8a0, 0xc0017fb460, 0x14, 0xc000e14b44, 0xc, 0x17bc031, 0xc001119cd8, 0xc0005f6180, 0xc0009c1c98)
	/go/src/github.com/openshift/compliance-operator/pkg/controller/compliancescan/compliancescan_controller.go:129 +0xd1e
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0001e20c0, 0x2268680, 0xc0005a0d00, 0xc000de2f00)
	/go/src/github.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:256 +0x1d0
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0001e20c0, 0x35cee00)
	/go/src/github.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232 +0x11e
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc0001e20c0)
	/go/src/github.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211 +0x39
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000e18250)
	/go/src/github.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x70
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000e18250, 0x26ff6e0, 0xc0006f1230, 0xc000a62201, 0xc00001e0c0)
	/go/src/github.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xb4
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000e18250, 0x3b9aca00, 0x0, 0x1, 0xc00001e0c0)
	/go/src/github.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x146
k8s.io/apimachinery/pkg/util/wait.Until(0xc000e18250, 0x3b9aca00, 0xc00001e0c0)
	/go/src/github.com/openshift/compliance-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90 +0x5b
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/go/src/github.com/openshift/compliance-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:193 +0x4fb
panic: cannot parse '': quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$' [recovered]
	panic: cannot parse '': quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
```

Some of the crashes our users have been seeing with the latest version
are probably due to the mismatch between CRD and the code during our
release. But, some crashes were reported prior to the latest release,
which suggests we should fix it anyway.

This commit uses the default value for the storage size, if the scan.Spec.RawResultStorage.Size
attribute has the null value.

Related:
https://github.com/openshift/compliance-operator/issues/360