### PR TITLE
Ignore deploy/ directory when building the container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ build/_output
 build/_test
 _output
 README.md
+deploy/


### PR DESCRIPTION
This is done by adding that entry to the .dockerignore file