### PR TITLE
Detect if nodeSelector doesn't match

### DIFF
--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -135,6 +135,7 @@ spec:
                   type: object
                 type: array
               scanType:
+                default: Node
                 description: The type of Compliance scan.
                 type: string
               tailoringConfigMap:

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -154,6 +154,7 @@ spec:
                         type: object
                       type: array
                     scanType:
+                      default: Node
                       description: The type of Compliance scan.
                       type: string
                     tailoringConfigMap:

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -26,6 +26,7 @@ const ComplianceCheckResultRuleAnnotation = "compliance.openshift.io/rule"
 // It either lists statuses of nodes that differ from ComplianceCheckResultMostCommonAnnotation or,
 // if the most common state does not exist, just lists all sources of all nodes.
 const ComplianceCheckResultInconsistentSourceAnnotation = "compliance.openshift.io/inconsistent-source"
+
 // ComplianceCheckResultMostCommonAnnotation stores the most common ComplianceCheckStatus value
 // in an inconsistent check. In order for the result to be most common, at least 60% of the nodes
 // must report the same result. The nodes that differ from the most common status are listed using

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -1,6 +1,9 @@
 package v1alpha1
 
 import (
+	"fmt"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -243,6 +246,29 @@ func (cs *ComplianceScan) NeedsRescan() bool {
 	}
 	_, needsRescan := annotations[ComplianceScanRescanAnnotation]
 	return needsRescan
+}
+
+// GetScanTypeIfValid returns scan type if the scan has a valid one, else it returns
+// an error
+func (cs *ComplianceScan) GetScanTypeIfValid() (ComplianceScanType, error) {
+	if strings.ToLower(string(cs.Spec.ScanType)) == strings.ToLower(string(ScanTypePlatform)) {
+		return ScanTypePlatform, nil
+	}
+
+	if strings.ToLower(string(cs.Spec.ScanType)) == strings.ToLower(string(ScanTypeNode)) {
+		return ScanTypeNode, nil
+	}
+	return "", fmt.Errorf("Unknown scan type")
+}
+
+// GetScanType get's the scan type for a scan
+func (cs *ComplianceScan) GetScanType() ComplianceScanType {
+	scantype, err := cs.GetScanTypeIfValid()
+	if err != nil {
+		// This shouldn't happen
+		panic(err)
+	}
+	return scantype
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -144,6 +144,7 @@ type ComplianceScanSettings struct {
 // +k8s:openapi-gen=true
 type ComplianceScanSpec struct {
 	// The type of Compliance scan.
+	// +kubebuilder:default=Node
 	ScanType ComplianceScanType `json:"scanType,omitempty"`
 	// Is the image with the content (Data Stream), that will be used to run
 	// OpenSCAP.

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -165,6 +165,26 @@ func (r *ReconcileComplianceScan) phasePendingHandler(instance *compv1alpha1.Com
 		return reconcile.Result{}, err
 	}
 
+	// Set default scan type if missing
+	if instance.Spec.ScanType == "" {
+		instanceCopy := instance.DeepCopy()
+		instanceCopy.Spec.ScanType = compv1alpha1.ScanTypeNode
+		err := r.client.Update(context.TODO(), instanceCopy)
+		return reconcile.Result{}, err
+	}
+
+	// validate scan type
+	if _, err := instance.GetScanTypeIfValid(); err != nil {
+		r.recorder.Event(instance, corev1.EventTypeWarning, "InvalidScanType",
+			"The scan type was invalid")
+		instanceCopy := instance.DeepCopy()
+		instanceCopy.Status.Result = compv1alpha1.ResultError
+		instanceCopy.Status.ErrorMessage = fmt.Sprintf("Scan type '%s' is not valid", instance.Spec.ScanType)
+		instanceCopy.Status.Phase = compv1alpha1.PhaseDone
+		updateErr := r.client.Status().Update(context.TODO(), instanceCopy)
+		return reconcile.Result{}, updateErr
+	}
+
 	// Set default storage if missing
 	if instance.Spec.RawResultStorage.Size == "" {
 		instanceCopy := instance.DeepCopy()
@@ -183,7 +203,7 @@ func (r *ReconcileComplianceScan) phasePendingHandler(instance *compv1alpha1.Com
 		return reconcile.Result{}, err
 	}
 
-	if isNodeScan(instance) {
+	if instance.GetScanType() == compv1alpha1.ScanTypeNode {
 		var nodes corev1.NodeList
 		var err error
 		if nodes, err = getTargetNodes(r, instance); err != nil {
@@ -293,7 +313,7 @@ func (r *ReconcileComplianceScan) phaseRunningHandler(instance *compv1alpha1.Com
 
 	logger.Info("Phase: Running")
 
-	if isPlatformScan(instance) {
+	if instance.GetScanType() == compv1alpha1.ScanTypePlatform {
 		running, err := isPlatformScanPodRunning(r, instance, logger)
 		if errors.IsNotFound(err) {
 			// Let's go back to the previous state and make sure all the nodes are covered.
@@ -435,7 +455,7 @@ func (r *ReconcileComplianceScan) phaseDoneHandler(instance *compv1alpha1.Compli
 	// We need to remove resources before doing a re-scan
 	if doDelete || instance.NeedsRescan() {
 		logger.Info("Cleaning up scan's resources")
-		if isPlatformScan(instance) {
+		if instance.GetScanType() == compv1alpha1.ScanTypePlatform {
 			if err := r.deletePlatformScanPod(instance, logger); err != nil {
 				log.Error(err, "Cannot delete platform scan pod")
 				return reconcile.Result{}, err
@@ -598,7 +618,7 @@ func (r *ReconcileComplianceScan) generateResultEventForScan(scan *compv1alpha1.
 func getTargetNodes(r *ReconcileComplianceScan, instance *compv1alpha1.ComplianceScan) (corev1.NodeList, error) {
 	var nodes corev1.NodeList
 
-	if isPlatformScan(instance) {
+	if instance.GetScanType() == compv1alpha1.ScanTypePlatform {
 		return nodes, nil // Nodes are only relevant to the node scan type. Return the empty node list otherwise.
 	} else {
 		listOpts := client.ListOptions{
@@ -692,7 +712,7 @@ func getNodeScanCM(r *ReconcileComplianceScan, instance *compv1alpha1.Compliance
 // hard in which case there might not be a reason to launch the aggregator pod, e.g.
 // in cases the content cannot be loaded at all
 func shouldLaunchAggregator(r *ReconcileComplianceScan, instance *compv1alpha1.ComplianceScan, nodes corev1.NodeList) (bool, error) {
-	if isPlatformScan(instance) {
+	if instance.GetScanType() == compv1alpha1.ScanTypePlatform {
 		foundCM, err := getPlatformScanCM(r, instance)
 
 		// Could be a transient error, so we requeue if there's any
@@ -737,7 +757,7 @@ func gatherResults(r *ReconcileComplianceScan, instance *compv1alpha1.Compliance
 	compliant := true
 	isReady := true
 
-	if isPlatformScan(instance) {
+	if instance.GetScanType() == compv1alpha1.ScanTypePlatform {
 		foundCM, err := getPlatformScanCM(r, instance)
 
 		// Could be a transient error, so we requeue if there's any
@@ -828,12 +848,4 @@ func getInitContainerImage(scanSpec *compv1alpha1.ComplianceScanSpec, logger log
 
 	logger.Info("Content image", "image", image)
 	return image
-}
-
-func isPlatformScan(instance *compv1alpha1.ComplianceScan) bool {
-	return instance.Spec.ScanType == compv1alpha1.ScanTypePlatform
-}
-
-func isNodeScan(instance *compv1alpha1.ComplianceScan) bool {
-	return instance.Spec.ScanType == compv1alpha1.ScanTypeNode
 }

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -574,8 +574,8 @@ func (r *ReconcileComplianceScan) generateResultEventForScan(scan *compv1alpha1.
 
 	if scan.Status.Result == compv1alpha1.ResultNotApplicable {
 		r.recorder.Eventf(
-			scan, corev1.EventTypeNormal, "ScanNotApplicable",
-			"The scan result is not applicable, please check if you're using the correct platform")
+			scan, corev1.EventTypeWarning, "ScanNotApplicable",
+			"The scan result is not applicable, please check if you're using the correct platform or if the nodeSelector matches nodes.")
 	} else if scan.Status.Result == compv1alpha1.ResultInconsistent {
 		r.recorder.Eventf(
 			scan, corev1.EventTypeNormal, "ScanNotConsistent",

--- a/pkg/controller/compliancescan/compliancescan_controller_test.go
+++ b/pkg/controller/compliancescan/compliancescan_controller_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 				Name: "test",
 			},
 			Spec: compv1alpha1.ComplianceScanSpec{
+				ScanType: compv1alpha1.ScanTypeNode,
 				ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 					RawResultStorage: compv1alpha1.RawResultStorageSettings{
 						Size: compv1alpha1.DefaultRawStorageSize,

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -26,7 +26,7 @@ const (
 )
 
 func (r *ReconcileComplianceScan) createScanPods(instance *compv1alpha1.ComplianceScan, nodes corev1.NodeList, logger logr.Logger) error {
-	if isPlatformScan(instance) {
+	if instance.GetScanType() == compv1alpha1.ScanTypePlatform {
 		return r.createPlatformScanPod(instance, logger)
 	}
 	// ScanTypeNode


### PR DESCRIPTION
For node scan types, if the node selector doesn't match, the result
won't be valid. So let's detect this and so something about it:

* We issue an event that indicates that the nodeSelector didn't match nodes.
* We move the state directly to "Done" and the result to "NotApplicable"

piggy-backed to this, was some refactoring to the handling of scan types.

This keeps the functionality that allows case-insensitive usage of scan types
but does validation so only allowed scan types can be used. This will result in
an event and an appropriate status on the CR.

Jira: OCPBUGSM-1430