### PR TITLE
Change aggregator's container name to something more fitting

### DIFF
--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -57,7 +57,7 @@ func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Log
 			},
 			Containers: []corev1.Container{
 				{
-					Name:  "log-collector",
+					Name:  "aggregator",
 					Image: utils.GetComponentImage(utils.OPERATOR),
 					Command: []string{
 						"compliance-operator", "aggregator",


### PR DESCRIPTION
The aggregator's main container was using the name log-collector. Most
likely as a copy-paste error. This turns out a little confusing when
reading the namespace's events. So let's use something more suitable.