### PR TITLE
WIP: Dump operator installation YAMLs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,0 @@
-# Exclude test files
-*_test.go
-tests/
-.git/
-build/_output
-build/_test
-_output
-README.md
-deploy/

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=compliance-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+
+COPY deploy/olm-catalog/compliance-operator/manifests /manifests/
+COPY deploy/olm-catalog/compliance-operator/metadata /metadata/

--- a/deploy/olm-catalog/catalog-source.yaml
+++ b/deploy/olm-catalog/catalog-source.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: compliance-operator
+  namespace: openshift-marketplace
+spec:
+  displayName: Compliance Operator Upstream
+  publisher: github.com/openshift/compliance-operator
+  sourceType: grpc
+  # FIXME: CO namespace
+  image: quay.io/jhrozek/compliance-operator-index:test

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1,0 +1,1285 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "compliance.openshift.io/v1alpha1",
+          "kind": "ComplianceScan",
+          "metadata": {
+            "name": "example-compliancescan"
+          },
+          "spec": {
+            "content": "ssg-rhcos4-ds.xml",
+            "profile": "xccdf_org.ssgproject.content_profile_moderate"
+          }
+        },
+        {
+          "apiVersion": "compliance.openshift.io/v1alpha1",
+          "kind": "ComplianceScan",
+          "metadata": {
+            "name": "example-compliancescan"
+          },
+          "spec": {
+            "content": "ssg-ocp4-ds.xml",
+            "profile": "xccdf_org.ssgproject.content_profile_moderate",
+            "scanType": "Platform"
+          }
+        },
+        {
+          "apiVersion": "compliance.openshift.io/v1alpha1",
+          "kind": "ComplianceSuite",
+          "metadata": {
+            "name": "example-compliancesuite"
+          },
+          "spec": {
+            "autoApplyRemediations": false,
+            "scans": [
+              {
+                "content": "ssg-rhcos4-ds.xml",
+                "contentImage": "quay.io/complianceascode/ocp4:latest",
+                "name": "workers-scan",
+                "nodeSelector": {
+                  "node-role.kubernetes.io/worker": ""
+                },
+                "profile": "xccdf_org.ssgproject.content_profile_moderate"
+              },
+              {
+                "content": "ssg-ocp4-ds.xml",
+                "contentImage": "quay.io/complianceascode/ocp4:latest",
+                "name": "platform-scan",
+                "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                "scanType": "Platform"
+              }
+            ],
+            "schedule": "0 1 * * *"
+          }
+        },
+        {
+          "apiVersion": "compliance.openshift.io/v1alpha1",
+          "kind": "ProfileBundle",
+          "metadata": {
+            "name": "ocp4"
+          },
+          "spec": {
+            "contentFile": "ssg-ocp4-ds.xml",
+            "contentImage": "quay.io/complianceascode/ocp4:latest"
+          }
+        },
+        {
+          "apiVersion": "compliance.openshift.io/v1alpha1",
+          "autoApplyRemediations": false,
+          "debug": true,
+          "kind": "ScanSetting",
+          "metadata": {
+            "name": "my-companys-constraints"
+          },
+          "rawResultStorage": {
+            "rotation": 10,
+            "size": "2Gi"
+          },
+          "roles": [
+            "worker",
+            "master"
+          ],
+          "schedule": "0 1 * * *"
+        },
+        {
+          "apiVersion": "compliance.openshift.io/v1alpha1",
+          "kind": "ScanSettingBinding",
+          "metadata": {
+            "name": "nist-moderate"
+          },
+          "profiles": [
+            {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "Profile",
+              "name": "rhcos4-moderate"
+            }
+          ],
+          "settingsRef": {
+            "apiGroup": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSetting",
+            "name": "default"
+          }
+        },
+        {
+          "apiVersion": "compliance.openshift.io/v1alpha1",
+          "kind": "TailoredProfile",
+          "metadata": {
+            "name": "example-tailoredprofile"
+          },
+          "spec": {
+            "disableRules": [
+              {
+                "name": "ocp4-file-permissions-node-config",
+                "rationale": "This breaks X application."
+              },
+              {
+                "name": "ocp4-account-disable-post-pw-expiration",
+                "rationale": "testing this"
+              },
+              {
+                "name": "ocp4-accounts-no-uid-except-zero",
+                "rationale": "testing this"
+              },
+              {
+                "name": "ocp4-audit-rules-dac-modification-chmod",
+                "rationale": "testing this"
+              },
+              {
+                "name": "ocp4-audit-rules-dac-modification-chown",
+                "rationale": "testing this"
+              },
+              {
+                "name": "ocp4-audit-rules-dac-modification-fchmod",
+                "rationale": "testing this"
+              },
+              {
+                "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                "rationale": "testing this"
+              },
+              {
+                "name": "ocp4-audit-rules-dac-modification-fchown",
+                "rationale": "testing this"
+              }
+            ],
+            "extends": "ocp4-moderate",
+            "setValues": [
+              {
+                "name": "ocp4-var-selinux-state",
+                "rationale": "trolling dwalsh",
+                "value": "permissive"
+              }
+            ],
+            "title": "My little profile"
+          }
+        }
+      ]
+    capabilities: Basic Install
+  name: compliance-operator.v0.1.15
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: ComplianceCheckResult represent a result of a single compliance
+        "test"
+      kind: ComplianceCheckResult
+      name: compliancecheckresults.compliance.openshift.io
+      version: v1alpha1
+    - description: ComplianceRemediation represents a remediation that can be applied
+        to the cluster to fix the found issues.
+      kind: ComplianceRemediation
+      name: complianceremediations.compliance.openshift.io
+      version: v1alpha1
+    - description: ComplianceScan represents a scan with a certain configuration that
+        will be applied to objects of a certain entity in the host. These could be
+        nodes that apply to a certain nodeSelector, or the cluster itself.
+      kind: ComplianceScan
+      name: compliancescans.compliance.openshift.io
+      version: v1alpha1
+    - description: ComplianceSuite represents a set of scans that will be applied
+        to the cluster. These should help deployers achieve a certain compliance target.
+      kind: ComplianceSuite
+      name: compliancesuites.compliance.openshift.io
+      version: v1alpha1
+    - description: ProfileBundle is the Schema for the profilebundles API
+      kind: ProfileBundle
+      name: profilebundles.compliance.openshift.io
+      version: v1alpha1
+    - description: Profile is the Schema for the profiles API
+      kind: Profile
+      name: profiles.compliance.openshift.io
+      version: v1alpha1
+    - description: Rule is the Schema for the rules API
+      kind: Rule
+      name: rules.compliance.openshift.io
+      version: v1alpha1
+    - description: ScanSettingBinding is the Schema for the scansettingbindings API
+      kind: ScanSettingBinding
+      name: scansettingbindings.compliance.openshift.io
+      version: v1alpha1
+    - description: ScanSetting is the Schema for the scansettings API
+      kind: ScanSetting
+      name: scansettings.compliance.openshift.io
+      version: v1alpha1
+    - description: TailoredProfile is the Schema for the tailoredprofiles API
+      kind: TailoredProfile
+      name: tailoredprofiles.compliance.openshift.io
+      version: v1alpha1
+    - description: Variable describes a tunable in the XCCDF profile
+      kind: Variable
+      name: variables.compliance.openshift.io
+      version: v1alpha1
+  description: An operator which runs OpenSCAP and allows you to keep your cluster
+    compliant with the security benchmark you need.
+  displayName: Compliance Operator
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - machineconfiguration.openshift.io
+          resources:
+          - machineconfigs
+          - machineconfigpools
+          verbs:
+          - list
+          - get
+          - patch
+          - create
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - compliance.openshift.io
+          resources:
+          - compliancesuites
+          verbs:
+          - get
+          - list
+        serviceAccountName: compliance-operator
+      - rules:
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - operatorhubs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - metrics.k8s.io
+          resources:
+          - pods
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - componentstatuses
+          - nodes
+          - nodes/status
+          - persistentvolumeclaims/status
+          - persistentvolumes
+          - persistentvolumes/status
+          - pods/binding
+          - pods/eviction
+          - podtemplates
+          - securitycontextconstraints
+          - services/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - controllerrevisions
+          - daemonsets/status
+          - deployments/status
+          - replicasets/status
+          - statefulsets/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          - customresourcedefinitions/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          - apiservices/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs/status
+          - jobs/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - daemonsets/status
+          - deployments/status
+          - horizontalpodautoscalers
+          - horizontalpodautoscalers/status
+          - ingresses/status
+          - jobs
+          - jobs/status
+          - podsecuritypolicies
+          - replicasets/status
+          - replicationcontrollers
+          - storageclasses
+          - thirdpartyresources
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - events.k8s.io
+          resources:
+          - events
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - node.k8s.io
+          resources:
+          - runtimeclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets/status
+          - podsecuritypolicies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - settings.k8s.io
+          resources:
+          - podpresets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - csidrivers
+          - csinodes
+          - storageclasses
+          - volumeattachments
+          - volumeattachments/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - scheduling.k8s.io
+          resources:
+          - priorityclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - certificates.k8s.io
+          resources:
+          - certificatesigningrequests
+          - certificatesigningrequests/approval
+          - certificatesigningrequests/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - authorization.openshift.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindingrestrictions
+          - rolebindings
+          - roles
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - builds/details
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - images
+          - imagesignatures
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams/layers
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          - oauth.openshift.io
+          resources:
+          - oauthclientauthorizations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - project.openshift.io
+          resources:
+          - projects
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - project.openshift.io
+          resources:
+          - projectrequests
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - quota.openshift.io
+          resources:
+          - clusterresourcequotas
+          - clusterresourcequotas/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - network.openshift.io
+          resources:
+          - clusternetworks
+          - egressnetworkpolicies
+          - hostsubnets
+          - netnamespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - rangeallocations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - template.openshift.io
+          resources:
+          - brokertemplateinstances
+          - templateinstances/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - user.openshift.io
+          resources:
+          - groups
+          - identities
+          - useridentitymappings
+          - users
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - authorization.openshift.io
+          resources:
+          - localresourceaccessreviews
+          - localsubjectaccessreviews
+          - resourceaccessreviews
+          - selfsubjectrulesreviews
+          - subjectaccessreviews
+          - subjectrulesreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - localsubjectaccessreviews
+          - selfsubjectaccessreviews
+          - selfsubjectrulesreviews
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - security.openshift.io
+          resources:
+          - podsecuritypolicyreviews
+          - podsecuritypolicyselfsubjectreviews
+          - podsecuritypolicysubjectreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - nodes/metrics
+          - nodes/spec
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - nodes/stats
+          verbs:
+          - create
+          - get
+        - nonResourceURLs:
+          - '*'
+          verbs:
+          - get
+        - apiGroups:
+          - cloudcredential.openshift.io
+          resources:
+          - credentialsrequests
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - apiservers
+          - authentications
+          - builds
+          - clusteroperators
+          - clusterversions
+          - consoles
+          - dnses
+          - featuregates
+          - images
+          - infrastructures
+          - ingresses
+          - networks
+          - oauths
+          - projects
+          - proxies
+          - schedulers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - samples.operator.openshift.io
+          resources:
+          - configs
+          - configs/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - machineconfiguration.openshift.io
+          resources:
+          - containerruntimeconfigs
+          - controllerconfigs
+          - kubeletconfigs
+          - machineconfigpools
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          - catalogsources
+          - installplans
+          - subscriptions
+          - operatorgroups
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - packages.operators.coreos.com
+          resources:
+          - packagemanifests
+          - packagemanifests/icon
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - packages.operators.coreos.com
+          resources:
+          - packagemanifests
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreamimages
+          - imagestreammappings
+          - imagestreams
+          - imagestreamtags
+          - imagetags
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          - project.openshift.io
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - endpoints
+          - persistentvolumeclaims
+          - persistentvolumeclaims/status
+          - pods
+          - replicationcontrollers
+          - replicationcontrollers/scale
+          - serviceaccounts
+          - services
+          - services/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - bindings
+          - events
+          - limitranges
+          - namespaces/status
+          - pods/log
+          - pods/status
+          - replicationcontrollers/status
+          - resourcequotas
+          - resourcequotas/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - controllerrevisions
+          - daemonsets
+          - daemonsets/status
+          - deployments
+          - deployments/scale
+          - deployments/status
+          - replicasets
+          - replicasets/scale
+          - replicasets/status
+          - statefulsets
+          - statefulsets/scale
+          - statefulsets/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          - horizontalpodautoscalers/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - cronjobs/status
+          - jobs
+          - jobs/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - daemonsets
+          - daemonsets/status
+          - deployments
+          - deployments/scale
+          - deployments/status
+          - ingresses
+          - ingresses/status
+          - networkpolicies
+          - replicasets
+          - replicasets/scale
+          - replicasets/status
+          - replicationcontrollers/scale
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          - poddisruptionbudgets/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          - ingresses/status
+          - networkpolicies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildconfigs
+          - buildconfigs/webhooks
+          - builds
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - builds/log
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - build.openshift.io
+          resources:
+          - jenkins
+          verbs:
+          - view
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          - deploymentconfigs/scale
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs/log
+          - deploymentconfigs/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - quota.openshift.io
+          resources:
+          - appliedclusterresourcequotas
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - template.openshift.io
+          resources:
+          - processedtemplates
+          - templateconfigs
+          - templateinstances
+          - templates
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildlogs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - resourcequotausages
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: api-resource-collector
+      deployments:
+      - name: compliance-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: compliance-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: compliance-operator
+            spec:
+              containers:
+              - command:
+                - compliance-operator
+                - operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: compliance-operator
+                - name: RELATED_IMAGE_OPENSCAP
+                  value: quay.io/compliance-operator/openscap-ocp:1.3.3
+                - name: RELATED_IMAGE_OPERATOR
+                  value: quay.io/compliance-operator/compliance-operator:latest
+                - name: RELATED_IMAGE_PROFILE
+                  value: quay.io/complianceascode/ocp4:latest
+                image: quay.io/compliance-operator/compliance-operator:latest
+                imagePullPolicy: Always
+                name: compliance-operator
+                resources: {}
+              nodeSelector:
+                node-role.kubernetes.io/master: ""
+              serviceAccountName: compliance-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+                operator: Exists
+              - effect: NoExecute
+                key: node.kubernetes.io/unreachable
+                operator: Exists
+                tolerationSeconds: 120
+              - effect: NoExecute
+                key: node.kubernetes.io/not-ready
+                operator: Exists
+                tolerationSeconds: 120
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          - persistentvolumes
+          verbs:
+          - watch
+          - create
+          - get
+          - list
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          - events
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - delete
+          - deletecollection
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - compliance.openshift.io
+          resources:
+          - compliancescans
+          verbs:
+          - create
+          - watch
+          - patch
+          - get
+          - list
+        - apiGroups:
+          - compliance.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resourceNames:
+          - compliance-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - services/finalizers
+          verbs:
+          - create
+          - get
+          - update
+          - delete
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - compliance-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        serviceAccountName: compliance-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+        - apiGroups:
+          - compliance.openshift.io
+          resources:
+          - compliancescans
+          verbs:
+          - get
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: resultscollector
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+        - apiGroups:
+          - compliance.openshift.io
+          resources:
+          - compliancescans
+          verbs:
+          - get
+        serviceAccountName: api-resource-collector
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - get
+          - list
+          - create
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - update
+        - apiGroups:
+          - compliance.openshift.io
+          resources:
+          - compliancescans
+          verbs:
+          - get
+        - apiGroups:
+          - compliance.openshift.io
+          resources:
+          - compliancescans/finalizers
+          - compliancecheckresults/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - compliance.openshift.io
+          resources:
+          - complianceremediations
+          - complianceremediations/status
+          verbs:
+          - create
+          - get
+          - update
+          - patch
+        - apiGroups:
+          - compliance.openshift.io
+          resources:
+          - compliancecheckresults
+          verbs:
+          - create
+          - get
+          - update
+          - patch
+        serviceAccountName: remediation-aggregator
+      - rules:
+        - apiGroups:
+          - compliance.openshift.io
+          resources:
+          - compliancescans
+          verbs:
+          - get
+          - list
+          - update
+        serviceAccountName: rerunner
+      - rules:
+        - apiGroups:
+          - compliance.openshift.io
+          resources:
+          - profilebundles
+          - profilebundles/status
+          - profilebundles/finalizers
+          verbs:
+          - get
+          - watch
+          - list
+          - update
+        - apiGroups:
+          - compliance.openshift.io
+          resources:
+          - profiles
+          - rules
+          - variables
+          verbs:
+          - get
+          - watch
+          - list
+          - create
+          - update
+          - delete
+        serviceAccountName: profileparser
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - security
+  - compliance
+  - openscap
+  - audit
+  links:
+  - name: Compliance Operator
+    url: https://compliance-operator.domain
+  maintainers:
+  - email: support@redhat.com
+    name: Red Hat Support
+  maturity: alpha
+  provider:
+    name: Red Hat Inc.
+    url: www.redhat.com
+  version: 0.1.15

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancecheckresults_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancecheckresults_crd.yaml
@@ -1,0 +1,65 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: compliancecheckresults.compliance.openshift.io
+spec:
+  group: compliance.openshift.io
+  names:
+    kind: ComplianceCheckResult
+    listKind: ComplianceCheckResultList
+    plural: compliancecheckresults
+    singular: compliancecheckresult
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status
+      name: Status
+      type: string
+    - jsonPath: .severity
+      name: Severity
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          description:
+            description: A human-readable check description, what and why it does
+            type: string
+          id:
+            description: A unique identifier of a check
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          severity:
+            description: The severity of a check status
+            type: string
+          status:
+            description: The result of a check
+            type: string
+        required:
+        - id
+        - severity
+        - status
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_complianceremediations_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_complianceremediations_crd.yaml
@@ -1,0 +1,86 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: complianceremediations.compliance.openshift.io
+spec:
+  group: compliance.openshift.io
+  names:
+    kind: ComplianceRemediation
+    listKind: ComplianceRemediationList
+    plural: complianceremediations
+    singular: complianceremediation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.applicationState
+      name: State
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Contains the definition of what the remediation should be
+            properties:
+              apply:
+                description: Whether the remediation should be picked up and applied
+                  by the operator
+                type: boolean
+              current:
+                properties:
+                  object:
+                    description: The remediation payload. This would normally be a
+                      full Kubernetes object.
+                    type: object
+                    x-kubernetes-embedded-resource: true
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              outdated:
+                properties:
+                  object:
+                    description: The remediation payload. This would normally be a
+                      full Kubernetes object.
+                    type: object
+                    x-kubernetes-embedded-resource: true
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+            required:
+            - apply
+            type: object
+          status:
+            description: Contains information on the remediation (whether it's applied
+              or not)
+            properties:
+              applicationState:
+                default: NotApplied
+                description: Whether the remediation is already applied or not
+                type: string
+              errorMessage:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancescans_crd.yaml
@@ -1,0 +1,223 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: compliancescans.compliance.openshift.io
+spec:
+  group: compliance.openshift.io
+  names:
+    kind: ComplianceScan
+    listKind: ComplianceScanList
+    plural: compliancescans
+    singular: compliancescan
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.result
+      name: Result
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: The spec is the configuration for the compliance scan.
+            properties:
+              content:
+                description: Is the path to the file that contains the content (the
+                  data stream). Note that the path needs to be relative to the `/`
+                  (root) directory, as it is in the ContentImage
+                type: string
+              contentImage:
+                description: Is the image with the content (Data Stream), that will
+                  be used to run OpenSCAP.
+                type: string
+              debug:
+                description: Enable debug logging of workloads and OpenSCAP
+                type: boolean
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: By setting this, it's possible to only run the scan on
+                  certain nodes in the cluster. Note that when applying remediations
+                  generated from the scan, this should match the selector of the MachineConfigPool
+                  you want to apply the remediations to.
+                type: object
+              profile:
+                description: Is the profile in the data stream to be used. This is
+                  the collection of rules that will be checked for.
+                type: string
+              rawResultStorage:
+                description: Specifies settings that pertain to raw result storage.
+                properties:
+                  pvAccessModes:
+                    default:
+                    - ReadWriteOnce
+                    description: Specifies the access modes that the PersistentVolume
+                      will be created with. The persistent volume will hold the raw
+                      results of the scan.
+                    items:
+                      type: string
+                    type: array
+                  rotation:
+                    default: 3
+                    description: Specifies the amount of scans for which the raw results
+                      will be stored. Older results will get rotated, and it's the
+                      responsibility of administrators to store these results elsewhere
+                      before rotation happens. Note that a rotation policy of '0'
+                      disables rotation entirely. Defaults to 3.
+                    type: integer
+                  size:
+                    default: 1Gi
+                    description: Specifies the amount of storage to ask for storing
+                      the raw results. Note that if re-scans happen, the new results
+                      will also need to be stored. Defaults to 1Gi.
+                    type: string
+                  storageClassName:
+                    description: Specifies the StorageClassName to use when creating
+                      the PersistentVolumeClaim to hold the raw results. By default
+                      this is null, which will attempt to use the default storage
+                      class configured in the cluster. If there is no default class
+                      specified then this needs to be set.
+                    nullable: true
+                    type: string
+                type: object
+              rule:
+                description: A Rule can be specified if the scan should check only
+                  for a specific rule. Note that when leaving this empty, the scan
+                  will check for all the rules for a specific profile.
+                type: string
+              scanTolerations:
+                default:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/master
+                  operator: Exists
+                description: Specifies tolerations needed for the scan to run on the
+                  nodes. This is useful in case the target set of nodes have custom
+                  taints that don't allow certain workloads to run. Defaults to allowing
+                  scheduling on the master nodes.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              scanType:
+                default: Node
+                description: The type of Compliance scan.
+                type: string
+              tailoringConfigMap:
+                description: Is a reference to a ConfigMap that contains the tailoring
+                  file. It assumes a key called `tailoring.xml` which will have the
+                  tailoring contents.
+                properties:
+                  name:
+                    description: Name of the ConfigMap being referenced
+                    type: string
+                required:
+                - name
+                type: object
+            type: object
+          status:
+            description: The status will give valuable information on what's going
+              on with the scan; and, more importantly, if the scan is successful (compliant)
+              or not (non-compliant)
+            properties:
+              currentIndex:
+                description: Specifies the current index of the scan. Given multiple
+                  scans, this marks the amount that have been executed.
+                format: int64
+                type: integer
+              errormsg:
+                description: If there are issues on the scan, this will be filled
+                  up with an error message.
+                type: string
+              phase:
+                description: Is the phase where the scan is at. Normally, one must
+                  wait for the scan to reach the phase DONE.
+                type: string
+              result:
+                description: Once the scan reaches the phase DONE, this will contain
+                  the result of the scan. Where COMPLIANT means that the scan succeeded;
+                  NON-COMPLIANT means that there were rule violations; and ERROR means
+                  that the scan couldn't complete due to an issue.
+                type: string
+              resultsStorage:
+                description: Specifies the object that's storing the raw results for
+                  the scan.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancesuites_crd.yaml
@@ -1,0 +1,274 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: compliancesuites.compliance.openshift.io
+spec:
+  group: compliance.openshift.io
+  names:
+    kind: ComplianceSuite
+    listKind: ComplianceSuiteList
+    plural: compliancesuites
+    singular: compliancesuite
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.result
+      name: Result
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Contains the definition of the suite
+            properties:
+              autoApplyRemediations:
+                description: Defines whether or not the remediations should be applied
+                  automatically
+                type: boolean
+              scans:
+                description: Contains a list of the scans to execute on the cluster
+                items:
+                  description: ComplianceScanSpecWrapper provides a ComplianceScanSpec
+                    and a Name
+                  properties:
+                    content:
+                      description: Is the path to the file that contains the content
+                        (the data stream). Note that the path needs to be relative
+                        to the `/` (root) directory, as it is in the ContentImage
+                      type: string
+                    contentImage:
+                      description: Is the image with the content (Data Stream), that
+                        will be used to run OpenSCAP.
+                      type: string
+                    debug:
+                      description: Enable debug logging of workloads and OpenSCAP
+                      type: boolean
+                    name:
+                      description: Contains a human readable name for the scan. This
+                        is to identify the objects that it creates.
+                      type: string
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: By setting this, it's possible to only run the
+                        scan on certain nodes in the cluster. Note that when applying
+                        remediations generated from the scan, this should match the
+                        selector of the MachineConfigPool you want to apply the remediations
+                        to.
+                      type: object
+                    profile:
+                      description: Is the profile in the data stream to be used. This
+                        is the collection of rules that will be checked for.
+                      type: string
+                    rawResultStorage:
+                      description: Specifies settings that pertain to raw result storage.
+                      properties:
+                        pvAccessModes:
+                          default:
+                          - ReadWriteOnce
+                          description: Specifies the access modes that the PersistentVolume
+                            will be created with. The persistent volume will hold
+                            the raw results of the scan.
+                          items:
+                            type: string
+                          type: array
+                        rotation:
+                          default: 3
+                          description: Specifies the amount of scans for which the
+                            raw results will be stored. Older results will get rotated,
+                            and it's the responsibility of administrators to store
+                            these results elsewhere before rotation happens. Note
+                            that a rotation policy of '0' disables rotation entirely.
+                            Defaults to 3.
+                          type: integer
+                        size:
+                          default: 1Gi
+                          description: Specifies the amount of storage to ask for
+                            storing the raw results. Note that if re-scans happen,
+                            the new results will also need to be stored. Defaults
+                            to 1Gi.
+                          type: string
+                        storageClassName:
+                          description: Specifies the StorageClassName to use when
+                            creating the PersistentVolumeClaim to hold the raw results.
+                            By default this is null, which will attempt to use the
+                            default storage class configured in the cluster. If there
+                            is no default class specified then this needs to be set.
+                          nullable: true
+                          type: string
+                      type: object
+                    rule:
+                      description: A Rule can be specified if the scan should check
+                        only for a specific rule. Note that when leaving this empty,
+                        the scan will check for all the rules for a specific profile.
+                      type: string
+                    scanTolerations:
+                      default:
+                      - effect: NoSchedule
+                        key: node-role.kubernetes.io/master
+                        operator: Exists
+                      description: Specifies tolerations needed for the scan to run
+                        on the nodes. This is useful in case the target set of nodes
+                        have custom taints that don't allow certain workloads to run.
+                        Defaults to allowing scheduling on the master nodes.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                    scanType:
+                      default: Node
+                      description: The type of Compliance scan.
+                      type: string
+                    tailoringConfigMap:
+                      description: Is a reference to a ConfigMap that contains the
+                        tailoring file. It assumes a key called `tailoring.xml` which
+                        will have the tailoring contents.
+                      properties:
+                        name:
+                          description: Name of the ConfigMap being referenced
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              schedule:
+                description: Defines a schedule for the scans to run. This is in cronjob
+                  format. Note the scan will still be triggered immediately, and the
+                  scheduled scans will start running only after the initial results
+                  are ready.
+                type: string
+            required:
+            - scans
+            type: object
+          status:
+            description: Contains the current state of the suite
+            properties:
+              errorMessage:
+                type: string
+              phase:
+                description: Represents the status of the compliance scan run.
+                type: string
+              result:
+                description: Represents the result of the compliance scan
+                type: string
+              scanStatuses:
+                items:
+                  description: ComplianceScanStatusWrapper provides a ComplianceScanStatus
+                    and a Name
+                  properties:
+                    currentIndex:
+                      description: Specifies the current index of the scan. Given
+                        multiple scans, this marks the amount that have been executed.
+                      format: int64
+                      type: integer
+                    errormsg:
+                      description: If there are issues on the scan, this will be filled
+                        up with an error message.
+                      type: string
+                    name:
+                      description: Contains a human readable name for the scan. This
+                        is to identify the objects that it creates.
+                      type: string
+                    phase:
+                      description: Is the phase where the scan is at. Normally, one
+                        must wait for the scan to reach the phase DONE.
+                      type: string
+                    result:
+                      description: Once the scan reaches the phase DONE, this will
+                        contain the result of the scan. Where COMPLIANT means that
+                        the scan succeeded; NON-COMPLIANT means that there were rule
+                        violations; and ERROR means that the scan couldn't complete
+                        due to an issue.
+                      type: string
+                    resultsStorage:
+                      description: Specifies the object that's storing the raw results
+                        for the scan.
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                      type: object
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - scanStatuses
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_profilebundles_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_profilebundles_crd.yaml
@@ -1,0 +1,77 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: profilebundles.compliance.openshift.io
+spec:
+  group: compliance.openshift.io
+  names:
+    kind: ProfileBundle
+    listKind: ProfileBundleList
+    plural: profilebundles
+    singular: profilebundle
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.contentImage
+      name: ContentImage
+      type: string
+    - jsonPath: .status.dataStreamStatus
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ProfileBundle is the Schema for the profilebundles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Defines the desired state of ProfileBundle
+            properties:
+              contentFile:
+                description: Is the path for the file in the image that contains the
+                  content for this bundle.
+                type: string
+              contentImage:
+                description: Is the path for the image that contains the content for
+                  this bundle.
+                type: string
+            required:
+            - contentFile
+            - contentImage
+            type: object
+          status:
+            description: Defines the observed state of ProfileBundle
+            properties:
+              dataStreamStatus:
+                default: PENDING
+                description: Presents the current status for the datastream for this
+                  bundle
+                type: string
+              errorMessage:
+                description: If there's an error in the datastream, it'll be presented
+                  here
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_profiles_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_profiles_crd.yaml
@@ -1,0 +1,65 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: profiles.compliance.openshift.io
+spec:
+  group: compliance.openshift.io
+  names:
+    kind: Profile
+    listKind: ProfileList
+    plural: profiles
+    singular: profile
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Profile is the Schema for the profiles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          description:
+            type: string
+          id:
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          rules:
+            items:
+              description: ProfileRule defines the name of a specific rule in the
+                profile
+              type: string
+            nullable: true
+            type: array
+            x-kubernetes-list-type: atomic
+          title:
+            type: string
+          values:
+            items:
+              description: ProfileValue defines a value for a setting in the profile
+              type: string
+            nullable: true
+            type: array
+            x-kubernetes-list-type: atomic
+        required:
+        - description
+        - id
+        - title
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_rules_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_rules_crd.yaml
@@ -1,0 +1,83 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: rules.compliance.openshift.io
+spec:
+  group: compliance.openshift.io
+  names:
+    kind: Rule
+    listKind: RuleList
+    plural: rules
+    singular: rule
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Rule is the Schema for the rules API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          availableFixes:
+            description: The Available fixes
+            items:
+              description: FixDefinition Specifies a fix or remediation that applies
+                to a rule
+              properties:
+                disruption:
+                  description: An estimate of the potential disruption or operational
+                    degradation that this fix will impose in the target system
+                  type: string
+                fixObject:
+                  description: an object that should bring the rule into compliance
+                  type: object
+                  x-kubernetes-embedded-resource: true
+                  x-kubernetes-preserve-unknown-fields: true
+                platform:
+                  description: The platform that the fix applies to
+                  type: string
+              type: object
+            nullable: true
+            type: array
+            x-kubernetes-list-type: atomic
+          description:
+            description: The description of the Rule
+            type: string
+          id:
+            description: The XCCDF ID
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          rationale:
+            description: The rationale of the Rule
+            type: string
+          severity:
+            description: The severity level
+            type: string
+          title:
+            description: The title of the Rule
+            type: string
+          warning:
+            description: A discretionary warning about the of the Rule
+            type: string
+        required:
+        - id
+        - title
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_scansettingbindings_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_scansettingbindings_crd.yaml
@@ -1,0 +1,61 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: scansettingbindings.compliance.openshift.io
+spec:
+  group: compliance.openshift.io
+  names:
+    kind: ScanSettingBinding
+    listKind: ScanSettingBindingList
+    plural: scansettingbindings
+    singular: scansettingbinding
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          profiles:
+            items:
+              properties:
+                apiGroup:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+              type: object
+            type: array
+          settingsRef:
+            properties:
+              apiGroup:
+                type: string
+              kind:
+                type: string
+              name:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_scansettings_crd.yaml
@@ -1,0 +1,141 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: scansettings.compliance.openshift.io
+spec:
+  group: compliance.openshift.io
+  names:
+    kind: ScanSetting
+    listKind: ScanSettingList
+    plural: scansettings
+    singular: scansetting
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ScanSetting is the Schema for the scansettings API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          autoApplyRemediations:
+            description: Defines whether or not the remediations should be applied
+              automatically
+            type: boolean
+          debug:
+            description: Enable debug logging of workloads and OpenSCAP
+            type: boolean
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          rawResultStorage:
+            description: Specifies settings that pertain to raw result storage.
+            properties:
+              pvAccessModes:
+                default:
+                - ReadWriteOnce
+                description: Specifies the access modes that the PersistentVolume
+                  will be created with. The persistent volume will hold the raw results
+                  of the scan.
+                items:
+                  type: string
+                type: array
+              rotation:
+                default: 3
+                description: Specifies the amount of scans for which the raw results
+                  will be stored. Older results will get rotated, and it's the responsibility
+                  of administrators to store these results elsewhere before rotation
+                  happens. Note that a rotation policy of '0' disables rotation entirely.
+                  Defaults to 3.
+                type: integer
+              size:
+                default: 1Gi
+                description: Specifies the amount of storage to ask for storing the
+                  raw results. Note that if re-scans happen, the new results will
+                  also need to be stored. Defaults to 1Gi.
+                type: string
+              storageClassName:
+                description: Specifies the StorageClassName to use when creating the
+                  PersistentVolumeClaim to hold the raw results. By default this is
+                  null, which will attempt to use the default storage class configured
+                  in the cluster. If there is no default class specified then this
+                  needs to be set.
+                nullable: true
+                type: string
+            type: object
+          roles:
+            description: The list of roles to apply node-specific checks to
+            items:
+              type: string
+            type: array
+          scanTolerations:
+            default:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/master
+              operator: Exists
+            description: Specifies tolerations needed for the scan to run on the nodes.
+              This is useful in case the target set of nodes have custom taints that
+              don't allow certain workloads to run. Defaults to allowing scheduling
+              on the master nodes.
+            items:
+              description: The pod this Toleration is attached to tolerates any taint
+                that matches the triple <key,value,effect> using the matching operator
+                <operator>.
+              properties:
+                effect:
+                  description: Effect indicates the taint effect to match. Empty means
+                    match all taint effects. When specified, allowed values are NoSchedule,
+                    PreferNoSchedule and NoExecute.
+                  type: string
+                key:
+                  description: Key is the taint key that the toleration applies to.
+                    Empty means match all taint keys. If the key is empty, operator
+                    must be Exists; this combination means to match all values and
+                    all keys.
+                  type: string
+                operator:
+                  description: Operator represents a key's relationship to the value.
+                    Valid operators are Exists and Equal. Defaults to Equal. Exists
+                    is equivalent to wildcard for value, so that a pod can tolerate
+                    all taints of a particular category.
+                  type: string
+                tolerationSeconds:
+                  description: TolerationSeconds represents the period of time the
+                    toleration (which must be of effect NoExecute, otherwise this
+                    field is ignored) tolerates the taint. By default, it is not set,
+                    which means tolerate the taint forever (do not evict). Zero and
+                    negative values will be treated as 0 (evict immediately) by the
+                    system.
+                  format: int64
+                  type: integer
+                value:
+                  description: Value is the taint value the toleration matches to.
+                    If the operator is Exists, the value should be empty, otherwise
+                    just a regular string.
+                  type: string
+              type: object
+            type: array
+          schedule:
+            description: Defines a schedule for the scans to run. This is in cronjob
+              format. Note the scan will still be triggered immediately, and the scheduled
+              scans will start running only after the initial results are ready.
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_tailoredprofiles_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_tailoredprofiles_crd.yaml
@@ -1,0 +1,151 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: tailoredprofiles.compliance.openshift.io
+spec:
+  group: compliance.openshift.io
+  names:
+    kind: TailoredProfile
+    listKind: TailoredProfileList
+    plural: tailoredprofiles
+    singular: tailoredprofile
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: State of the tailored profile
+      jsonPath: .status.state
+      name: State
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TailoredProfile is the Schema for the tailoredprofiles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TailoredProfileSpec defines the desired state of TailoredProfile
+            properties:
+              description:
+                description: Overwrites the description of the extended profile (optional)
+                type: string
+              disableRules:
+                description: Disables the referenced rules
+                items:
+                  description: RuleReferenceSpec specifies a rule to be selected/deselected,
+                    as well as the reason why
+                  properties:
+                    name:
+                      description: Name of the rule that's being referenced
+                      type: string
+                    rationale:
+                      description: Rationale of why this rule is being selected/deselected
+                      type: string
+                  required:
+                  - name
+                  - rationale
+                  type: object
+                nullable: true
+                type: array
+              enableRules:
+                description: Enables the referenced rules
+                items:
+                  description: RuleReferenceSpec specifies a rule to be selected/deselected,
+                    as well as the reason why
+                  properties:
+                    name:
+                      description: Name of the rule that's being referenced
+                      type: string
+                    rationale:
+                      description: Rationale of why this rule is being selected/deselected
+                      type: string
+                  required:
+                  - name
+                  - rationale
+                  type: object
+                nullable: true
+                type: array
+              extends:
+                description: Points to the name of the profile to extend
+                type: string
+              outputType:
+                description: Defines the type of output that the tailored profile
+                  will do.
+                enum:
+                - ConfigMap
+                - Policy
+                type: string
+              setValues:
+                description: Sets the referenced variables to selected values
+                items:
+                  description: ValueReferenceSpec specifies a value to be set for
+                    a variable with a reason why
+                  properties:
+                    name:
+                      description: Name of the variable that's being referenced
+                      type: string
+                    rationale:
+                      description: Rationale of why this value is being tailored
+                      type: string
+                    value:
+                      description: Rationale of why this value is being tailored
+                      type: string
+                  required:
+                  - name
+                  - rationale
+                  - value
+                  type: object
+                nullable: true
+                type: array
+              title:
+                description: Overwrites the title of the extended profile (optional)
+                type: string
+            required:
+            - extends
+            type: object
+          status:
+            description: TailoredProfileStatus defines the observed state of TailoredProfile
+            properties:
+              errorMessagae:
+                type: string
+              id:
+                description: The XCCDF ID of the tailored profile
+                type: string
+              outputRef:
+                description: Points to the generated resource of the type specified
+                  in "outputType"
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              state:
+                description: The current state of the tailored profile
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_variables_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_variables_crd.yaml
@@ -1,0 +1,78 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: variables.compliance.openshift.io
+spec:
+  group: compliance.openshift.io
+  names:
+    kind: Variable
+    listKind: VariableList
+    plural: variables
+    singular: variable
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Variable describes a tunable in the XCCDF profile
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          description:
+            description: The description of the Variable
+            type: string
+          id:
+            description: the ID of the variable
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          selections:
+            description: Enumerates what values are allowed for this variable. Can
+              be empty.
+            items:
+              properties:
+                description:
+                  description: The string description of the selection
+                  type: string
+                value:
+                  description: The value of the variable
+                  type: string
+              type: object
+            nullable: true
+            type: array
+            x-kubernetes-list-type: atomic
+          title:
+            description: The title of the Variable
+            type: string
+          type:
+            description: The type of the variable
+            enum:
+            - number
+            - bool
+            - string
+            type: string
+          value:
+            description: The value of the variable
+            type: string
+        required:
+        - id
+        - title
+        - type
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/deploy/olm-catalog/compliance-operator/metadata/annotations.yaml
+++ b/deploy/olm-catalog/compliance-operator/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: compliance-operator

--- a/deploy/olm-catalog/operator-group.yaml
+++ b/deploy/olm-catalog/operator-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: compliance-operator
+  namespace: openshift-compliance
+spec:
+  targetNamespaces:
+  - openshift-compliance

--- a/deploy/olm-catalog/subscription.yaml
+++ b/deploy/olm-catalog/subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: compliance-operator-sub
+  namespace: openshift-compliance
+spec:
+  channel: alpha
+  name: compliance-operator
+  source: compliance-operator
+  sourceNamespace: openshift-marketplace
+  # uncomment to specify a version
+  #startingCSV: compliance-operator.v0.1.15


### PR DESCRIPTION
This PR is a github backup of experiments we did today with @JAORMX on
installation of a bundle. The catalogSource must be adjusted with the
URL of the bundle we would publish. The other two YAMLs with the Subscription
and the OperatorGroup can be used as they are (modulo changes to names etc..)