### PR TITLE
profileparser: Close XML file when run has ended

### DIFF
--- a/cmd/manager/profileparser.go
+++ b/cmd/manager/profileparser.go
@@ -141,13 +141,14 @@ func runProfileParser(cmd *cobra.Command, args []string) {
 		updateProfileBundleStatus(pcfg, pb, fmt.Errorf("Couldn't read content file: %s", err))
 		os.Exit(1)
 	}
-	// #nosec
-	defer contentFile.Close()
 	bufContentFile := bufio.NewReader(contentFile)
 	contentDom, err := xmldom.Parse(bufContentFile)
 	if err != nil {
 		log.Error(err, "Couldn't read the content XML")
 		updateProfileBundleStatus(pcfg, pb, fmt.Errorf("Couldn't read content XML: %s", err))
+		if closeErr := contentFile.Close(); closeErr != nil {
+			log.Error(err, "Couldn't close the content file")
+		}
 		os.Exit(1)
 	}
 
@@ -156,6 +157,10 @@ func runProfileParser(cmd *cobra.Command, args []string) {
 	// The err variable might be nil, this is fine, it'll just update the status
 	// to valid
 	updateProfileBundleStatus(pcfg, pb, err)
+
+	if closeErr := contentFile.Close(); closeErr != nil {
+		log.Error(err, "Couldn't close the content file")
+	}
 
 	<-exitSignal
 }

--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"regexp"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	cmpv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/openshift/compliance-operator/pkg/xccdf"


### PR DESCRIPTION
The file was left lingering open for the rest of the duration of the
run... so let's close it explicitly instead of relying on the defer
which will never run.