### PR TITLE
Clean up suite-rerunner pods if suite is deleted

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -6,7 +6,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods        # Pods are used to run the compliance container
   - persistentvolumeclaims
   - persistentvolumes
   verbs:
@@ -18,6 +17,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods        # Pods are used to run the compliance container
   - configmaps  # The log collecting sidecar uses configmaps to store results
   - events
   verbs:

--- a/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
@@ -1,14 +1,19 @@
 package v1alpha1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // SuiteLabel indicates that an object (normally the ComplianceScan
 // or a ComplianceRemediation) belongs to a certain ComplianceSuite.
 // This is an easy way to filter them.
 const SuiteLabel = "compliance.openshift.io/suite"
+
+// SuiteScriptLabel indicates that the object is a script belonging to the
+// compliance suite controller
+const SuiteScriptLabel = "compliance.openshift.io/suite-script"
 
 // SuiteFinalizer is a finalizer for ComplianceSuites. It gets automatically
 // added by the ComplianceSuite controller in order to delete resources.

--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -156,6 +156,16 @@ func (r *ReconcileComplianceSuite) suiteDeleteHandler(suite *compv1alpha1.Compli
 		return err
 	}
 
+	inNs := client.InNamespace(common.GetComplianceOperatorNamespace())
+	withLabel := client.MatchingLabels{
+		compv1alpha1.SuiteLabel:       suite.Name,
+		compv1alpha1.SuiteScriptLabel: "",
+	}
+	err = r.client.DeleteAllOf(context.Background(), &corev1.Pod{}, inNs, withLabel)
+	if err != nil {
+		return err
+	}
+
 	suiteCopy := suite.DeepCopy()
 	// remove our finalizer from the list and update it.
 	suiteCopy.ObjectMeta.Finalizers = common.RemoveFinalizer(suiteCopy.ObjectMeta.Finalizers, compv1alpha1.SuiteFinalizer)

--- a/pkg/controller/compliancesuite/suitererunner.go
+++ b/pkg/controller/compliancesuite/suitererunner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/openshift/compliance-operator/pkg/controller/common"
 	"github.com/robfig/cron"
 	batchv1 "k8s.io/api/batch/v1"
@@ -14,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/openshift/compliance-operator/pkg/utils"
 )
 
@@ -91,6 +91,12 @@ func getRerunner(suite *compv1alpha1.ComplianceSuite) *batchv1beta1.CronJob {
 			JobTemplate: batchv1beta1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								compv1alpha1.SuiteLabel:       suite.Name,
+								compv1alpha1.SuiteScriptLabel: "",
+							},
+						},
 						Spec: corev1.PodSpec{
 							ServiceAccountName: rerunnerServiceAccount,
 							RestartPolicy:      corev1.RestartPolicyOnFailure,


### PR DESCRIPTION
The CronJob object doesn't fully clean up all objects; so we need to do
that ourselves.