### PR TITLE
Normalize the usage of labels to identify components in the operator

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -181,9 +181,9 @@ a `Platform` scan instance and one scanner pod per matching node for a
 `Node` scan instance. The per-node pods are labeled with the node name,
 each pod is always labeled with the `ComplianceScan` name, for example:
 ```
-oc get pods -lcompliance.openshift.io/scan-name=rhcos4-e8-worker --show-labels
+oc get pods -lcompliance.openshift.io/scan-name=rhcos4-e8-worker,workload=scanner --show-labels
 NAME                                                              READY   STATUS      RESTARTS   AGE   LABELS
-rhcos4-e8-worker-ip-10-0-169-90.eu-north-1.compute.internal-pod   0/2     Completed   0          39m   compliance.openshift.io/scan-name=rhcos4-e8-worker,targetNode=ip-10-0-169-90.eu-north-1.compute.internal
+rhcos4-e8-worker-ip-10-0-169-90.eu-north-1.compute.internal-pod   0/2     Completed   0          39m   compliance.openshift.io/scan-name=rhcos4-e8-worker,targetNode=ip-10-0-169-90.eu-north-1.compute.internal,workload=scanner
 ```
 
 At this point, the scan proceeds to the Running phase.
@@ -362,3 +362,32 @@ oc get compliancecheckresults/rhcos4-e8-worker-audit-rules-dac-modification-chmo
 NAME                                                  STATUS   SEVERITY
 rhcos4-e8-worker-audit-rules-dac-modification-chmod   PASS     medium
 ```
+
+## Useful labels
+
+Each pod that's spawned by the compliance-operator is labeled specifically with
+the scan it belongs to and the work it does.
+
+The scan identifier is labeled with the `compliance.openshift.io/scan-name`
+label.
+
+The workload identifier is labeled with the `workload` label.
+
+The compliance-operator schedules the following workloads:
+
+* **scanner**: Performs the actual compliance scan.
+
+* **resultserver**: Stores the raw results for the compliance scan.
+
+* **aggregator**: Aggregates the results, detects inconsistencies and outputs
+  result objects (checkresults and remediations).
+
+* **suitererunner**: Will tag a suite to be re-run (when a schedule is set).
+
+* **profileparser**: Parses a datastream and creates the appropriate profiles,
+  rules and variables.
+
+So, when debugging and needing the logs for a certain workload, it's possible
+to do:
+
+`oc logs -l workload=<workload name>`

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -26,6 +26,7 @@ func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Log
 
 	podLabels := map[string]string{
 		compv1alpha1.ComplianceScanLabel: scanInstance.Name,
+		"workload":                       "aggregator",
 	}
 
 	return &corev1.Pod{

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -104,7 +104,7 @@ func (r *ReconcileComplianceScan) deleteResultServer(instance *compv1alpha1.Comp
 func getResultServerLabels(instance *compv1alpha1.ComplianceScan) map[string]string {
 	return map[string]string{
 		compv1alpha1.ComplianceScanLabel: instance.Name,
-		"app":                            "resultserver",
+		"workload":                       "resultserver",
 	}
 }
 

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -92,6 +92,7 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 	podLabels := map[string]string{
 		compv1alpha1.ComplianceScanLabel: scanInstance.Name,
 		"targetNode":                     node.Name,
+		"workload":                       "scanner",
 	}
 
 	return &corev1.Pod{
@@ -252,6 +253,7 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 	cmName := getConfigMapForNodeName(scanInstance.Name, PlatformScanName)
 	podLabels := map[string]string{
 		compv1alpha1.ComplianceScanLabel: scanInstance.Name,
+		"workload":                       "scanner",
 	}
 	collectorCmd := []string{
 		"compliance-operator", "api-resource-collector",

--- a/pkg/controller/compliancesuite/suitererunner.go
+++ b/pkg/controller/compliancesuite/suitererunner.go
@@ -95,6 +95,7 @@ func getRerunner(suite *compv1alpha1.ComplianceSuite) *batchv1beta1.CronJob {
 							Labels: map[string]string{
 								compv1alpha1.SuiteLabel:       suite.Name,
 								compv1alpha1.SuiteScriptLabel: "",
+								"workload":                    "suitererunner",
 							},
 						},
 						Spec: corev1.PodSpec{

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -201,6 +201,7 @@ func (r *ReconcileProfileBundle) profileBundleDeleteHandler(pb *compliancev1alph
 func getWorkloadLabels(pb *compliancev1alpha1.ProfileBundle) map[string]string {
 	return map[string]string{
 		"profile-bundle": pb.Name,
+		"workload":       "profileparser",
 	}
 }
 


### PR DESCRIPTION
The operator creates several workloads in order to do what it needs;
To ease debugging, this commit normalizes the usage of the "workload"
label to identify the different pods, so they could be dynamically
fetched using standard kube utilities.