### PR TITLE
Workaround: Only use profileparser as an init container

### DIFF
--- a/cmd/manager/pause.go
+++ b/cmd/manager/pause.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+var pauseCmd = &cobra.Command{
+	Use:   "pause",
+	Short: "A command that simply pauses",
+	Long:  `Pauses and waits for the SIGTERM signal`,
+	Run:   pause,
+}
+
+func init() {
+	rootCmd.AddCommand(pauseCmd)
+}
+
+func pause(cmd *cobra.Command, args []string) {
+	exitSignal := make(chan os.Signal, 1)
+	signal.Notify(exitSignal, syscall.SIGINT, syscall.SIGTERM)
+
+	<-exitSignal
+}

--- a/cmd/manager/pause.go
+++ b/cmd/manager/pause.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/spf13/cobra"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var pauseCmd = &cobra.Command{
@@ -17,11 +20,24 @@ var pauseCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(pauseCmd)
+	definePauserFlags(pauseCmd)
+}
+
+func definePauserFlags(cmd *cobra.Command) {
+	cmd.Flags().String("main-container", "", "The main container you should be checking the logs for")
+
+	flags := cmd.Flags()
+	flags.AddFlagSet(zap.FlagSet())
 }
 
 func pause(cmd *cobra.Command, args []string) {
 	exitSignal := make(chan os.Signal, 1)
 	signal.Notify(exitSignal, syscall.SIGINT, syscall.SIGTERM)
+
+	ct := getValidStringArg(cmd, "main-container")
+	logf.SetLogger(zap.Logger())
+
+	log.Info(fmt.Sprintf("This is merely a 'pause' container. You should instead check the logs of: %s", ct))
 
 	<-exitSignal
 }

--- a/cmd/manager/profileparser.go
+++ b/cmd/manager/profileparser.go
@@ -6,8 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -124,8 +122,6 @@ func updateProfileBundleStatus(pcfg *profileparser.ParserConfig, pb *cmpv1alpha1
 }
 
 func runProfileParser(cmd *cobra.Command, args []string) {
-	exitSignal := make(chan os.Signal, 1)
-	signal.Notify(exitSignal, syscall.SIGINT, syscall.SIGTERM)
 	pcfg := newParserConfig(cmd)
 
 	pb, err := getProfileBundle(pcfg)
@@ -161,6 +157,4 @@ func runProfileParser(cmd *cobra.Command, args []string) {
 	if closeErr := contentFile.Close(); closeErr != nil {
 		log.Error(err, "Couldn't close the content file")
 	}
-
-	<-exitSignal
 }

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -264,6 +264,7 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle) *appsv1.Deployme
 							Image: utils.GetComponentImage(utils.OPERATOR),
 							Command: []string{
 								"compliance-operator", "pause",
+								"--main-container", "profileparser",
 							},
 						},
 					},


### PR DESCRIPTION
The profileparser pod takes a lot of resources and doesn't let them
go... This shows up as excessive resource usage in the monitoring
dashboard (up to 400MiB).

By changing that profileparser to be an init container, as opposed to a
daemon, the parser process will end and the resources will be freed. The
daemon bit will now be a "pauser" container, which merely waits for a
kill signal. This way, this container takes a very minimal amount of
resources and it keeps running as is needed by the kubernetes' Deployment
that manages it.