### PR TITLE
images: Use a fallback RELATED_IMAGE_OPENSCAP value that actually works

### DIFF
--- a/pkg/utils/images.go
+++ b/pkg/utils/images.go
@@ -14,7 +14,7 @@ var componentDefaults = []struct {
 	defaultImage string
 	envVar       string
 }{
-	{"quay.io/jhrozek/openscap-ocp:latest", "RELATED_IMAGE_OPENSCAP"},
+	{"quay.io/compliance-operator/openscap-ocp:1.3.3", "RELATED_IMAGE_OPENSCAP"},
 	{"quay.io/compliance-operator/compliance-operator:latest", "RELATED_IMAGE_OPERATOR"},
 	{"quay.io/complianceascode/ocp4:latest", "RELATED_IMAGE_PROFILE"},
 }


### PR DESCRIPTION
We recently changed the environment variable names to match downstream,
which caused in one instance the operator to be assigned the new names,
while the code was still handling the old names.

This uncovered the issue this patch is trying to address: the fallback
image for when RELATED_IMAGE_OPENSCAP is not set is too old and it was
causing the platform scans to fail because the old scap version doesn't
understand the YAML probes.

Jira: OCPBUGSM-13604