### PR TITLE
Enable Compliance Operator development on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,15 @@ RELATED_IMAGE_OPENSCAP_NAME=openscap-ocp
 # Container image variables
 # =========================
 IMAGE_REPO?=quay.io/compliance-operator
-RUNTIME?=podman
+
+# Detect the OS to set per-OS defaults
+OS_NAME=$(shell uname -s)
+# Container runtime
+ifeq ($(OS_NAME), Linux)
+    RUNTIME?=podman
+else ifeq ($(OS_NAME), Darwin)
+    RUNTIME?=docker
+endif
 
 # Temporary
 OPENSCAP_DEFAULT_IMAGE_TAG=1.3.3

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ RELATED_IMAGE_OPENSCAP_TAG?=$(OPENSCAP_DEFAULT_IMAGE_TAG)
 # the cluster or if we're on CI.
 RELATED_IMAGE_OPERATOR_PATH?=$(IMAGE_REPO)/$(APP_NAME)
 RELATED_IMAGE_OPENSCAP_PATH=$(IMAGE_REPO)/$(RELATED_IMAGE_OPENSCAP_NAME)
-OPENSCAP_DOCKERFILE_PATH=./images/openscap/Dockerfile
+OPENSCAP_DOCKER_CONTEXT=./images/openscap
 
 # Image tag to use. Set this if you want to use a specific tag for building
 # or your e2e tests.
@@ -114,7 +114,7 @@ operator-image: operator-sdk
 
 .PHONY: openscap-image
 openscap-image:
-	$(RUNTIME) build -f $(OPENSCAP_DOCKERFILE_PATH) -t $(RELATED_IMAGE_OPENSCAP_PATH):$(TAG)
+	$(RUNTIME) build -t $(RELATED_IMAGE_OPENSCAP_PATH):$(TAG) $(OPENSCAP_DOCKER_CONTEXT)
 
 .PHONY: build
 build: fmt manager ## Build the compliance-operator binary

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,11 @@ export OPERATOR_NAMESPACE?=openshift-compliance
 # Operator-sdk variables
 # ======================
 SDK_VERSION?=v0.18.2
-OPERATOR_SDK_URL=https://github.com/operator-framework/operator-sdk/releases/download/$(SDK_VERSION)/operator-sdk-$(SDK_VERSION)-x86_64-linux-gnu
+ifeq ($(OS_NAME), Linux)
+    OPERATOR_SDK_URL=https://github.com/operator-framework/operator-sdk/releases/download/$(SDK_VERSION)/operator-sdk-$(SDK_VERSION)-x86_64-linux-gnu
+else ifeq ($(OS_NAME), Darwin)
+    OPERATOR_SDK_URL=https://github.com/operator-framework/operator-sdk/releases/download/$(SDK_VERSION)/operator-sdk-$(SDK_VERSION)-x86_64-apple-darwin
+endif
 
 # Test variables
 # ==============

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /go/src/github.com/openshift/compliance-operator
 
 ENV GOFLAGS=-mod=vendor
 
-COPY . .
+COPY --chown=default:root . .
 RUN make manager
 
 # Step two: containerize compliance-operator

--- a/pkg/utils/directory.go
+++ b/pkg/utils/directory.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"syscall"
+	"time"
+)
+
+// Directory is a holding struct used to sort directories by time
+type Directory struct {
+	CreationTime time.Time
+	Path         string
+}
+
+func timespecToTime(ts syscall.Timespec) time.Time {
+	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
+}

--- a/pkg/utils/directory_darwin.go
+++ b/pkg/utils/directory_darwin.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"os"
+	"syscall"
+)
+
+func NewDirectory(path string, info os.FileInfo) Directory {
+	statinfo := info.Sys().(*syscall.Stat_t)
+	return Directory{
+		CreationTime: timespecToTime(statinfo.Ctimespec),
+		Path:         path,
+	}
+}

--- a/pkg/utils/directory_linux.go
+++ b/pkg/utils/directory_linux.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"os"
+	"syscall"
+)
+
+func NewDirectory(path string, info os.FileInfo) Directory {
+	statinfo := info.Sys().(*syscall.Stat_t)
+	return Directory{
+		CreationTime: timespecToTime(statinfo.Ctim),
+		Path:         path,
+	}
+}


### PR DESCRIPTION
This is a result of last week's "Hack'n'Hustle day". I thought that since
many developers in the cloud world use macs and we definitely want to enable
outside contributions, we should make it possible to do at least the very
basic things on a Mac. The intent is not for the operator to run on a Mac,
but at least be able to compile, test and create images from a Mac.

This patchset enables the basic "make" targets like "make all", "make
test-unit", "make image" etc. I haven't tested all targets but I didn't
see anything incompatible in them either.

tl;dr the patches use docker by default on macOS, remove some podman-specific
usage and provide a compat wrapper for one Linux-only codepath. Please see
the commit messages for more details.