### PR TITLE
Use the moderate profile in the example ComplianceScan CR

### DIFF
--- a/deploy/crds/compliance.openshift.io_v1alpha1_compliancescan_cr.yaml
+++ b/deploy/crds/compliance.openshift.io_v1alpha1_compliancescan_cr.yaml
@@ -4,5 +4,5 @@ metadata:
   name: example-compliancescan
 spec:
   # Add fields here
-  profile: xccdf_org.ssgproject.content_profile_coreos-ncp
+  profile: xccdf_org.ssgproject.content_profile_moderate
   content: ssg-rhcos4-ds.xml


### PR DESCRIPTION
This was spotted by our QE engineers. It's more user-friendly to use the
moderate profile as the NCP profile does not work at the moment.