### PR TITLE
Add descriptions for remediation keys

### DIFF
--- a/deploy/crds/compliance.openshift.io_complianceremediations_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_complianceremediations_crd.yaml
@@ -41,6 +41,9 @@ spec:
                   by the operator
                 type: boolean
               current:
+                description: Defines the remediation that is proposed by the scan.
+                  If there is no "outdated" remediation in this object, the "current"
+                  remediation is what will be applied.
                 properties:
                   object:
                     description: The remediation payload. This would normally be a
@@ -50,6 +53,11 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               outdated:
+                description: In case there was a previous remediation proposed by
+                  a previous scan, and that remediation now differs, the old remediation
+                  will be kept in this "outdated" key. This requires admin intervention
+                  to remove this outdated object and ensure the current is what's
+                  applied.
                 properties:
                   object:
                     description: The remediation payload. This would normally be a

--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -48,8 +48,13 @@ type ComplianceRemediationPayload struct {
 // +k8s:openapi-gen=true
 type ComplianceRemediationSpec struct {
 	ComplianceRemediationSpecMeta `json:",inline"`
-	Current                       ComplianceRemediationPayload `json:"current,omitempty"`
-	Outdated                      ComplianceRemediationPayload `json:"outdated,omitempty"`
+	// Defines the remediation that is proposed by the scan. If there is no "outdated"
+	// remediation in this object, the "current" remediation is what will be applied.
+	Current ComplianceRemediationPayload `json:"current,omitempty"`
+	// In case there was a previous remediation proposed by a previous scan, and that remediation
+	// now differs, the old remediation will be kept in this "outdated" key. This requires admin
+	// intervention to remove this outdated object and ensure the current is what's applied.
+	Outdated ComplianceRemediationPayload `json:"outdated,omitempty"`
 }
 
 // ComplianceRemediationStatus defines the observed state of ComplianceRemediation


### PR DESCRIPTION
These were missing, and thus using
`oc explain complianceremediation.spec` didn't show anything
for them.