### PR TITLE
Add support for remediation patching (4.6 backport)

### DIFF
--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -27,7 +27,8 @@ const (
 
 const (
 	// OutdatedRemediationLabel specifies that the remediation has been superseded by a newer version
-	OutdatedRemediationLabel = "complianceoperator.openshift.io/outdated-remediation"
+	OutdatedRemediationLabel               = "complianceoperator.openshift.io/outdated-remediation"
+	RemediationCreatedByOperatorAnnotation = "compliance.openshift.io/remediation"
 )
 
 type ComplianceRemediationSpecMeta struct {
@@ -116,6 +117,28 @@ type ComplianceRemediationList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ComplianceRemediation `json:"items"`
+}
+
+// AddRemediationAnnotation annotates an object to say it was created
+// by this operator
+func AddRemediationAnnotation(obj metav1.Object) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[RemediationCreatedByOperatorAnnotation] = ""
+	obj.SetAnnotations(annotations)
+}
+
+// AddRemediationAnnotation tells us if an object was created by this
+// operator
+func RemediationWasCreatedByOperator(obj metav1.Object) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, ok := annotations[RemediationCreatedByOperatorAnnotation]
+	return ok
 }
 
 func init() {

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -47,6 +47,11 @@ var contentImagePath string
 var rhcosPb *compv1alpha1.ProfileBundle
 var ocp4Pb *compv1alpha1.ProfileBundle
 
+type ObjectResouceVersioner interface {
+	runtime.Object
+	metav1.Common
+}
+
 func init() {
 	contentImagePath = os.Getenv("CONTENT_IMAGE")
 
@@ -485,6 +490,38 @@ func waitForObjectToExist(t *testing.T, f *framework.Framework, name, namespace 
 				return false, nil
 			}
 			E2ELogf(t, "Retrying. Got error: %v\n", lastErr)
+			return false, nil
+		}
+
+		return true, nil
+	})
+	// Error in function call
+	if lastErr != nil {
+		return lastErr
+	}
+	// Timeout
+	if timeouterr != nil {
+		return timeouterr
+	}
+
+	E2ELogf(t, "Object found '%s' found\n", name)
+	return nil
+}
+
+func waitForObjectToUpdate(t *testing.T, f *framework.Framework, name, namespace string, obj ObjectResouceVersioner) error {
+	var lastErr error
+
+	initialVersion := obj.GetResourceVersion()
+
+	// retry and ignore errors until timeout
+	timeouterr := wait.Poll(retryInterval, timeout, func() (bool, error) {
+		lastErr = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, obj)
+		if lastErr != nil {
+			E2ELogf(t, "Retrying. Got error: %v\n", lastErr)
+			return false, nil
+		}
+		if obj.GetResourceVersion() == initialVersion {
+			E2ELogf(t, "Retrying. Object still doesn't update. got version %s ... wanted %s\n", obj.GetResourceVersion(), initialVersion)
 			return false, nil
 		}
 


### PR DESCRIPTION
This enables us to create partial remediations, these will merely patch
the objects that already exist in kube and ensure that they're
compliant.

If an object is created from scratch, it'll annotate the object saying
the operator created it.

If an object already exists on the cluster, it is patched.

When unapplying remediations, the operator will only delete objects that
were created by the operator to begin with. However, we currently won't
be able to roll back remediations that patched objects.

On the other hand, this patch makes sure to handle authorization issues with
remediations by surfacing any RBAC issues we encounter when
applying/unapplying remediations.

This handles cases where we don't have permission to get/create/patch a
certain object, and it should reflect it in the remediation's status.