### PR TITLE
Limit parallelism in our go test invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ E2E_SKIP_CONTAINER_BUILD?=false
 # Pass extra flags to the e2e test run.
 # e.g. to run a specific test in the e2e test suite, do:
 # 	make e2e E2E_GO_TEST_FLAGS="-v -run TestE2E/TestScanWithNodeSelectorFiltersCorrectly"
-E2E_GO_TEST_FLAGS?=-test.v -test.timeout 120m
+E2E_GO_TEST_FLAGS?=-test.v -test.timeout 120m -test.p 2
 
 # Specifies the image path to use for the content in the tests
 DEFAULT_CONTENT_IMAGE_PATH=quay.io/complianceascode/ocp4:latest


### PR DESCRIPTION
This will limit the amount of processes to run parallel tests.