### PR TITLE
Don't crash the api-resource-collector if no checks are found

### DIFF
--- a/cmd/manager/scap.go
+++ b/cmd/manager/scap.go
@@ -112,7 +112,7 @@ func openNonEmptyFile(filename string) (*os.File, error) {
 func (c *scapContentDataStream) FigureResources(profile string) error {
 	found := getResourcePaths(c.dataStream, profile)
 	if len(found) == 0 {
-		return fmt.Errorf("no checks found in datastream")
+		fmt.Printf("no valid checks found in datastream\n")
 	}
 	// Always stage the clusteroperators/openshift-apiserver object for version detection.
 	paths := []string{"/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver"}


### PR DESCRIPTION
the api-resource-collector used to crash if it found no rules to
check... This makes the run problematic as it'll enter a
CrashLoopBackOff state; so no results will be given.

Ultimately we want to evaluate the scan, even if it's just informative,
and give results from that.