### PR TITLE
Remediations: Set default state

### DIFF
--- a/deploy/crds/compliance.openshift.io_complianceremediations_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_complianceremediations_crd.yaml
@@ -82,6 +82,7 @@ spec:
               or not)
             properties:
               applicationState:
+                default: NotApplied
                 description: Whether the remediation is already applied or not
                 type: string
               errorMessage:

--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -2,8 +2,9 @@ package v1alpha1
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"reflect"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -63,6 +64,7 @@ type ComplianceRemediationSpec struct {
 // +k8s:openapi-gen=true
 type ComplianceRemediationStatus struct {
 	// Whether the remediation is already applied or not
+	// +kubebuilder:default="NotApplied"
 	ApplicationState RemediationApplicationState `json:"applicationState,omitempty"`
 	ErrorMessage     string                      `json:"errorMessage,omitempty"`
 }


### PR DESCRIPTION
The default state is NotApplied, so let's use that default from the CRD.
This way, when creating a remediation, we won't have an empty state
(even if it's temporary).