### PR TITLE
Only compare Machineconfig spec, not the metadata

### DIFF
--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -481,5 +481,5 @@ func mcHasRemediation(mc *mcfgv1.MachineConfig, rem *compv1alpha1.ComplianceReme
 }
 
 func mcDiffers(current *mcfgv1.MachineConfig, merged *mcfgv1.MachineConfig) bool {
-	return !reflect.DeepEqual(current, merged)
+	return !reflect.DeepEqual(current.Spec, merged.Spec)
 }


### PR DESCRIPTION
the mcDiffers was comparing the whole machineConfig. This is problematic
on updates, as the metadata (e.g. resourceVersion) will be differen this
scenario. What we really want to evaluate is the contents of the
MachineConfig, which is in the spec.