### PR TITLE
utils: Don't use ctime but mtime instead

### DIFF
--- a/cmd/manager/resultserver_test.go
+++ b/cmd/manager/resultserver_test.go
@@ -68,6 +68,18 @@ var _ = Describe("Resultserver testing", func() {
 			dir3, err = ioutil.TempDir(rootDir, "rotate-3")
 			Expect(err).To(BeNil())
 
+			// chmod the dirs in reverse order to make sure we are really relying on
+			// modification time and not change time (see OCPBUGSM-13482)
+			time.Sleep(5 * time.Millisecond)
+			err = os.Chmod(dir3, os.ModePerm)
+			Expect(err).To(BeNil())
+			time.Sleep(5 * time.Millisecond)
+			err = os.Chmod(dir2, os.ModePerm)
+			Expect(err).To(BeNil())
+			time.Sleep(5 * time.Millisecond)
+			err = os.Chmod(dir1, os.ModePerm)
+			Expect(err).To(BeNil())
+
 			// Read a file to ensure that hierarchy doesn't change
 			_, err = ioutil.ReadAll(fileToBeRead)
 			Expect(err).To(BeNil())

--- a/pkg/utils/directory_darwin.go
+++ b/pkg/utils/directory_darwin.go
@@ -8,7 +8,7 @@ import (
 func NewDirectory(path string, info os.FileInfo) Directory {
 	statinfo := info.Sys().(*syscall.Stat_t)
 	return Directory{
-		CreationTime: timespecToTime(statinfo.Ctimespec),
+		CreationTime: timespecToTime(statinfo.Mtimespec),
 		Path:         path,
 	}
 }

--- a/pkg/utils/directory_linux.go
+++ b/pkg/utils/directory_linux.go
@@ -8,7 +8,7 @@ import (
 func NewDirectory(path string, info os.FileInfo) Directory {
 	statinfo := info.Sys().(*syscall.Stat_t)
 	return Directory{
-		CreationTime: timespecToTime(statinfo.Ctim),
+		CreationTime: timespecToTime(statinfo.Mtim),
 		Path:         path,
 	}
 }


### PR DESCRIPTION
ctime updates even when the contents of the files don't update, e.g.
with permissions update or adding links. It appers that when the
resultserver is scaled up or down, the ctime is always updated,
resulting in the sort of the directories being quite random.

Let's use mtime instead.

Jira: OCPBUGSM-13482