### PR TITLE
Bug 1899479: Aggregator: Only parse ConfigMaps with results

### DIFF
--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -99,7 +99,10 @@ func getScanConfigMaps(crClient *complianceCrClient, scan, namespace string) ([]
 
 	// Look for configMap with this scan label
 	inNs := client.InNamespace(namespace)
-	withLabel := client.MatchingLabels{compv1alpha1.ComplianceScanLabel: scan}
+	withLabel := client.MatchingLabels{
+		compv1alpha1.ComplianceScanLabel: scan,
+		compv1alpha1.ResultLabel:         "",
+	}
 
 	err = crClient.client.List(context.TODO(), cMapList, inNs, withLabel)
 	if err != nil {


### PR DESCRIPTION
The aggregatorw as parsing all configMaps relevant to the scan. But
adding the relevant result label to the label selector that the pod uses
to fetch the configmaps, we can reduce the number of configmaps is
fetches and:

* Have cleaner aggregator logs
* Have a (slightly) more efficient aggregator