### PR TITLE
Fix memory leak in profileparser

### DIFF
--- a/pkg/profileparser/profileparser_test.go
+++ b/pkg/profileparser/profileparser_test.go
@@ -2,6 +2,7 @@ package profileparser
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
@@ -565,7 +566,8 @@ var _ = Describe("Testing parse rules", func() {
 			return nil
 		}
 
-		err := ParseRulesAndDo(pInput.contentDom, pInput.pb, ruleAdder)
+		stdParser := newStandardParser()
+		err := ParseRulesAndDo(pInput.contentDom, stdParser, pInput.pb, ruleAdder)
 		Expect(err).To(BeNil())
 	})
 


### PR DESCRIPTION
The reference parser is initialized as a global variable and allocated
in the profileparser's package init function.

While this works nicely for the profileparser subcommand, it does this
for every workload since we compile the subcommands together. This
causes a memory leak since the parser stays allocated and in memory.

This is fixed by adding the initialization as part of the
`newStandardParser()` function, and calling that explicitly where it's
needed.