### PR TITLE
Bug 1877807: Support disconnected installs

### DIFF
--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -52,6 +52,17 @@ spec:
               debug:
                 description: Enable debug logging of workloads and OpenSCAP
                 type: boolean
+              httpsProxy:
+                description: Defines a proxy for the scan to get external resources
+                  from. This is useful for disconnected installations with access
+                  to a proxy.
+                type: string
+              noExternalResources:
+                description: Defines that no external resources in the Data Stream
+                  should be used. External resources could be, for instance, CVE feeds.
+                  This is useful for disconnected installations without access to
+                  a proxy.
+                type: boolean
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -62,10 +62,21 @@ spec:
                     debug:
                       description: Enable debug logging of workloads and OpenSCAP
                       type: boolean
+                    httpsProxy:
+                      description: Defines a proxy for the scan to get external resources
+                        from. This is useful for disconnected installations with access
+                        to a proxy.
+                      type: string
                     name:
                       description: Contains a human readable name for the scan. This
                         is to identify the objects that it creates.
                       type: string
+                    noExternalResources:
+                      description: Defines that no external resources in the Data
+                        Stream should be used. External resources could be, for instance,
+                        CVE feeds. This is useful for disconnected installations without
+                        access to a proxy.
+                      type: boolean
                     nodeSelector:
                       additionalProperties:
                         type: string

--- a/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
@@ -28,6 +28,10 @@ spec:
           debug:
             description: Enable debug logging of workloads and OpenSCAP
             type: boolean
+          httpsProxy:
+            description: Defines a proxy for the scan to get external resources from.
+              This is useful for disconnected installations with access to a proxy.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
@@ -35,6 +39,11 @@ spec:
             type: string
           metadata:
             type: object
+          noExternalResources:
+            description: Defines that no external resources in the Data Stream should
+              be used. External resources could be, for instance, CVE feeds. This
+              is useful for disconnected installations without access to a proxy.
+            type: boolean
           rawResultStorage:
             description: Specifies settings that pertain to raw result storage.
             properties:

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -149,6 +149,13 @@ type ComplianceScanSettings struct {
 	Debug bool `json:"debug,omitempty"`
 	// Specifies settings that pertain to raw result storage.
 	RawResultStorage RawResultStorageSettings `json:"rawResultStorage,omitempty"`
+	// Defines that no external resources in the Data Stream should be used. External
+	// resources could be, for instance, CVE feeds. This is useful for disconnected
+	// installations without access to a proxy.
+	NoExternalResources bool `json:"noExternalResources,omitempty"`
+	// Defines a proxy for the scan to get external resources from. This is useful for
+	// disconnected installations with access to a proxy.
+	HTTPSProxy string `json:"httpsProxy,omitempty"`
 	// Specifies tolerations needed for the scan to run on the nodes. This is useful
 	// in case the target set of nodes have custom taints that don't allow certain
 	// workloads to run. Defaults to allowing scheduling on the master nodes.

--- a/pkg/controller/compliancescan/config.go
+++ b/pkg/controller/compliancescan/config.go
@@ -32,6 +32,8 @@ const (
 	OpenScapRuleEnvName         = "RULE"
 	OpenScapVerbosityeEnvName   = "VERBOSITY"
 	OpenScapTailoringDirEnvName = "TAILORING_DIR"
+	HTTPSProxyEnvName           = "HTTPS_PROXY"
+	DisconnectedInstallEnvName  = "DISCONNECTED"
 
 	ResultServerPort = int32(8443)
 
@@ -87,8 +89,15 @@ if [ ! -z "$TAILORING_DIR" ]; then
 	cmd+=(--tailoring-file "$TAILORING_DIR/tailoring.xml")
 fi
 
+if [ ! -z "$HTTPS_PROXY" ]; then
+	export http_proxy="$HTTPS_PROXY"
+fi
+
+if [ -z "$DISCONNECTED" ]; then
+	cmd+=(--fetch-remote-resources)
+fi
+
 cmd+=(
-    --fetch-remote-resources \
     --profile $PROFILE \
     --results-arf $ARF_REPORT
 )
@@ -237,6 +246,14 @@ func defaultOpenScapEnvCm(name string, scan *compv1alpha1.ComplianceScan) *corev
 
 	if scan.Spec.TailoringConfigMap != nil {
 		cm.Data[OpenScapTailoringDirEnvName] = OpenScapTailoringDir
+	}
+
+	if scan.Spec.HTTPSProxy != "" {
+		cm.Data[HTTPSProxyEnvName] = scan.Spec.HTTPSProxy
+	}
+
+	if scan.Spec.NoExternalResources {
+		cm.Data[DisconnectedInstallEnvName] = "true"
 	}
 
 	return cm


### PR DESCRIPTION
The current default behavior is to allow the `oscap` command to download
external resources. This is an issue in disconnected installs since
they'll either have no access to the internet, or have so, but through a
proxy.

This enables the usage of the operator in such environments by allowing
the admin to set two new scan settings:

* **noExternalResources**: This will entirely remove the flag that
  downloads external resources, and stuff like cve checks simply won't
  run.

* **httpsProxy**: This sets the `http_proxy` environment variable, so
  the `oscap` command will use the proxy. Note that the name
  `httpsProxy` was chosen to encourage folks to use https for their
  proxies.