### PR TITLE
Hardening: Set some general hardening settings for our containers

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,6 +20,9 @@ spec:
           - compliance-operator
           - operator
           imagePullPolicy: Always
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -29,6 +29,9 @@ func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Log
 		"workload":                       "aggregator",
 	}
 
+	falseP := false
+	trueP := true
+
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
@@ -47,6 +50,10 @@ func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Log
 						fmt.Sprintf("cp %s /content | /bin/true", path.Join("/", scanInstance.Spec.Content)),
 					},
 					ImagePullPolicy: corev1.PullAlways,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &falseP,
+						ReadOnlyRootFilesystem:   &trueP,
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "content-dir",
@@ -64,6 +71,10 @@ func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Log
 						"--content=" + absContentPath(scanInstance.Spec.Content),
 						"--scan=" + scanInstance.Name,
 						"--namespace=" + scanInstance.Namespace,
+					},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &falseP,
+						ReadOnlyRootFilesystem:   &trueP,
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -112,6 +112,8 @@ func getResultServerLabels(instance *compv1alpha1.ComplianceScan) map[string]str
 // Needs corresponding Service (with service-serving cert).
 // Need to aggregate reports into one service ? on subdirs?
 func resultServer(scanInstance *compv1alpha1.ComplianceScan, labels map[string]string, logger logr.Logger) *appsv1.Deployment {
+	falseP := false
+	trueP := true
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getResultServerName(scanInstance),
@@ -144,6 +146,10 @@ func resultServer(scanInstance *compv1alpha1.ComplianceScan, labels map[string]s
 								"--tls-server-cert=/etc/pki/tls/tls.crt",
 								"--tls-server-key=/etc/pki/tls/tls.key",
 								"--tls-ca=/etc/pki/tls/ca.crt",
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &falseP,
+								ReadOnlyRootFilesystem:   &trueP,
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -94,6 +94,8 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 		"targetNode":                     node.Name,
 		"workload":                       "scanner",
 	}
+	falseP := false
+	trueP := true
 
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -116,6 +118,10 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 						fmt.Sprintf("cp %s /content | /bin/true", path.Join("/", scanInstance.Spec.Content)),
 					},
 					ImagePullPolicy: corev1.PullAlways,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &falseP,
+						ReadOnlyRootFilesystem:   &trueP,
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "content-dir",
@@ -144,6 +150,10 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 						"--tls-ca=/etc/pki/tls/ca.crt",
 					},
 					ImagePullPolicy: corev1.PullAlways,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &falseP,
+						ReadOnlyRootFilesystem:   &trueP,
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "report-dir",
@@ -162,7 +172,10 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 					Image:   utils.GetComponentImage(utils.OPENSCAP),
 					Command: []string{OpenScapScriptPath},
 					SecurityContext: &corev1.SecurityContext{
-						Privileged: &trueVal,
+						Privileged:             &trueVal,
+						ReadOnlyRootFilesystem: &trueP,
+						// TODO(jaosorior): Figure out if the default
+						// seccomp profile is sufficient here.
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -261,6 +274,8 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 		"--resultdir=" + PlatformScanDataRoot,
 		"--profile=" + scanInstance.Spec.Profile,
 	}
+	falseP := false
+	trueP := true
 
 	if scanInstance.Spec.Debug {
 		collectorCmd = append(collectorCmd, "--debug")
@@ -284,6 +299,10 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 						fmt.Sprintf("cp %s /content | /bin/true", path.Join("/", scanInstance.Spec.Content)),
 					},
 					ImagePullPolicy: corev1.PullAlways,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &falseP,
+						ReadOnlyRootFilesystem:   &trueP,
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "content-dir",
@@ -296,10 +315,15 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 					Image:           utils.GetComponentImage(utils.OPERATOR),
 					Command:         collectorCmd,
 					ImagePullPolicy: corev1.PullAlways,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &falseP,
+						ReadOnlyRootFilesystem:   &trueP,
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "content-dir",
 							MountPath: "/content",
