### PR TITLE
Bug 1862453: Also delete jobs when deleting compliancesuites

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -113,6 +113,12 @@ rules:
   - delete 
   - update
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - deletecollection # Needed for cleaning up jobs
+- apiGroups:
   - image.openshift.io
   resources:
   - imagestreamtags

--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -151,18 +151,7 @@ func (r *ReconcileComplianceSuite) Reconcile(request reconcile.Request) (reconci
 
 func (r *ReconcileComplianceSuite) suiteDeleteHandler(suite *compv1alpha1.ComplianceSuite, logger logr.Logger) error {
 	rerunner := getRerunner(suite)
-	err := r.client.Delete(context.TODO(), rerunner)
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-
-	inNs := client.InNamespace(common.GetComplianceOperatorNamespace())
-	withLabel := client.MatchingLabels{
-		compv1alpha1.SuiteLabel:       suite.Name,
-		compv1alpha1.SuiteScriptLabel: "",
-	}
-	err = r.client.DeleteAllOf(context.Background(), &corev1.Pod{}, inNs, withLabel)
-	if err != nil {
+	if err := r.handleRerunnerDelete(rerunner, suite.Name, logger); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
It was the case that we were deleting the pods and the cronjobs... but
the jobs were being left out. This fixes that.
    
Also, this reconciles the logic for cleanup to be only in one place.
