### PR TITLE
Deprecate Type field from ComplianceRemediation object

### DIFF
--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -32,8 +32,6 @@ const (
 )
 
 type ComplianceRemediationSpecMeta struct {
-	// Remediation type specifies the artifact the remediation is based on. For now, only MachineConfig is supported
-	Type RemediationType `json:"type,omitempty"`
 	// Whether the remediation should be picked up and applied by the operator
 	Apply bool `json:"apply"`
 }

--- a/pkg/utils/parse_arf_result.go
+++ b/pkg/utils/parse_arf_result.go
@@ -256,7 +256,6 @@ func remediationFromString(scheme *runtime.Scheme, name string, namespace string
 		},
 		Spec: compv1alpha1.ComplianceRemediationSpec{
 			ComplianceRemediationSpecMeta: compv1alpha1.ComplianceRemediationSpecMeta{
-				Type:  compv1alpha1.McRemediation,
 				Apply: false,
 			},
 			Current: compv1alpha1.ComplianceRemediationPayload{

--- a/pkg/utils/remediation_diff_test.go
+++ b/pkg/utils/remediation_diff_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+
 	"github.com/clarketm/json"
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	. "github.com/onsi/ginkgo"
@@ -62,7 +63,6 @@ func getRemediation(serviceName string) *compv1alpha1.ComplianceRemediation {
 		},
 		Spec: compv1alpha1.ComplianceRemediationSpec{
 			ComplianceRemediationSpecMeta: compv1alpha1.ComplianceRemediationSpecMeta{
-				Type:  compv1alpha1.McRemediation,
 				Apply: false,
 			},
 			Current: compv1alpha1.ComplianceRemediationPayload{


### PR DESCRIPTION
We shouldn't ship with deprecated values. This is not used anywhere.