### PR TITLE
Rename aggregatedPhase and aggregatedResult to just Phase and Result

### DIFF
--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -12,10 +12,10 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.aggregatedPhase
+    - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .status.aggregatedResult
+    - jsonPath: .status.result
       name: Result
       type: string
     name: v1alpha1
@@ -200,13 +200,13 @@ spec:
           status:
             description: Contains the current state of the suite
             properties:
-              aggregatedPhase:
+              errorMessage:
+                type: string
+              phase:
                 description: Represents the status of the compliance scan run.
                 type: string
-              aggregatedResult:
+              result:
                 description: Represents the result of the compliance scan
-                type: string
-              errorMessage:
                 type: string
               scanStatuses:
                 items:

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -33,8 +33,8 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
 status:
-  aggregatedPhase: DONE
-  aggregatedResult: NON-COMPLIANT
+  Phase: DONE
+  Result: NON-COMPLIANT
   scanStatuses:
   - name: workers-scan
     phase: DONE
@@ -47,9 +47,9 @@ In the `spec`:
 * **scans** contains a list of scan specifications to run in the cluster.
 
 In the `status`:
-* **aggregatedPhase**: indicates the overall phase where the scans are at. To
+* **Phase**: indicates the overall phase where the scans are at. To
   get the results you normally have to wait for the overall phase to be `DONE`.
-* **aggregatedResult**: Is the overall verdict of the suite.
+* **Result**: Is the overall verdict of the suite.
 * **scanStatuses**: Will contain the status for each of the scans that the
   suite is tracking.
 

--- a/doc/remediation-flow.md
+++ b/doc/remediation-flow.md
@@ -70,8 +70,8 @@ spec:
       node-role.kubernetes.io/master: ""
     profile: xccdf_org.ssgproject.content_profile_coreos-ncp
 status:
-  aggregatedPhase: DONE
-  aggregatedResult: NON-COMPLIANT
+  Phase: DONE
+  Result: NON-COMPLIANT
   scanStatuses:
   - name: workers-scan
     phase: DONE

--- a/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
@@ -83,10 +83,10 @@ type ComplianceSuiteSpec struct {
 // +k8s:openapi-gen=true
 type ComplianceSuiteStatus struct {
 	// +listType=atomic
-	ScanStatuses     []ComplianceScanStatusWrapper `json:"scanStatuses"`
-	AggregatedPhase  ComplianceScanStatusPhase     `json:"aggregatedPhase,omitempty"`
-	AggregatedResult ComplianceScanStatusResult    `json:"aggregatedResult,omitempty"`
-	ErrorMessage     string                        `json:"errorMessage,omitempty"`
+	ScanStatuses []ComplianceScanStatusWrapper `json:"scanStatuses"`
+	Phase        ComplianceScanStatusPhase     `json:"phase,omitempty"`
+	Result       ComplianceScanStatusResult    `json:"result,omitempty"`
+	ErrorMessage string                        `json:"errorMessage,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -96,8 +96,8 @@ type ComplianceSuiteStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=compliancesuites,scope=Namespaced
-// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=`.status.aggregatedPhase`
-// +kubebuilder:printcolumn:name="Result",type="string",JSONPath=`.status.aggregatedResult`
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Result",type="string",JSONPath=`.status.result`
 type ComplianceSuite struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -508,14 +508,14 @@ func waitForSuiteScansStatus(t *testing.T, f *framework.Framework, namespace, na
 			return false, nil
 		}
 
-		if suite.Status.AggregatedPhase != targetStatus {
-			E2ELogf(t, "Waiting until suite %s reaches target status '%s'. Current status: %s", suite.Name, targetStatus, suite.Status.AggregatedPhase)
+		if suite.Status.Phase != targetStatus {
+			E2ELogf(t, "Waiting until suite %s reaches target status '%s'. Current status: %s", suite.Name, targetStatus, suite.Status.Phase)
 			return false, nil
 		}
 
 		// The suite is now done, make sure the compliance status is expected
-		if suite.Status.AggregatedResult != targetComplianceStatus {
-			return false, fmt.Errorf("expecting %s got %s", targetComplianceStatus, suite.Status.AggregatedResult)
+		if suite.Status.Result != targetComplianceStatus {
+			return false, fmt.Errorf("expecting %s got %s", targetComplianceStatus, suite.Status.Result)
 		}
 
 		// If we were expecting an error, there's no use checking the scans


### PR DESCRIPTION
The OCP console currently does not honor additionalPrinterColumns. Instead, the console looks for one of hardcoded attributes:
        - status.phase
        - status.status
        - status.state
        - status.conditions
to support displaying the suite status in the same way we display the Scan status - for scans we already have status.phase, for suites we used to have status.aggregatedPhase. This patch uses status.phase for the  phase aggregated from scans to suite.

Jira: OCPBUGSM-8550