### PR TITLE
Take namespace into account for profilebundle deployment

### DIFF
--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -309,7 +309,7 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *a
 	labels := getWorkloadLabels(pb)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      pb.Name + "-pp",
+			Name:      pb.Name + "-" + pb.Namespace + "-pp",
 			Namespace: common.GetComplianceOperatorNamespace(),
 			Labels:    labels,
 		},


### PR DESCRIPTION
This adds the name of the namespace for creating the profilebundle
deployment object. Thus allowing us to listen on several namespaces.

Closes-Bug: #461