### PR TITLE
Unify log tags for controllers

### DIFF
--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("controller_profilebundle")
+var log = logf.Log.WithName("profilebundlectrl")
 
 var oneReplica int32 = 1
 

--- a/pkg/controller/scansettingbinding/scansettingbinding_controller.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller.go
@@ -33,7 +33,7 @@ const (
 	requeueAfterDefault = 10 * time.Second
 )
 
-var log = logf.Log.WithName("controller_scansettingbinding")
+var log = logf.Log.WithName("scansettingbindingctrl")
 
 func Add(mgr manager.Manager) error {
 	return add(mgr, newReconciler(mgr))

--- a/pkg/controller/tailoredprofile/tailoredprofile_controller.go
+++ b/pkg/controller/tailoredprofile/tailoredprofile_controller.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("controller_tailoredprofile")
+var log = logf.Log.WithName("tailoredprofilectrl")
 
 const (
 	tailoringFile string = "tailoring.xml"


### PR DESCRIPTION
I noticed different controllers use a different "name" in the structured
logs. This might be irritating for admins who are trying to grep messages
from one controller.

Some controllers were using controller_$api, some were using $(api)ctrl.
This patch unifies the tag to use the latter, older format, but we can
standartize on something else, as long as the operator uses the same format.