### PR TITLE
e2e/testUnapplyRemediation: Wait for MC to change before continuing

### DIFF
--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -391,7 +391,7 @@ func createOrUpdateMachineConfig(r *ReconcileComplianceRemediation, merged *mcfg
 		// If we have already applied this there's nothing to do
 		logger.Info("Remediation already applied, doing nothing")
 		return nil
-	} else if !rem.Spec.Apply && !mcHasRemediationAnnotation(mc, rem) {
+	} else if !rem.Spec.Apply && !MCHasRemediationAnnotation(mc, rem) {
 		// If we have already un-applied this there's nothing to do
 		logger.Info("Remediation already unapplied, doing nothing")
 		return nil
@@ -471,7 +471,7 @@ func ensureRemediationAnnotationIsNotSet(mc *mcfgv1.MachineConfig, rem *compv1al
 	}
 }
 
-func mcHasRemediationAnnotation(mc *mcfgv1.MachineConfig, rem *compv1alpha1.ComplianceRemediation) bool {
+func MCHasRemediationAnnotation(mc *mcfgv1.MachineConfig, rem *compv1alpha1.ComplianceRemediation) bool {
 	if mc.Annotations == nil {
 		return false
 	}

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -36,6 +36,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/compliance-operator/pkg/apis"
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/openshift/compliance-operator/pkg/controller/complianceremediation"
 	compsuitectrl "github.com/openshift/compliance-operator/pkg/controller/compliancesuite"
 	"github.com/openshift/compliance-operator/pkg/utils"
 	mcfgapi "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io"
@@ -1042,9 +1043,18 @@ func unApplyRemediationAndCheck(t *testing.T, f *framework.Framework, namespace,
 
 	predicate := func(t *testing.T, pool *mcfgv1.MachineConfigPool) (bool, error) {
 		// If the remediation that we deselect is NOT the last one, it is expected
-		// that the MC would still be present. Just return true in this case.
+		// that the MC would still be present. Check for appropriate annotation
 		if lastRemediation == false {
-			return true, nil
+			mc := &mcfgv1.MachineConfig{}
+			err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: rem.GetMcName()}, mc)
+			if err != nil {
+				E2ELogf(t, "Error while getting relevant MC, returning false: %v", err)
+				return false, nil
+			}
+
+			// If the MC doesn't have the appropriate annotation, we keep
+			// going...
+			return !complianceremediation.MCHasRemediationAnnotation(mc, rem), nil
 		}
 
 		// On the other hand, if the remediation we deselect WAS the last one, we want


### PR DESCRIPTION
We were not giving the operator enough time to update the MachineConfig
obejct before continuing with the test. This resulted in flaky e2e
tests.

Co-Authored-By: Jakub Hrozek <jhrozek@redhat.com>