### PR TITLE
Rename image env variables for downstream

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -31,12 +31,12 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "compliance-operator"
-            - name: OPENSCAP_IMAGE
+            - name: RELATED_IMAGE_OPENSCAP
               # Hardcoding this temporarily until its propagated to CI
               value: "quay.io/compliance-operator/openscap-ocp:1.3.3"
-            - name: OPERATOR_IMAGE
+            - name: RELATED_IMAGE_OPERATOR
               value: "quay.io/compliance-operator/compliance-operator:latest"
-            - name: DEFAULT_PROFILE_BUNDLES_IMAGE
+            - name: RELATED_IMAGE_PROFILE
               value: "quay.io/complianceascode/ocp4:latest"
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/pkg/utils/images.go
+++ b/pkg/utils/images.go
@@ -14,9 +14,9 @@ var componentDefaults = []struct {
 	defaultImage string
 	envVar       string
 }{
-	{"quay.io/jhrozek/openscap-ocp:latest", "OPENSCAP_IMAGE"},
-	{"quay.io/compliance-operator/compliance-operator:latest", "OPERATOR_IMAGE"},
-	{"quay.io/complianceascode/ocp4:latest", "DEFAULT_PROFILE_BUNDLES_IMAGE"},
+	{"quay.io/jhrozek/openscap-ocp:latest", "RELATED_IMAGE_OPENSCAP"},
+	{"quay.io/compliance-operator/compliance-operator:latest", "RELATED_IMAGE_OPERATOR"},
+	{"quay.io/complianceascode/ocp4:latest", "RELATED_IMAGE_PROFILE"},
 }
 
 // GetComponentImage returns a full image pull spec for a given component


### PR DESCRIPTION
The RHBS digest pinning feature relies on RELATED_IMAGE_* variables to do image reference substitution.