### PR TITLE
Rename openscap-ocp container to just `scanner`

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -31,7 +31,7 @@ Please refer to the README for general information about the API objects.
      to run a single scan or a suite with only that rule - you can find the
      rule ID from the corresponding `ComplianceCheckResult` object and use it
      as the `rule` attribute value in a Scan CR. Then, together with the
-     `debug` option enabled, the openscap-ocp container logs in the scanner
+     `debug` option enabled, the `scanner` container logs in the scanner
      pod would show the raw OpenSCAP logs.
 
 ## Anatomy of a scan
@@ -199,7 +199,7 @@ might be a good place to start debugging:
      `content-container.` It runs the *contentImage* container and
      executes a single command that copies the *contentFile* to the `/content`
      directory shared with the other containers in this pod
-   * **openscap-ocp**: This container runs the actual scan. For Node scans, the container
+   * **scanner**: This container runs the actual scan. For Node scans, the container
      mounts the node filesystem as `/host` and mounts the content delivered by the
      init container. The container also mounts the `entrypoint`
      `ConfigMap` created in the Launching phase and executes it. The default
@@ -207,7 +207,7 @@ might be a good place to start debugging:
      files in the `/results` directory shared between the pod's containers.
      Logs from this pod, especially when the `debug` flag is enabled, allow
      you to see what exactly did the openscap scanner check for.
-   * **logcollector**: The logcollector container waits until the openscap-ocp
+   * **logcollector**: The logcollector container waits until the scanner
       container finishes. Then, it uploads the full ARF results to the
       `ResultServer` and separately uploads the XCCDF results along with scan
       result and openscap result code as a `ConfigMap.` These result configmaps
@@ -240,8 +240,8 @@ Scanner pods for `Platform` scans are similar, except:
       reads the OpenScap content provided by the content-container init,
       container, figures out which API resources the content needs to
       examine and stores those API resources to a shared directory where the
-      openscap-ocp scanner pod would read them from.
-    * The openscap-ocp container does not need to mount the host filesystem
+      `scanner` container would read them from.
+    * The `scanner` container does not need to mount the host filesystem
 
 When the scanner pods are done, the scans move on to the Aggregating phase.
 

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -46,7 +46,7 @@ const (
 
 const (
 	// OpenSCAPScanContainerName defines the name of the contianer that will run OpenSCAP
-	OpenSCAPScanContainerName = "openscap-ocp"
+	OpenSCAPScanContainerName = "scanner"
 	// The default time we should wait before requeuing
 	requeueAfterDefault = 10 * time.Second
 )

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -7,14 +7,15 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"os"
 	"path"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"k8s.io/client-go/kubernetes"
 
@@ -628,7 +629,7 @@ func getConfigMapsFromScan(f *framework.Framework, scaninstance *compv1alpha1.Co
 	var configmaps corev1.ConfigMapList
 	labelselector := map[string]string{
 		compv1alpha1.ComplianceScanLabel: scaninstance.Name,
-		compv1alpha1.ResultLabel: "",
+		compv1alpha1.ResultLabel:         "",
 	}
 	lo := &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labelselector),
@@ -1778,7 +1779,7 @@ func writeToArtifactsDir(t *testing.T, f *framework.Framework, dir, scan, pod, c
 
 func logContainerOutput(t *testing.T, f *framework.Framework, namespace, name string) {
 	// Try all container/init variants for each pod and the pod itself (self), log nothing if the container is not applicable.
-	containers := []string{"self", "api-resource-collector", "log-collector", "openscap-ocp", "content-container"}
+	containers := []string{"self", "api-resource-collector", "log-collector", "scanner", "content-container"}
 	artifacts := os.Getenv("ARTIFACT_DIR")
 	if artifacts == "" {
 		return


### PR DESCRIPTION
This decouples the implementation details from the pod/container names
we're using. Also, it's easier to remember for someone troubleshooting.