### PR TITLE
WIP: Enforce resource limits for all pods

### DIFF
--- a/cmd/manager/profileparser.go
+++ b/cmd/manager/profileparser.go
@@ -141,13 +141,14 @@ func runProfileParser(cmd *cobra.Command, args []string) {
 		updateProfileBundleStatus(pcfg, pb, fmt.Errorf("Couldn't read content file: %s", err))
 		os.Exit(1)
 	}
-	// #nosec
-	defer contentFile.Close()
 	bufContentFile := bufio.NewReader(contentFile)
 	contentDom, err := xmldom.Parse(bufContentFile)
 	if err != nil {
 		log.Error(err, "Couldn't read the content XML")
 		updateProfileBundleStatus(pcfg, pb, fmt.Errorf("Couldn't read content XML: %s", err))
+		if closeErr := contentFile.Close(); closeErr != nil {
+			log.Error(err, "Couldn't close the content file")
+		}
 		os.Exit(1)
 	}
 
@@ -156,6 +157,10 @@ func runProfileParser(cmd *cobra.Command, args []string) {
 	// The err variable might be nil, this is fine, it'll just update the status
 	// to valid
 	updateProfileBundleStatus(pcfg, pb, err)
+
+	if closeErr := contentFile.Close(); closeErr != nil {
+		log.Error(err, "Couldn't close the content file")
+	}
 
 	<-exitSignal
 }

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: compliance-operator
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       name: compliance-operator
@@ -13,6 +13,7 @@ spec:
         name: compliance-operator
     spec:
       serviceAccountName: compliance-operator
+
       containers:
         - name: compliance-operator
           image: "quay.io/compliance-operator/compliance-operator:latest"
@@ -20,6 +21,10 @@ spec:
           - compliance-operator
           - operator
           imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 150m
+              memory: 500Mi
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
 
       containers:
         - name: compliance-operator
-          image: "quay.io/compliance-operator/compliance-operator:latest"
+          image: "image-registry.openshift-image-registry.svc:5000/openshift/compliance-operator:latest"
           command:
           - compliance-operator
           - operator
@@ -40,7 +40,7 @@ spec:
               # Hardcoding this temporarily until its propagated to CI
               value: "quay.io/compliance-operator/openscap-ocp:1.3.3"
             - name: RELATED_IMAGE_OPERATOR
-              value: "quay.io/compliance-operator/compliance-operator:latest"
+              value: "image-registry.openshift-image-registry.svc:5000/openshift/compliance-operator:latest"
             - name: RELATED_IMAGE_PROFILE
               value: "quay.io/complianceascode/ocp4:latest"
       nodeSelector:

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
@@ -63,6 +64,12 @@ func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Log
 						"--content=" + absContentPath(scanInstance.Spec.Content),
 						"--scan=" + scanInstance.Name,
 						"--namespace=" + scanInstance.Namespace,
+					},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("200Mi"),
+						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -144,6 +145,12 @@ func resultServer(scanInstance *compv1alpha1.ComplianceScan, labels map[string]s
 								"--tls-server-cert=/etc/pki/tls/tls.crt",
 								"--tls-server-key=/etc/pki/tls/tls.key",
 								"--tls-ca=/etc/pki/tls/ca.crt",
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
+								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -143,6 +144,12 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 						"--tls-ca=/etc/pki/tls/ca.crt",
 					},
 					ImagePullPolicy: corev1.PullAlways,
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "report-dir",
@@ -160,6 +167,12 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 					Name:    OpenSCAPScanContainerName,
 					Image:   utils.GetComponentImage(utils.OPENSCAP),
 					Command: []string{OpenScapScriptPath},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("150m"),
+							corev1.ResourceMemory: resource.MustParse("200Mi"),
+						},
+					},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: &trueVal,
 					},
@@ -294,6 +307,12 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 					Image:           utils.GetComponentImage(utils.OPERATOR),
 					Command:         collectorCmd,
 					ImagePullPolicy: corev1.PullAlways,
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "content-dir",
@@ -325,6 +344,12 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 						"--tls-ca=/etc/pki/tls/ca.crt",
 					},
 					ImagePullPolicy: corev1.PullAlways,
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "report-dir",
@@ -342,6 +367,12 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 					Name:    OpenSCAPScanContainerName,
 					Image:   utils.GetComponentImage(utils.OPENSCAP),
 					Command: []string{OpenScapScriptPath},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("150m"),
+							corev1.ResourceMemory: resource.MustParse("200Mi"),
+						},
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "report-dir",

--- a/pkg/controller/compliancesuite/suitererunner.go
+++ b/pkg/controller/compliancesuite/suitererunner.go
@@ -11,6 +11,7 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -102,6 +103,12 @@ func getRerunner(suite *compv1alpha1.ComplianceSuite) *batchv1beta1.CronJob {
 										"compliance-operator", "suitererunner",
 										"--name", suite.GetName(),
 										"--namespace", suite.GetNamespace(),
+									},
+									Resources: corev1.ResourceRequirements{
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("10m"),
+											corev1.ResourceMemory: resource.MustParse("20Mi"),
+										},
 									},
 								},
 							},

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -16,6 +16,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -250,6 +251,12 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle) *appsv1.Deployme
 								"--name", pb.Name,
 								"--namespace", pb.Namespace,
 								"--ds-path", path.Join("/content", pb.Spec.ContentFile),
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("500Mi"),
+								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"regexp"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	cmpv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/openshift/compliance-operator/pkg/xccdf"


### PR DESCRIPTION
This enforces resource limits for all pods related to the operator.

**For the operator itself:**

We were using three replicas and not settings the resources. This was
unnecessary, as it's not a critical workload. So instead let's just
ensure we have one replica running, and then reduce the resource limits
to have 150m of cpu and 200M of memory. These numbers were taken from
what etcd uses.


**aggregator:**
* cpu: 100m
* memory: 100M

**resultserver:**
* cpu: 100m
* memory: 100M

**logcollector:**
* cpu: 100m
* memory: 100M

**openscap:**
* cpu: 150m
* memory: 200M

**api resource collector:**
* cpu: 100m
* memory: 100M

**suite rerunner:**
* cpu: 10m
* memory: 20M

**profileparser:**
* cpu: 100m
* memory: 100M

Note that OpenSCAP gets more resources since it's known to use a lot of
resources.