### PR TITLE
Add a troubleshooting document

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ metadata:
     compliance.openshift.io/check-severity: medium
     compliance.openshift.io/check-status: FAIL
     compliance.openshift.io/suite: example-compliancesuite
-    complianceoperator.openshift.io/scan: workers-scan
+    compliance.openshift.io/scan-name: workers-scan
   name: workers-scan-no-direct-root-logins
   namespace: openshift-compliance
   ownerReferences:
@@ -291,7 +291,7 @@ kind: ComplianceRemediation
 metadata:
   labels:
     compliance.openshift.io/suite: example-compliancesuite
-    complianceoperator.openshift.io/scan: workers-scan
+    compliance.openshift.io/scan-name: workers-scan
     machineconfiguration.openshift.io/role: worker
   name: workers-scan-disable-users-coredumps
   namespace: openshift-compliance

--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -99,7 +99,7 @@ func getScanConfigMaps(crClient *complianceCrClient, scan, namespace string) ([]
 
 	// Look for configMap with this scan label
 	inNs := client.InNamespace(namespace)
-	withLabel := client.MatchingLabels{compv1alpha1.ComplianceScanIndicatorLabel: scan}
+	withLabel := client.MatchingLabels{compv1alpha1.ComplianceScanLabel: scan}
 
 	err = crClient.client.List(context.TODO(), cMapList, inNs, withLabel)
 	if err != nil {
@@ -284,7 +284,7 @@ func canCreateRemediation(scan *compv1alpha1.ComplianceScan) (bool, string) {
 
 func getRemediationLabels(scan *compv1alpha1.ComplianceScan, obj runtime.Object) map[string]string {
 	labels := make(map[string]string)
-	labels[compv1alpha1.ScanLabel] = scan.Name
+	labels[compv1alpha1.ComplianceScanLabel] = scan.Name
 	labels[compv1alpha1.SuiteLabel] = scan.Labels[compv1alpha1.SuiteLabel]
 
 	// FIXME(jaosorior): Figure out a more pluggable way of adding these sorts of special cases
@@ -298,7 +298,7 @@ func getRemediationLabels(scan *compv1alpha1.ComplianceScan, obj runtime.Object)
 
 func getCheckResultLabels(cr *compv1alpha1.ComplianceCheckResult, resultLabels map[string]string, scan *compv1alpha1.ComplianceScan) map[string]string {
 	labels := make(map[string]string)
-	labels[compv1alpha1.ScanLabel] = scan.Name
+	labels[compv1alpha1.ComplianceScanLabel] = scan.Name
 	labels[compv1alpha1.SuiteLabel] = scan.Labels[compv1alpha1.SuiteLabel]
 	labels[compv1alpha1.ComplianceCheckResultStatusLabel] = string(cr.Status)
 	labels[compv1alpha1.ComplianceCheckResultSeverityLabel] = string(cr.Severity)

--- a/cmd/manager/resultcollector.go
+++ b/cmd/manager/resultcollector.go
@@ -254,7 +254,8 @@ func getConfigMap(owner metav1.Object, configMapName, filename, nodeName string,
 			Namespace:   common.GetComplianceOperatorNamespace(),
 			Annotations: annotations,
 			Labels: map[string]string{
-				compv1alpha1.ComplianceScanIndicatorLabel: owner.GetName(),
+				compv1alpha1.ComplianceScanLabel: owner.GetName(),
+				compv1alpha1.ResultLabel:         "",
 			},
 		},
 		Data: map[string]string{

--- a/deploy/olm-catalog/compliance-operator/0.1.8/compliance-operator.v0.1.8.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/0.1.8/compliance-operator.v0.1.8.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
           "kind": "ComplianceRemediation",
           "metadata": {
             "labels": {
-              "complianceoperator.openshift.io/scan": "example-scan",
+              "compliance.openshift.io/scan-name": "example-scan",
               "complianceoperator.openshift.io/suite": "example-suite",
               "machineconfiguration.openshift.io/role": "worker"
             },

--- a/deploy/olm-catalog/compliance-operator/0.1.9/compliance-operator.v0.1.9.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/0.1.9/compliance-operator.v0.1.9.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
           "kind": "ComplianceRemediation",
           "metadata": {
             "labels": {
-              "complianceoperator.openshift.io/scan": "example-scan",
+              "compliance.openshift.io/scan-name": "example-scan",
               "complianceoperator.openshift.io/suite": "example-suite",
               "machineconfiguration.openshift.io/role": "worker"
             },

--- a/doc/remediation-flow.md
+++ b/doc/remediation-flow.md
@@ -88,7 +88,7 @@ kind: ComplianceRemediation
 metadata:
   labels:
     compliance.openshift.io/suite: example-compliancesuite
-    complianceoperator.openshift.io/scan: masters-scan
+    compliance.openshift.io/scan-name: masters-scan
     machineconfiguration.openshift.io/role: master
   name: masters-scan-no-direct-root-logins
   namespace: openshift-compliance

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -147,11 +147,11 @@ In this phase, several `ConfigMaps` that contain either environment for the
 scanner pods or directly the script that the scanner pods will be evaluating.
 List the CMs with:
 ```shell
-oc get cm -lcomplianceoperator.openshift.io/scan=$scan_name
+oc get cm -lcompliance.openshift.io/scan-name=$scan_name,complianceoperator.openshift.io/scan-script=
 ```
 e.g.:
 ```shell
-oc get cm -lcomplianceoperator.openshift.io/scan=rhcos4-e8-worker
+oc get cm -lcompliance.openshift.io/scan-name=rhcos4-e8-worker,complianceoperator.openshift.io/scan-script=
 ```
 These `ConfigMaps` will be used by the scanner pods. If you ever needed to
 modify the scanner behaviour, change the scanner debug level or print the
@@ -181,9 +181,9 @@ a `Platform` scan instance and one scanner pod per matching node for a
 `Node` scan instance. The per-node pods are labeled with the node name,
 each pod is always labeled with the `ComplianceScan` name, for example:
 ```
-oc get pods -lcomplianceScan=rhcos4-e8-worker --show-labels
+oc get pods -lcompliance.openshift.io/scan-name=rhcos4-e8-worker --show-labels
 NAME                                                              READY   STATUS      RESTARTS   AGE   LABELS
-rhcos4-e8-worker-ip-10-0-169-90.eu-north-1.compute.internal-pod   0/2     Completed   0          39m   complianceScan=rhcos4-e8-worker,targetNode=ip-10-0-169-90.eu-north-1.compute.internal
+rhcos4-e8-worker-ip-10-0-169-90.eu-north-1.compute.internal-pod   0/2     Completed   0          39m   compliance.openshift.io/scan-name=rhcos4-e8-worker,targetNode=ip-10-0-169-90.eu-north-1.compute.internal
 ```
 
 At this point, the scan proceeds to the Running phase.
@@ -211,12 +211,13 @@ might be a good place to start debugging:
       container finishes. Then, it uploads the full ARF results to the
       `ResultServer` and separately uploads the XCCDF results along with scan
       result and openscap result code as a `ConfigMap.` These result configmaps
-      are labeled with the scan name (`compliance-scan=$scan_name`):
+      are labeled with the scan name (`compliance.openshift.io/scan-name=$scan_name`):
       ```
       $ oc describe cm/rhcos4-e8-worker-ip-10-0-169-90.eu-north-1.compute.internal-pod
       Name:         rhcos4-e8-worker-ip-10-0-169-90.eu-north-1.compute.internal-pod
       Namespace:    openshift-compliance
-      Labels:       compliance-scan=rhcos4-e8-worker
+      Labels:       compliance.openshift.io/scan-name-scan=rhcos4-e8-worker
+                    complianceoperator.openshift.io/scan-result=
       Annotations:  compliance-remediations/processed: 
                     compliance.openshift.io/scan-error-msg: 
                     compliance.openshift.io/scan-result: NON-COMPLIANT
@@ -258,14 +259,14 @@ When a `ConfigMap` is processed by an aggregator pod,it is labeled the
 
 The result of this phase are `ComplianceCheckResult` objects:
 ```
-oc get compliancecheckresults -lcomplianceoperator.openshift.io/scan=rhcos4-e8-worker
+oc get compliancecheckresults -lcompliance.openshift.io/scan-name=rhcos4-e8-worker
 NAME                                                       STATUS   SEVERITY
 rhcos4-e8-worker-accounts-no-uid-except-zero               PASS     high
 rhcos4-e8-worker-audit-rules-dac-modification-chmod        FAIL     medium
 ```
 and `ComplianceRemediation` objects:
 ```
-oc get complianceremediations -lcomplianceoperator.openshift.io/scan=rhcos4-e8-worker
+oc get complianceremediations -lcompliance.openshift.io/scan-name=rhcos4-e8-worker
 NAME                                                       STATE
 rhcos4-e8-worker-audit-rules-dac-modification-chmod        NotApplied
 rhcos4-e8-worker-audit-rules-dac-modification-chown        NotApplied

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -1,0 +1,363 @@
+# Troubleshooting Compliance Operator
+This document describes how to troubleshoot problems with the Compliance
+Operator. The information can be useful either to diagnose a problem or
+provide information in a bug report.
+
+Please refer to the README for general information about the API objects.
+
+## General tips
+
+   * The Compliance Operator emits Kubernetes events when something
+     important happens. You can either view all events in the cluster (`oc get events
+     -nopenshift-compliance`) or events for an object, e.g. for a scan
+     (`oc describe compliancescan/$scan`)
+
+   * The Compliance Operator consists of several controllers, roughly
+     one per API object. It could be handy to filter only those controller that correspond to
+     the API object having issues, e.g. if a `ComplianceRemediation` can't be applied,
+     the first place to look might be the messages from the `remediationctrl` controller.
+     You can filter the messages from a single controller e.g. using `jq`:
+     `oc logs compliance-operator-775d7bddbd-gj58f | jq -c 'select(.logger == "profilebundlectrl")' `
+
+   * The timestamps are logged as seconds since UNIX epoch in UTC. To convert
+     them to a human-readable date, use
+     `date -d @timestamp --utc`, e.g. `date -d @1596184628.955853 --utc`
+
+   * Many CRs, most importantly `ComplianceSuite` and `ScanSetting` allow
+     the `debug` option to be set. Enabling this option increases verbosity
+     of the openscap scanner pods as well as some other helper pods.
+
+   * If a single rule is passing or failing unexpectedly, it could be helpful
+     to run a single scan or a suite with only that rule - you can find the
+     rule ID from the corresponding `ComplianceCheckResult` object and use it
+     as the `rule` attribute value in a Scan CR. Then, together with the
+     `debug` option enabled, the openscap-ocp container logs in the scanner
+     pod would show the raw OpenSCAP logs.
+
+## Anatomy of a scan
+
+Debugging a problem is easier when the control flow of the operator is
+clear.  Let's illustrate the complete flow with an example - we'll define
+a Suite using the high-level `ScanSetting/ScanSettingBinding` objects,
+run it, remediate a failing check and re-run the scan again to see the
+difference. Along the way, we'll illustrate which object is reconciled
+at that point and which controller is doing the work.
+
+## Compliance sources
+First, the compliance content must come from somewhere. We're
+going to be referencing a `Profile` object that is generated from a
+`ProfileBundle`. Compliance operator creates two (one for the cluster,
+one for the cluster nodes) `ProfileBundles` by default:
+```shell
+oc get profilebundle.compliance
+oc get profile.compliance
+```
+The `ProfileBundle` objects are processed by deployments labeled with the
+`Bundle` name, so in order to debug an issue with the `Bundle,` you can find
+the deployment and check out logs of the pods in that deployment, for
+example for the `ocp4` profile bundle:
+```shell
+oc logs -lprofile-bundle=ocp4
+oc get deployments,pods -lprofile-bundle=ocp4
+oc logs pods/...
+```
+
+## The ScanSetting and ScanSettingBinding lifecycle and debugging
+Provided we have valid compliance content sources, we can use the
+high-level `ScanSetting` and `ScanSettingBinding` objects to generate
+`ComplianceSuite` and `ComplianceScan` objects respectively:
+
+```
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSetting
+metadata:
+  name: my-companys-constraints
+debug: true
+# For each role, a separate scan will be created pointing
+# to a node-role specified in roles
+roles:
+  - worker
+---
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: my-companys-compliance-requirements
+profiles:
+  # Node checks
+  - name: rhcos4-e8
+    kind: Profile
+    apiGroup: compliance.openshift.io/v1alpha1
+  # Cluster checks
+  - name: ocp4-e8
+    kind: Profile
+    apiGroup: compliance.openshift.io/v1alpha1
+settingsRef:
+  name: my-companys-constraints
+  kind: ScanSetting
+  apiGroup: compliance.openshift.io/v1alpha1
+```
+Both `ScanSetting` and `ScanSettingBinding` objects are handled by the
+same controller tagged with `logger=scansettingbindingctrl`.  These objects
+have no status, any issues are communicated in form of events. On success,
+you'd see something like:
+```
+Events:
+  Type     Reason        Age    From                    Message
+  ----     ------        ----   ----                    -------
+  Normal   SuiteCreated  9m52s  scansettingbindingctrl  ComplianceSuite openshift-compliance/my-companys-compliance-requirements created
+```
+And a `ComplianceSuite` object is created. At that point, the flow continues
+to reconcile the newly created `ComplianceSuite`.
+
+## ComplianceSuite lifecycle and debugging
+The `ComplianceSuite` CR is mostly a wrapper around `ComplianceScan` CRs. The
+`ComplianceSuite` CR is handled by controller tagged with `logger=suitectrl`.
+This controller handles creating Scans from a Suite, reconciling and
+aggregating individual Scan statuses into a single Suite status. If a Suite
+is set to execute periodically, the `suitectrl` also handles creating a
+`CronJob` CR that re-runs the Scans in the Suite after the initial run
+is done:
+```shell
+oc get cronjobs
+NAME                                           SCHEDULE    SUSPEND   ACTIVE   LAST SCHEDULE   AGE
+my-companys-compliance-requirements-rerunner   0 1 * * *   False     0        <none>          151m
+```
+
+For the most important issues, Events are emitted, view them with `oc
+describe compliancesuites/$name`. The Suite objects also have a Status
+subresource that is updated when any of Scan objects that belong to
+this suite update their Status subresource (unless an error happens
+when processing the Suite itself before the Scans are created)
+
+As long as all expected scans are created, the control is handed over to
+the scan controller.
+
+## ComplianceScan lifecycle and debugging
+The `ComplianceScan` CRs are handled by the `scanctrl` controller. This
+is also where the actual scans happen and the scan results are created.
+Each scan goes through several phases:
+
+### Pending phase
+The scan is just validated for correctness in this phase. If some parameters
+like storage size are invalid, the scan transitions to DONE with ERROR result,
+otherwise proceeds to the Launching phase.
+
+### Launching phase
+In this phase, several `ConfigMaps` that contain either environment for the
+scanner pods or directly the script that the scanner pods will be evaluating.
+List the CMs with:
+```shell
+oc get cm -lcomplianceoperator.openshift.io/scan=$scan_name
+```
+e.g.:
+```shell
+oc get cm -lcomplianceoperator.openshift.io/scan=rhcos4-e8-worker
+```
+These `ConfigMaps` will be used by the scanner pods. If you ever needed to
+modify the scanner behaviour, change the scanner debug level or print the
+raw results, modifying the `ConfigMaps` is the way to go.
+
+Afterwards, a `PersistentVolumeClaim` is created per scan in order to store the
+raw ARF results:
+```
+oc get pvc -l$scan_name
+```
+Refer to the README for information on how to mount and read the ARF results.
+
+The PVCs are mounted by a per-scan `ResultServer` deployment. A
+`ResultServer` is a simple HTTP server where the individual scanner pods,
+each of which might be running on a different node, upload the full
+ARF results to. This might seem odd, but the full ARF results might be
+quite big and at the same time, without knowing details about the storage
+configured on the cluster, we can't presume that it would be possible
+to create a volume that could be mounted from multiple nodes at the same
+time. After the scan is finished, the `ResultServer` deployment is scaled
+down and the PVC with the raw results can be mounted from another custom
+pod and the results can be fetched or inspected. The traffic between the
+scanner pods and the `ResultServer` is protected by mutual TLS.
+
+Finally, the scanner pods are launched in this phase; one scanner pod for
+a `Platform` scan instance and one scanner pod per matching node for a
+`Node` scan instance. The per-node pods are labeled with the node name,
+each pod is always labeled with the `ComplianceScan` name, for example:
+```
+oc get pods -lcomplianceScan=rhcos4-e8-worker --show-labels
+NAME                                                              READY   STATUS      RESTARTS   AGE   LABELS
+rhcos4-e8-worker-ip-10-0-169-90.eu-north-1.compute.internal-pod   0/2     Completed   0          39m   complianceScan=rhcos4-e8-worker,targetNode=ip-10-0-169-90.eu-north-1.compute.internal
+```
+
+At this point, the scan proceeds to the Running phase.
+
+### Running phase
+The running phase simply waits until the scanner pods finish. In case you
+need to debug the scanner pods, it might be useful to learn what containers
+are running there -- when the scan itself is having issues, either the
+scanner pods or the artifacts it creates such as the resulting ConfigMaps
+might be a good place to start debugging:
+
+   * **init container**: There is one init container called
+     `content-container.` It runs the *contentImage* container and
+     executes a single command that copies the *contentFile* to the `/content`
+     directory shared with the other containers in this pod
+   * **openscap-ocp**: This container runs the actual scan. For Node scans, the container
+     mounts the node filesystem as `/host` and mounts the content delivered by the
+     init container. The container also mounts the `entrypoint`
+     `ConfigMap` created in the Launching phase and executes it. The default
+     script in the entrypoint `ConfigMap` executes openscap and stores the result
+     files in the `/results` directory shared between the pod's containers.
+     Logs from this pod, especially when the `debug` flag is enabled, allow
+     you to see what exactly did the openscap scanner check for.
+   * **logcollector**: The logcollector container waits until the openscap-ocp
+      container finishes. Then, it uploads the full ARF results to the
+      `ResultServer` and separately uploads the XCCDF results along with scan
+      result and openscap result code as a `ConfigMap.` These result configmaps
+      are labeled with the scan name (`compliance-scan=$scan_name`):
+      ```
+      $ oc describe cm/rhcos4-e8-worker-ip-10-0-169-90.eu-north-1.compute.internal-pod
+      Name:         rhcos4-e8-worker-ip-10-0-169-90.eu-north-1.compute.internal-pod
+      Namespace:    openshift-compliance
+      Labels:       compliance-scan=rhcos4-e8-worker
+      Annotations:  compliance-remediations/processed: 
+                    compliance.openshift.io/scan-error-msg: 
+                    compliance.openshift.io/scan-result: NON-COMPLIANT
+                    openscap-scan-result/node: ip-10-0-169-90.eu-north-1.compute.internal
+
+      Data
+      ====
+      exit-code:
+      ----
+      2
+      results:
+      ----
+      <?xml version="1.0" encoding="UTF-8"?>
+      ...
+
+      ```
+
+Scanner pods for `Platform` scans are similar, except:
+    * There is one extra init container called `api-resource-collector` that
+      reads the OpenScap content provided by the content-container init,
+      container, figures out which API resources the content needs to
+      examine and stores those API resources to a shared directory where the
+      openscap-ocp scanner pod would read them from.
+    * The openscap-ocp container does not need to mount the host filesystem
+
+When the scanner pods are done, the scans move on to the Aggregating phase.
+
+### Aggregating phase
+In the aggregating phase, the scan controller spawns yet another pod called
+the aggregator pod. Its purpose it to take the result `ConfigMap` objects,
+read the results and for each check result create the corresponding k8s
+object and, if the check failure can be automatically remediated, also creates
+a `ComplianceRemediation` object. In order to provide human-readable metadata
+for the checks and remediations, the aggregator pod also mounts the OpenScap
+content using an init container.
+
+When a `ConfigMap` is processed by an aggregator pod,it is labeled the
+`compliance-remediations/processed` label.
+
+The result of this phase are `ComplianceCheckResult` objects:
+```
+oc get compliancecheckresults -lcomplianceoperator.openshift.io/scan=rhcos4-e8-worker
+NAME                                                       STATUS   SEVERITY
+rhcos4-e8-worker-accounts-no-uid-except-zero               PASS     high
+rhcos4-e8-worker-audit-rules-dac-modification-chmod        FAIL     medium
+```
+and `ComplianceRemediation` objects:
+```
+oc get complianceremediations -lcomplianceoperator.openshift.io/scan=rhcos4-e8-worker
+NAME                                                       STATE
+rhcos4-e8-worker-audit-rules-dac-modification-chmod        NotApplied
+rhcos4-e8-worker-audit-rules-dac-modification-chown        NotApplied
+rhcos4-e8-worker-audit-rules-execution-chcon               NotApplied
+rhcos4-e8-worker-audit-rules-execution-restorecon          NotApplied
+rhcos4-e8-worker-audit-rules-execution-semanage            NotApplied
+rhcos4-e8-worker-audit-rules-execution-setfiles            NotApplied
+```
+
+Once these CRs are created, the aggregator pod exits and the scan
+moves on to the Done phase.
+
+### Done phase
+In the final scan phase, the scan resources are cleaned up if needed and the
+`ResultServer` deployment is either scaled down (if the scan was one-time)
+or deleted if the scan is continuous; the next scan instance would then
+recreate the deployment again.
+
+It is also possible to trigger a re-run of a scan in the Done phase by
+annotating it:
+```
+oc annotate compliancescans/rhcos4-e8-worker compliance.openshift.io/rescan=
+```
+
+After the scan reaches the Done phase, nothing else happens on its
+own unless the remediations are set to be applied automatically with
+`autoApplyRemediations=true`. Typically, the administrator would now review
+the remediations and apply them as needed.
+
+If the remediations are set to be applied automatically, the `ComplianceSuite`
+controller takes over in the Done phase, pauses the `MachineConfigPool` to
+which the scan maps to and applies all the remediations in one go.
+
+Either way, if a remediation is applied, the `ComplianceRemediation`
+controller takes over.
+
+## ComplianceRemediation lifecycle and debugging
+At this point, our example scan has reported some findings. We can enable
+one of the remediations by toggling its `apply` attribute to `true`:
+```
+oc patch complianceremediations/rhcos4-e8-worker-audit-rules-dac-modification-chmod --patch '{"spec":{"apply":true}}' --type=merge
+```
+
+The complianceremediation controller (`logger=remediationctrl`) reconciles
+the modified object. The result of the reconciliation is change of status of
+the remediation object that is reconciled, but also a change of the rendered
+per-suite `MachineConfig` object that contains all the applied remediations.
+
+The `MachineConfig` object always begins with `75-` and is named after the
+scan and the suite, in our case it would be:
+```
+oc get mc | grep 75-
+75-rhcos4-e8-worker-my-companys-compliance-requirements                                                2.2.0             2m46s
+```
+
+The remediations the MC currently consists of are listed in the MC's
+annotations:
+```
+oc describe mc/75-rhcos4-e8-worker-my-companys-compliance-requirements
+Name:         75-rhcos4-e8-worker-my-companys-compliance-requirements
+Labels:       machineconfiguration.openshift.io/role=worker
+Annotations:  remediation/rhcos4-e8-worker-audit-rules-dac-modification-chmod: 
+```
+
+The complianceremediation controller's algorithm works roughly like this:
+
+   * All currently applied remediations are read into an inital remediation
+     set
+   * If the reconciled remediation is supposed to be applied, it is added
+     to the set
+   * A `MachineConfig` object is rendered from the set and annotated with names
+     of remediations in the set. If the set is empty (the last remediation
+     was unapplied), the rendered MachineConfig object is removed.
+   * If and only if the rendered `MachineConfig` is different from the one
+     already applied in the cluster, the applied MC is updated (or created,
+     or deleted).
+   * Creating or modifying a MachineConfig object triggers a reboot of nodes
+     that match the `machineconfiguration.openshift.io/role` label - see the
+     MachineConfig Operator documentation for more details.
+
+The remediation loop ends once the rendered MachineConfig is updated, if needed,
+and the reconciled remediation object status is updated.
+
+In our case, applying the remediation would trigger a reboot. After that we can
+annotate the scan to re-run it:
+```
+oc annotate compliancescans/rhcos4-e8-worker compliance.openshift.io/rescan=
+```
+Afterwards, we can wait for the scan run to finish at which point the check for
+the remediation we applied should pass:
+```
+oc get compliancecheckresults/rhcos4-e8-worker-audit-rules-dac-modification-chmod
+NAME                                                  STATUS   SEVERITY
+rhcos4-e8-worker-audit-rules-dac-modification-chmod   PASS     medium
+```

--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -26,8 +26,7 @@ const (
 )
 
 const (
-	// ScanLabel defines the label that associates the Remediation with the scan
-	ScanLabel                = "complianceoperator.openshift.io/scan"
+	// OutdatedRemediationLabel specifies that the remediation has been superseded by a newer version
 	OutdatedRemediationLabel = "complianceoperator.openshift.io/outdated-remediation"
 )
 
@@ -96,7 +95,7 @@ func (r *ComplianceRemediation) GetSuite() string {
 }
 
 func (r *ComplianceRemediation) GetScan() string {
-	return r.Labels[ScanLabel]
+	return r.Labels[ComplianceScanLabel]
 }
 
 func (r *ComplianceRemediation) GetMcName() string {

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -14,12 +14,15 @@ import (
 // should be re-run
 const ComplianceScanRescanAnnotation = "compliance.openshift.io/rescan"
 
-// ComplianceScanIndicatorLabel serves as an indicator for which ComplianceScan
+// ComplianceScanLabel serves as an indicator for which ComplianceScan
 // owns the referenced object
-const ComplianceScanIndicatorLabel = "compliance-scan"
+const ComplianceScanLabel = "compliance.openshift.io/scan-name"
 
 // ScriptLabel defines that the object is a script for a scan object
 const ScriptLabel = "complianceoperator.openshift.io/scan-script"
+
+// ResultLabel defines that the object is a result of a scan
+const ResultLabel = "complianceoperator.openshift.io/scan-result"
 
 // ScanFinalizer is a finalizer for ComplianceScans. It gets automatically
 // added by the ComplianceScan controller in order to delete resources.

--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -260,7 +260,7 @@ func getApplicableMcList(r *ReconcileComplianceRemediation, instance *compv1alph
 
 	if instance.Spec.Apply == true {
 		scan := &compv1alpha1.ComplianceScan{}
-		scanKey := types.NamespacedName{Name: instance.Labels[compv1alpha1.ScanLabel], Namespace: instance.Namespace}
+		scanKey := types.NamespacedName{Name: instance.Labels[compv1alpha1.ComplianceScanLabel], Namespace: instance.Namespace}
 		if err := r.client.Get(context.TODO(), scanKey, scan); err != nil {
 			logger.Error(err, "Cannot get the scan for the remediation", "ComplianceScan.Name", scan.Name)
 			return appliedRemediations, err
@@ -305,7 +305,7 @@ func getAppliedMcRemediations(r *ReconcileComplianceRemediation, rem *compv1alph
 
 	scanSuiteSelector := make(map[string]string)
 	scanSuiteSelector[compv1alpha1.SuiteLabel] = rem.Labels[compv1alpha1.SuiteLabel]
-	scanSuiteSelector[compv1alpha1.ScanLabel] = rem.Labels[compv1alpha1.ScanLabel]
+	scanSuiteSelector[compv1alpha1.ComplianceScanLabel] = rem.Labels[compv1alpha1.ComplianceScanLabel]
 	scanSuiteSelector[mcfgv1.MachineConfigRoleLabelKey] = rem.Labels[mcfgv1.MachineConfigRoleLabelKey]
 
 	listOpts := client.ListOptions{

--- a/pkg/controller/complianceremediation/complianceremediation_controller_test.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Testing complianceremediation controller", func() {
 
 		testRemLabels = make(map[string]string)
 		testRemLabels[compv1alpha1.SuiteLabel] = "mySuite"
-		testRemLabels[compv1alpha1.ScanLabel] = "myScan"
+		testRemLabels[compv1alpha1.ComplianceScanLabel] = "myScan"
 		testRemLabels[mcfgv1.MachineConfigRoleLabelKey] = "myRole"
 
 		// test instance

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -25,7 +25,7 @@ func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Log
 	podName := getAggregatorPodName(scanInstance.Name)
 
 	podLabels := map[string]string{
-		"complianceScan": scanInstance.Name,
+		compv1alpha1.ComplianceScanLabel: scanInstance.Name,
 	}
 
 	return &corev1.Pod{

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -640,8 +640,8 @@ func getTargetNodes(r *ReconcileComplianceScan, instance *compv1alpha1.Complianc
 func (r *ReconcileComplianceScan) deleteScriptConfigMaps(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
 	inNs := client.InNamespace(common.GetComplianceOperatorNamespace())
 	withLabel := client.MatchingLabels{
-		compv1alpha1.ScanLabel:   instance.Name,
-		compv1alpha1.ScriptLabel: "",
+		compv1alpha1.ComplianceScanLabel: instance.Name,
+		compv1alpha1.ScriptLabel:         "",
 	}
 	err := r.client.DeleteAllOf(context.Background(), &corev1.ConfigMap{}, inNs, withLabel)
 	if err != nil {
@@ -652,7 +652,7 @@ func (r *ReconcileComplianceScan) deleteScriptConfigMaps(instance *compv1alpha1.
 
 func (r *ReconcileComplianceScan) deleteResultConfigMaps(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
 	inNs := client.InNamespace(common.GetComplianceOperatorNamespace())
-	withLabel := client.MatchingLabels{compv1alpha1.ComplianceScanIndicatorLabel: instance.Name}
+	withLabel := client.MatchingLabels{compv1alpha1.ComplianceScanLabel: instance.Name}
 	err := r.client.DeleteAllOf(context.Background(), &corev1.ConfigMap{}, inNs, withLabel)
 	if err != nil {
 		return err
@@ -818,7 +818,7 @@ func gatherResults(r *ReconcileComplianceScan, instance *compv1alpha1.Compliance
 	var checkList compv1alpha1.ComplianceCheckResultList
 	checkListOpts := client.MatchingLabels{
 		compv1alpha1.ComplianceCheckInconsistentLabel: "",
-		compv1alpha1.ScanLabel:                        instance.Name,
+		compv1alpha1.ComplianceScanLabel:              instance.Name,
 	}
 	if err := r.client.List(context.TODO(), &checkList, &checkListOpts); err != nil {
 		isReady = false

--- a/pkg/controller/compliancescan/config.go
+++ b/pkg/controller/compliancescan/config.go
@@ -180,8 +180,8 @@ func defaultOpenScapScriptCm(name string, scan *compv1alpha1.ComplianceScan) *co
 			Name:      name,
 			Namespace: common.GetComplianceOperatorNamespace(),
 			Labels: map[string]string{
-				compv1alpha1.ScanLabel:   scan.Name,
-				compv1alpha1.ScriptLabel: "",
+				compv1alpha1.ComplianceScanLabel: scan.Name,
+				compv1alpha1.ScriptLabel:         "",
 			},
 		},
 		Data: map[string]string{
@@ -196,8 +196,8 @@ func platformOpenScapScriptCm(name string, scan *compv1alpha1.ComplianceScan) *c
 			Name:      name,
 			Namespace: common.GetComplianceOperatorNamespace(),
 			Labels: map[string]string{
-				compv1alpha1.ScanLabel:   scan.Name,
-				compv1alpha1.ScriptLabel: "",
+				compv1alpha1.ComplianceScanLabel: scan.Name,
+				compv1alpha1.ScriptLabel:         "",
 			},
 		},
 		Data: map[string]string{
@@ -214,8 +214,8 @@ func defaultOpenScapEnvCm(name string, scan *compv1alpha1.ComplianceScan) *corev
 			Name:      name,
 			Namespace: common.GetComplianceOperatorNamespace(),
 			Labels: map[string]string{
-				compv1alpha1.ScanLabel:   scan.Name,
-				compv1alpha1.ScriptLabel: "",
+				compv1alpha1.ComplianceScanLabel: scan.Name,
+				compv1alpha1.ScriptLabel:         "",
 			},
 		},
 		Data: map[string]string{
@@ -251,8 +251,8 @@ func platformOpenScapEnvCm(name string, scan *compv1alpha1.ComplianceScan) *core
 			Name:      name,
 			Namespace: common.GetComplianceOperatorNamespace(),
 			Labels: map[string]string{
-				compv1alpha1.ScanLabel:   scan.Name,
-				compv1alpha1.ScriptLabel: "",
+				compv1alpha1.ComplianceScanLabel: scan.Name,
+				compv1alpha1.ScriptLabel:         "",
 			},
 		},
 		Data: map[string]string{

--- a/pkg/controller/compliancescan/rawresults.go
+++ b/pkg/controller/compliancescan/rawresults.go
@@ -69,7 +69,7 @@ func getPVCForScan(instance *compv1alpha1.ComplianceScan) *corev1.PersistentVolu
 			Name:      getPVCForScanName(instance.Name),
 			Namespace: common.GetComplianceOperatorNamespace(),
 			Labels: map[string]string{
-				"complianceScan": instance.Name,
+				compv1alpha1.ComplianceScanLabel: instance.Name,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -103,8 +103,8 @@ func (r *ReconcileComplianceScan) deleteResultServer(instance *compv1alpha1.Comp
 
 func getResultServerLabels(instance *compv1alpha1.ComplianceScan) map[string]string {
 	return map[string]string{
-		"complianceScan": instance.Name,
-		"app":            "resultserver",
+		compv1alpha1.ComplianceScanLabel: instance.Name,
+		"app":                            "resultserver",
 	}
 }
 

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -90,8 +90,8 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 	podName := getPodForNodeName(scanInstance.Name, node.Name)
 	cmName := getConfigMapForNodeName(scanInstance.Name, node.Name)
 	podLabels := map[string]string{
-		"complianceScan": scanInstance.Name,
-		"targetNode":     node.Name,
+		compv1alpha1.ComplianceScanLabel: scanInstance.Name,
+		"targetNode":                     node.Name,
 	}
 
 	return &corev1.Pod{
@@ -251,7 +251,7 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 	podName := getPodForNodeName(scanInstance.Name, PlatformScanName)
 	cmName := getConfigMapForNodeName(scanInstance.Name, PlatformScanName)
 	podLabels := map[string]string{
-		"complianceScan": scanInstance.Name,
+		compv1alpha1.ComplianceScanLabel: scanInstance.Name,
 	}
 	collectorCmd := []string{
 		"compliance-operator", "api-resource-collector",
@@ -588,7 +588,7 @@ func (r *ReconcileComplianceScan) reconcileReplicatedTailoringConfigMap(scan *co
 		if newCM.Labels == nil {
 			newCM.Labels = make(map[string]string)
 		}
-		newCM.Labels[compv1alpha1.ScanLabel] = scanName
+		newCM.Labels[compv1alpha1.ComplianceScanLabel] = scanName
 		newCM.Labels[compv1alpha1.ScriptLabel] = ""
 		if newCM.Data == nil {
 			newCM.Data = make(map[string]string)
@@ -616,7 +616,7 @@ func (r *ReconcileComplianceScan) reconcileReplicatedTailoringConfigMap(scan *co
 		if updatedCM.Labels == nil {
 			updatedCM.Labels = make(map[string]string)
 		}
-		updatedCM.Labels[compv1alpha1.ScanLabel] = scanName
+		updatedCM.Labels[compv1alpha1.ComplianceScanLabel] = scanName
 		updatedCM.Labels[compv1alpha1.ScriptLabel] = ""
 		updatedCM.Data["tailoring.xml"] = origData
 		logger.Info("Updating private Tailoring ConfigMap", "ConfigMap.Name", privName, "ConfigMap.Namespace", privNs)

--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -445,7 +445,7 @@ func (r *ReconcileComplianceSuite) reconcileRemediations(suite *compv1alpha1.Com
 		if suite.Spec.AutoApplyRemediations {
 			// get relevant scan
 			scan := &compv1alpha1.ComplianceScan{}
-			scanKey := types.NamespacedName{Name: rem.Labels[compv1alpha1.ScanLabel], Namespace: rem.Namespace}
+			scanKey := types.NamespacedName{Name: rem.Labels[compv1alpha1.ComplianceScanLabel], Namespace: rem.Namespace}
 			if err := r.client.Get(context.TODO(), scanKey, scan); err != nil {
 				return reconcile.Result{}, err
 			}

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -610,7 +610,7 @@ func getNodesWithSelector(f *framework.Framework, labelselector map[string]strin
 
 func getPodsForScan(f *framework.Framework, scanName string) ([]corev1.Pod, error) {
 	selectPods := map[string]string{
-		"complianceScan": scanName,
+		compv1alpha1.ComplianceScanLabel: scanName,
 	}
 	var pods corev1.PodList
 	lo := &client.ListOptions{
@@ -627,7 +627,8 @@ func getPodsForScan(f *framework.Framework, scanName string) ([]corev1.Pod, erro
 func getConfigMapsFromScan(f *framework.Framework, scaninstance *compv1alpha1.ComplianceScan) []corev1.ConfigMap {
 	var configmaps corev1.ConfigMapList
 	labelselector := map[string]string{
-		compv1alpha1.ComplianceScanIndicatorLabel: scaninstance.Name,
+		compv1alpha1.ComplianceScanLabel: scaninstance.Name,
+		compv1alpha1.ResultLabel: "",
 	}
 	lo := &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labelselector),
@@ -660,7 +661,7 @@ func assertHasCheck(f *framework.Framework, suiteName, scanName string, check co
 		return fmt.Errorf("Did not find expected suite name label %s, found %s", suiteName, getCheck.Labels[compv1alpha1.SuiteLabel])
 	}
 
-	if getCheck.Labels[compv1alpha1.ScanLabel] != scanName {
+	if getCheck.Labels[compv1alpha1.ComplianceScanLabel] != scanName {
 		return fmt.Errorf("Did not find expected suite name label %s, found %s", suiteName, getCheck.Labels[compv1alpha1.SuiteLabel])
 	}
 
@@ -680,7 +681,7 @@ func getRemediationsFromScan(f *framework.Framework, suiteName, scanName string)
 
 	scanSuiteSelector := make(map[string]string)
 	scanSuiteSelector[compv1alpha1.SuiteLabel] = suiteName
-	scanSuiteSelector[compv1alpha1.ScanLabel] = scanName
+	scanSuiteSelector[compv1alpha1.ComplianceScanLabel] = scanName
 
 	listOpts := client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(scanSuiteSelector),


### PR DESCRIPTION
Adds a markdown document that adds some general troubleshooting tips
as well as describes a flow of a Suite and a Remediations, which should
hopefully make it easier for users to understand how the operator works.