### PR TITLE
ScanSettingBindings: Use normal events when creating or updating scans

### DIFF
--- a/pkg/controller/scansettingbinding/scansettingbinding_controller.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller.go
@@ -157,7 +157,7 @@ func (r *ReconcileScanSettingBinding) Reconcile(request reconcile.Request) (reco
 		if err == nil {
 			log.Info("Suite created", "suite.Name", suite.Name)
 			r.Eventf(
-				instance, corev1.EventTypeWarning, "SuiteCreated",
+				instance, corev1.EventTypeNormal, "SuiteCreated",
 				"ComplianceSuite %s/%s created", suite.Namespace, suite.Name,
 			)
 		} else {
@@ -179,7 +179,7 @@ func (r *ReconcileScanSettingBinding) Reconcile(request reconcile.Request) (reco
 		if err == nil {
 			log.Info("Suite updated", "suite.Name", suite.Name)
 			r.Eventf(
-				instance, corev1.EventTypeWarning, "SuiteUpdated",
+				instance, corev1.EventTypeNormal, "SuiteUpdated",
 				"ComplianceSuite %s/%s updatd", suite.Namespace, suite.Name,
 			)
 		} else {


### PR DESCRIPTION
These events should not be warnings as they're part of the normal
operation of the operator.