### PR TITLE
profileparser: Fix parsing rule severity

### DIFF
--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -313,7 +313,7 @@ func ParseRulesAndDo(contentDom *xmldom.Document, pcfg *ParserConfig, action fun
 		description := ruleObj.FindOneByName("description")
 		rationale := ruleObj.FindOneByName("rationale")
 		warning := ruleObj.FindOneByName("warning")
-		severity := ruleObj.FindOneByName("severity")
+		severity := ruleObj.GetAttributeValue("severity")
 
 		fixes := []cmpv1alpha1.FixDefinition{}
 		foundPlatformMap := make(map[string]bool)
@@ -391,8 +391,8 @@ func ParseRulesAndDo(contentDom *xmldom.Document, pcfg *ParserConfig, action fun
 			}
 			p.Warning = warn
 		}
-		if severity != nil {
-			p.Severity = severity.Text
+		if severity != "" {
+			p.Severity = severity
 		}
 		if len(fixes) > 0 {
 			p.AvailableFixes = fixes

--- a/pkg/profileparser/profileparser_test.go
+++ b/pkg/profileparser/profileparser_test.go
@@ -249,6 +249,10 @@ var _ = Describe("Testing parse rules", func() {
 			Expect(pwMinLenRule.Annotations).ToNot(BeNil())
 		})
 
+		It("Has the expected severity", func() {
+			Expect(pwMinLenRule.Severity).To(BeEquivalentTo("medium"))
+		})
+
 		It("Has the expected control NIST annotations in profile operator format", func() {
 			nistKey := controlAnnotationBase + "NIST-800-53"
 			Expect(pwMinLenRule.Annotations).To(HaveKeyWithValue(nistKey, "IA-5(f);IA-5(1)(a);CM-6(a)"))


### PR DESCRIPTION
Found while writing tests for the profile updates. Severity is an
attribute of the rule, not an element, e.g.:
```
<xccdf-1.2:Rule id="xccdf_org.ssgproject.content_rule_chronyd_or_ntpd_set_maxpoll" selected="false" severity="low">
```