### PR TITLE
Detect if scan is unschedulable

### DIFF
--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -169,9 +169,9 @@ func getScanResult(cm *v1.ConfigMap) (compv1alpha1.ComplianceScanStatusResult, s
 	exitcode, ok := cm.Data["exit-code"]
 	if ok {
 		switch exitcode {
-		case "0":
+		case common.OpenSCAPExitCodeCompliant:
 			return compv1alpha1.ResultCompliant, ""
-		case "2":
+		case common.OpenSCAPExitCodeNonCompliant:
 			return compv1alpha1.ResultNonCompliant, ""
 		default:
 			errorMsg, ok := cm.Data["error-msg"]

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -8,6 +8,15 @@ import (
 
 var complianceOperatorNamespace = "openshift-compliance"
 
+const (
+	// OpenSCAPExitCodeCompliant defines a success coming from OpenSCAP
+	OpenSCAPExitCodeCompliant string = "0"
+	// OpenSCAPExitCodeNonCompliant defines a non-compliance error coming from OpenSCAP
+	OpenSCAPExitCodeNonCompliant string = "2"
+	// PodUnschedulableExitCode is a custom error that indicates that we couldn't schedule the pod
+	PodUnschedulableExitCode string = "unschedulable"
+)
+
 func init() {
 	if isRunModeLocal() {
 		ns, ok := os.LookupEnv("OPERATOR_NAMESPACE")

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -626,16 +626,13 @@ func (r *ReconcileComplianceScan) reconcileReplicatedTailoringConfigMap(scan *co
 	return nil
 }
 
-func checkScanError(cm *corev1.ConfigMap) error {
+func checkScanUnknownError(cm *corev1.ConfigMap) error {
 	exitcode, ok := cm.Data["exit-code"]
 	if !ok {
 		return fmt.Errorf("the ConfigMap '%s' was missing 'exit-code'", cm.Name)
 	}
 
-	// 0: compliant
-	// 2: non-compliant
-	// anything else is treated as an error
-	if exitcode != "0" && exitcode != "2" {
+	if exitcode != common.OpenSCAPExitCodeCompliant && exitcode != common.OpenSCAPExitCodeNonCompliant && exitcode != common.PodUnschedulableExitCode {
 		errorMsg, ok := cm.Data["error-msg"]
 		if ok {
 			return fmt.Errorf(errorMsg)

--- a/pkg/controller/compliancescan/utils.go
+++ b/pkg/controller/compliancescan/utils.go
@@ -2,6 +2,7 @@ package compliancescan
 
 import (
 	"context"
+	"fmt"
 	"path"
 
 	// we can suppress the gosec warning about sha1 here because we don't use sha1 for crypto
@@ -30,6 +31,21 @@ const (
 	RootCAPrefix                 = "root-ca-"
 	CertValidityDays             = 1
 )
+
+// New returns an error that formats as the given text.
+func newPodUnschedulableError(pod, msg string) error {
+	return &podUnschedulableError{pod, msg}
+}
+
+// podUnschedulableError represents an error that tells us that a node couldn't be scheduled
+type podUnschedulableError struct {
+	pod string
+	msg string
+}
+
+func (e *podUnschedulableError) Error() string {
+	return fmt.Sprintf("Couldn't schedule scan pod '%s': %s", e.pod, e.msg)
+}
 
 func absContentPath(relContentPath string) string {
 	return path.Join("/content/", relContentPath)

--- a/pkg/profileparser/profileparser_test.go
+++ b/pkg/profileparser/profileparser_test.go
@@ -163,7 +163,7 @@ func init() {
 
 var _ = Describe("Testing ParseBundle", func() {
 	const (
-		moderateProfileName = "test-profile-moderate"
+		moderateProfileName        = "test-profile-moderate"
 		moderateAnotherProfileName = "test-anotherprofile-moderate"
 
 		chronydClientOnlyRuleName = "test-profile-chronyd-client-only"

--- a/pkg/utils/resultconfigmap.go
+++ b/pkg/utils/resultconfigmap.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"encoding/base64"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/openshift/compliance-operator/pkg/controller/common"
+)
+
+func encodetoBase64(str []byte) string {
+	return base64.StdEncoding.EncodeToString(str)
+}
+
+// GetResultConfigMap gets a configmap that reflects a result or an error for a scan
+func GetResultConfigMap(owner metav1.Object, configMapName, filename, nodeName string, contents []byte, compressed bool, exitcode string) *corev1.ConfigMap {
+	var strcontents string
+	annotations := map[string]string{}
+	if compressed {
+		annotations = map[string]string{
+			"openscap-scan-result/compressed": "",
+		}
+		strcontents = encodetoBase64(contents)
+	} else {
+		strcontents = string(contents)
+	}
+	if nodeName != "" {
+		annotations["openscap-scan-result/node"] = nodeName
+	}
+
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        configMapName,
+			Namespace:   common.GetComplianceOperatorNamespace(),
+			Annotations: annotations,
+			Labels: map[string]string{
+				compv1alpha1.ComplianceScanLabel: owner.GetName(),
+				compv1alpha1.ResultLabel:         "",
+			},
+		},
+		Data: map[string]string{
+			"exit-code": exitcode,
+			filename:    strcontents,
+		},
+	}
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1312,6 +1312,63 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
+			Name:       "TestNodeSchedulingErrorFailsTheScan",
+			IsParallel: false,
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
+				workerNodesLabel := map[string]string{
+					"node-role.kubernetes.io/worker": "",
+				}
+				workerNodes := getNodesWithSelector(f, workerNodesLabel)
+
+				taintedNode := &workerNodes[0]
+				taintKey := "co-e2e"
+				taintVal := "val"
+				taint := corev1.Taint{
+					Key:    taintKey,
+					Value:  taintVal,
+					Effect: corev1.TaintEffectNoSchedule,
+				}
+				if err := taintNode(t, f, taintedNode, taint); err != nil {
+					E2ELog(t, "Tainting node failed")
+					return err
+				}
+				suiteName := getObjNameFromTest(t)
+				scanName := suiteName
+				suite := &compv1alpha1.ComplianceSuite{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      suiteName,
+						Namespace: namespace,
+					},
+					Spec: compv1alpha1.ComplianceSuiteSpec{
+						Scans: []compv1alpha1.ComplianceScanSpecWrapper{
+							{
+								ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
+									ContentImage: contentImagePath,
+									Profile:      "xccdf_org.ssgproject.content_profile_moderate",
+									Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
+									Content:      rhcosContentFile,
+									NodeSelector: workerNodesLabel,
+									ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
+										Debug: true,
+									},
+								},
+								Name: scanName,
+							},
+						},
+					},
+				}
+				if err := f.Client.Create(goctx.TODO(), suite, getCleanupOpts(ctx)); err != nil {
+					return err
+				}
+
+				err := waitForSuiteScansStatus(t, f, namespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultError)
+				if err != nil {
+					return err
+				}
+				return removeNodeTaint(t, f, taintedNode.Name, taintKey)
+			},
+		},
+		testExecution{
 			Name:       "TestScanSettingBinding",
 			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {


### PR DESCRIPTION
If a pod (or more) is not schedulable in the scan due to a taint or
another scheduling issue, we detect this and issue partial results;
however, an error is persisted as the ultimate result of the scan.

This is done by creating a configMap (as the log-collector would do)
that contains a status that the node didn't get a scan due to it being
unschedulable, and adding the pod's condition as an error message.

This also changes how the aggregator is scheduled, as it now only gets
skipped if there's an unknown error.