### PR TITLE
Make profileparser use its own service account

### DIFF
--- a/deploy/crds/compliance.openshift.io_profiles_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_profiles_crd.yaml
@@ -39,6 +39,7 @@ spec:
               type: string
             nullable: true
             type: array
+            x-kubernetes-list-type: atomic
           title:
             type: string
           values:
@@ -47,6 +48,7 @@ spec:
               type: string
             nullable: true
             type: array
+            x-kubernetes-list-type: atomic
         required:
         - description
         - id

--- a/deploy/crds/compliance.openshift.io_rules_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_rules_crd.yaml
@@ -42,6 +42,7 @@ spec:
               type: object
             nullable: true
             type: array
+            x-kubernetes-list-type: atomic
           description:
             description: The description of the Rule
             type: string

--- a/deploy/crds/compliance.openshift.io_variables_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_variables_crd.yaml
@@ -48,6 +48,7 @@ spec:
               type: object
             nullable: true
             type: array
+            x-kubernetes-list-type: atomic
           title:
             description: The title of the Variable
             type: string

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -260,6 +260,36 @@ rules:
   - list
   - update
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: profileparser
+rules:
+- apiGroups:
+  - compliance.openshift.io
+  resources:
+  - profilebundles
+  - profilebundles/status
+  - profilebundles/finalizers
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+- apiGroups:
+  - compliance.openshift.io
+  resources:
+  - profiles
+  - rules
+  - variables
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+---
 # This is basically a copy of cluster-reader. But we needed to include it
 # because the OLM doesn't support adding labels to roles nor specifying
 # roleRefs

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -84,3 +84,16 @@ roleRef:
   kind: Role
   name: rerunner
   apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: profileparser
+subjects:
+- kind: ServiceAccount
+  name: profileparser
+  namespace: openshift-compliance
+roleRef:
+  kind: Role
+  name: profileparser
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -22,3 +22,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: api-resource-collector
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: profileparser

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -26,6 +26,7 @@ const ComplianceCheckResultRuleAnnotation = "compliance.openshift.io/rule"
 // It either lists statuses of nodes that differ from ComplianceCheckResultMostCommonAnnotation or,
 // if the most common state does not exist, just lists all sources of all nodes.
 const ComplianceCheckResultInconsistentSourceAnnotation = "compliance.openshift.io/inconsistent-source"
+
 // ComplianceCheckResultMostCommonAnnotation stores the most common ComplianceCheckStatus value
 // in an inconsistent check. In order for the result to be most common, at least 60% of the nodes
 // must report the same result. The nodes that differ from the most common status are listed using

--- a/pkg/apis/compliance/v1alpha1/profile_types.go
+++ b/pkg/apis/compliance/v1alpha1/profile_types.go
@@ -29,9 +29,11 @@ type ProfilePayload struct {
 	ID          string `json:"id"`
 	// +nullable
 	// +optional
+	// +listType=atomic
 	Rules []ProfileRule `json:"rules,omitempty"`
 	// +nullable
 	// +optional
+	// +listType=atomic
 	Values []ProfileValue `json:"values,omitempty"`
 }
 

--- a/pkg/apis/compliance/v1alpha1/rule_types.go
+++ b/pkg/apis/compliance/v1alpha1/rule_types.go
@@ -27,6 +27,7 @@ type RulePayload struct {
 	// The Available fixes
 	// +nullable
 	// +optional
+	// +listType=atomic
 	AvailableFixes []FixDefinition `json:"availableFixes,omitempty"`
 }
 

--- a/pkg/apis/compliance/v1alpha1/variable_types.go
+++ b/pkg/apis/compliance/v1alpha1/variable_types.go
@@ -3,8 +3,9 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // +kubebuilder:validation:Enum=number;bool;string
@@ -41,6 +42,7 @@ type VariablePayload struct {
 	// Enumerates what values are allowed for this variable. Can be empty.
 	// +optional
 	// +nullable
+	// +listType=atomic
 	Selections []ValueSelection `json:"selections,omitempty"`
 }
 

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -260,8 +260,7 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle) *appsv1.Deployme
 							},
 						},
 					},
-					//ServiceAccountName: "profileparser",
-					ServiceAccountName: "compliance-operator",
+					ServiceAccountName: "profileparser",
 					Volumes: []corev1.Volume{
 						{
 							Name: "content-dir",


### PR DESCRIPTION
This hardens the deployment by giving less permissions to this account.