+							ReadOnly:  true,
 						},
 						{
 							Name:      "fetch-results",
@@ -327,6 +351,10 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 						"--tls-ca=/etc/pki/tls/ca.crt",
 					},
 					ImagePullPolicy: corev1.PullAlways,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &falseP,
+						ReadOnlyRootFilesystem:   &trueP,
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "report-dir",
@@ -344,6 +372,10 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 					Name:    OpenSCAPScanContainerName,
 					Image:   utils.GetComponentImage(utils.OPENSCAP),
 					Command: []string{OpenScapScriptPath},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &falseP,
+						ReadOnlyRootFilesystem:   &trueP,
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "report-dir",

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -193,6 +193,10 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 							ReadOnly:  true,
 						},
 						{
+							Name:      "tmp-dir",
+							MountPath: "/tmp",
+						},
+						{
 							Name:      scriptCmForScan(scanInstance),
 							MountPath: "/scripts",
 							ReadOnly:  true,
@@ -232,6 +236,12 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 				},
 				{
 					Name: "content-dir",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: "tmp-dir",
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
@@ -387,6 +397,10 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 							ReadOnly:  true,
 						},
 						{
+							Name:      "tmp-dir",
+							MountPath: "/tmp",
+						},
+						{
 							Name:      "fetch-results",
 							MountPath: PlatformScanDataRoot,
 						},
@@ -421,6 +435,12 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 				},
 				{
 					Name: "content-dir",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: "tmp-dir",
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},

--- a/pkg/controller/compliancesuite/suitererunner.go
+++ b/pkg/controller/compliancesuite/suitererunner.go
@@ -98,6 +98,8 @@ func GetRerunnerName(suiteName string) string {
 }
 
 func getRerunner(suite *compv1alpha1.ComplianceSuite) *batchv1beta1.CronJob {
+	falseP := false
+	trueP := true
 	return &batchv1beta1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetRerunnerName(suite.Name),
@@ -122,6 +124,10 @@ func getRerunner(suite *compv1alpha1.ComplianceSuite) *batchv1beta1.CronJob {
 								{
 									Name:  "rerunner",
 									Image: utils.GetComponentImage(utils.OPERATOR),
+									SecurityContext: &corev1.SecurityContext{
+										AllowPrivilegeEscalation: &falseP,
+										ReadOnlyRootFilesystem:   &trueP,
+									},
 									Command: []string{
 										"compliance-operator", "suitererunner",
 										"--name", suite.GetName(),

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -306,6 +306,8 @@ func getISTagAnnotation(isTagName, isTagNamespace string) map[string]string {
 
 // newPodForBundle returns a busybox pod with the same name/namespace as the cr
 func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *appsv1.Deployment {
+	falseP := false
+	trueP := true
 	labels := getWorkloadLabels(pb)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -333,6 +335,10 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *a
 								fmt.Sprintf("cp %s /content | /bin/true", path.Join("/", pb.Spec.ContentFile)),
 							},
 							ImagePullPolicy: corev1.PullAlways,
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &falseP,
+								ReadOnlyRootFilesystem:   &trueP,
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "content-dir",
@@ -343,6 +349,10 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *a
 						{
 							Name:  "profileparser",
 							Image: utils.GetComponentImage(utils.OPERATOR),
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &falseP,
+								ReadOnlyRootFilesystem:   &trueP,
+							},
 							Command: []string{
 								"compliance-operator", "profileparser",
 								"--name", pb.Name,
@@ -362,6 +372,10 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *a
 						{
 							Name:  "pauser",
 							Image: utils.GetComponentImage(utils.OPERATOR),
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &falseP,
+								ReadOnlyRootFilesystem:   &trueP,
+							},
 							Command: []string{
 								"compliance-operator", "pause",
 								"--main-container", "profileparser",


### PR DESCRIPTION
This sets up some general hardening settings such as:

* Disallowing privilege escalation
* Read-only container filesystem

It also adds a read-only flag for a mount where needed.

This also mounts `/tmp` as an empty dir for the scanner containers. This
is because OpenSCAP will attempt to create a directory in `/tmp` in
order to temporarily dump the OVAL results. This way, we can mount the
directory and write to it, while still keeping the rest of the container
in a read-only filesystem.