### PR TITLE
Handle result events generically

### DIFF
--- a/pkg/controller/common/events.go
+++ b/pkg/controller/common/events.go
@@ -1,9 +1,16 @@
 package common
 
 import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
 )
 
 type SafeRecorder struct {
@@ -39,4 +46,64 @@ func (sr *SafeRecorder) AnnotatedEventf(object runtime.Object, annotations map[s
 	}
 
 	sr.recorder.AnnotatedEventf(object, annotations, eventtype, reason, messageFmt, args...)
+}
+
+func GenerateEventForResult(recorder record.EventRecorder, obj runtime.Object, objInfo metav1.Object, result compv1alpha1.ComplianceScanStatusResult) {
+	// Event for Suite
+	recorder.Event(
+		obj,
+		corev1.EventTypeNormal,
+		"ResultAvailable",
+		fmt.Sprintf("The result is: %s", result),
+	)
+
+	ownerRefs := objInfo.GetOwnerReferences()
+	if len(ownerRefs) == 0 {
+		return //there is nothing to do, since no owner is set
+	}
+	for _, ownerRef := range ownerRefs {
+		// we are making an assumption that the GRC policy has a single owner, or we chose the first owner in the list
+		if string(ownerRef.UID) == "" {
+			continue //there is nothing to do, since no owner UID is set
+		}
+		// FIXME(jaosorior): Figure out a less hacky way to check this
+		if ownerRef.Kind == "Policy" {
+			pol := getParentPolicy(&ownerRef, objInfo.GetNamespace())
+			recorder.Event(
+				pol,
+				corev1.EventTypeNormal,
+				fmt.Sprintf("policy: %s/%s", objInfo.GetNamespace(), objInfo.GetName()),
+				resultToACMPolicyStatus(objInfo.GetNamespace(), objInfo.GetName(), result),
+			)
+		}
+	}
+}
+
+func getParentPolicy(ownerRef *metav1.OwnerReference, ns string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": ownerRef.APIVersion,
+			"kind":       ownerRef.Kind,
+			"metadata": map[string]interface{}{
+				"name":      ownerRef.Name,
+				"namespace": ns,
+				"uid":       ownerRef.UID,
+			},
+		},
+	}
+}
+
+func resultToACMPolicyStatus(namespace, name string, scanresult compv1alpha1.ComplianceScanStatusResult) string {
+	const instfmt string = "; To view aggregated results, execute the following in the managed cluster: kubectl get compliancesuites -n %s %s"
+	instructions := fmt.Sprintf(instfmt, namespace, name)
+	var result string
+	switch scanresult {
+	case compv1alpha1.ResultCompliant:
+		result = "Compliant"
+	case compv1alpha1.ResultNonCompliant:
+		result = "NonCompliant"
+	default:
+		result = "UnknownCompliancy"
+	}
+	return result + instructions
 }

--- a/pkg/controller/scansettingbinding/scansettingbinding_controller.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller.go
@@ -67,6 +67,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Watch for changes to secondary resource ComplianceScans and requeue the owner ComplianceSuite
+	err = c.Watch(&source.Kind{Type: &compliancev1alpha1.ComplianceSuite{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &compliancev1alpha1.ScanSettingBinding{},
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -192,6 +201,11 @@ func (r *ReconcileScanSettingBinding) Reconcile(request reconcile.Request) (reco
 		return reconcile.Result{}, err
 	} else {
 		log.Info("Suite does not need update", "suite.Name", suite.Name)
+	}
+
+	if found.Status.Phase == compliancev1alpha1.PhaseDone {
+		reqLogger.Info("Generating events for scansettingbinding")
+		common.GenerateEventForResult(r.recorder, instance, instance, found.Status.Result)
 	}
 
 	return reconcile.Result{}, nil


### PR DESCRIPTION
The suite controller currently issues events for results being
available. For RHACM support, we need to do this for scansettingbindings
too, since that's the object that'll be created by RHACM as well.

this change enables such events to be created from both controllers in a
general manner.