### PR TITLE
Operator deployment: Change replicas to only deploy one

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: compliance-operator
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       name: compliance-operator


### PR DESCRIPTION
There is no reason why we would need 3 replicas of the operator running
at the same time. One is enough. The Deployment will ensure it's running
in case a crash happens.