### PR TITLE
Improve e2e test logging

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -62,7 +62,7 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				} else if found != true {
-					t.Errorf("Expected rule %s not found", prefixName(pbName, removedRule))
+					E2EErrorf(t, "Expected rule %s not found", prefixName(pbName, removedRule))
 					return err
 				}
 
@@ -73,7 +73,7 @@ func TestE2E(t *testing.T) {
 				}
 				found = findRuleReference(profilePreUpdate, prefixName(pbName, unlinkedRule))
 				if found != true {
-					t.Errorf("Expected rule %s not found", prefixName(pbName, unlinkedRule))
+					E2EErrorf(t, "Expected rule %s not found", prefixName(pbName, unlinkedRule))
 					return err
 				}
 
@@ -105,7 +105,7 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				} else if found != false {
-					t.Errorf("Rule %s unexpectedly found", prefixName(pbName, removedRule))
+					E2EErrorf(t, "Rule %s unexpectedly found", prefixName(pbName, removedRule))
 					return err
 				}
 
@@ -116,7 +116,7 @@ func TestE2E(t *testing.T) {
 				}
 				found = findRuleReference(profilePostUpdate, prefixName(pbName, unlinkedRule))
 				if found != false {
-					t.Errorf("Rule %s unexpectedly found", prefixName(pbName, unlinkedRule))
+					E2EErrorf(t, "Rule %s unexpectedly found", prefixName(pbName, unlinkedRule))
 					return err
 				}
 
@@ -174,7 +174,7 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				} else if found != true {
-					t.Errorf("Expected rule %s not found", prefixName(pbName, removedRule))
+					E2EErrorf(t, "Expected rule %s not found", prefixName(pbName, removedRule))
 					return err
 				}
 
@@ -185,7 +185,7 @@ func TestE2E(t *testing.T) {
 				}
 				found = findRuleReference(profilePreUpdate, prefixName(pbName, unlinkedRule))
 				if found != true {
-					t.Errorf("Expected rule %s not found", prefixName(pbName, unlinkedRule))
+					E2EErrorf(t, "Expected rule %s not found", prefixName(pbName, unlinkedRule))
 					return err
 				}
 
@@ -210,7 +210,7 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				} else if found != false {
-					t.Errorf("Rule %s unexpectedly found", prefixName(pbName, removedRule))
+					E2EErrorf(t, "Rule %s unexpectedly found", prefixName(pbName, removedRule))
 					return err
 				}
 
@@ -221,7 +221,7 @@ func TestE2E(t *testing.T) {
 				}
 				found = findRuleReference(profilePostUpdate, prefixName(pbName, unlinkedRule))
 				if found != false {
-					t.Errorf("Rule %s unexpectedly found", prefixName(pbName, unlinkedRule))
+					E2EErrorf(t, "Rule %s unexpectedly found", prefixName(pbName, unlinkedRule))
 					return err
 				}
 
@@ -280,7 +280,7 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				} else if found != true {
-					t.Errorf("Expected rule %s not found", prefixName(pbName, removedRule))
+					E2EErrorf(t, "Expected rule %s not found", prefixName(pbName, removedRule))
 					return err
 				}
 
@@ -291,7 +291,7 @@ func TestE2E(t *testing.T) {
 				}
 				found = findRuleReference(profilePreUpdate, prefixName(pbName, unlinkedRule))
 				if found != true {
-					t.Errorf("Expected rule %s not found", prefixName(pbName, unlinkedRule))
+					E2EErrorf(t, "Expected rule %s not found", prefixName(pbName, unlinkedRule))
 					return err
 				}
 
@@ -316,7 +316,7 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				} else if found != false {
-					t.Errorf("Rule %s unexpectedly found", prefixName(pbName, removedRule))
+					E2EErrorf(t, "Rule %s unexpectedly found", prefixName(pbName, removedRule))
 					return err
 				}
 
@@ -327,7 +327,7 @@ func TestE2E(t *testing.T) {
 				}
 				found = findRuleReference(profilePostUpdate, prefixName(pbName, unlinkedRule))
 				if found != false {
-					t.Errorf("Rule %s unexpectedly found", prefixName(pbName, unlinkedRule))
+					E2EErrorf(t, "Rule %s unexpectedly found", prefixName(pbName, unlinkedRule))
 					return err
 				}
 
@@ -1867,7 +1867,7 @@ func TestE2E(t *testing.T) {
 				}
 
 				if masterScan.Spec.Debug != true {
-					t.Errorf("Expected that the settings set debug to true in master scan")
+					E2EErrorf(t, "Expected that the settings set debug to true in master scan")
 				}
 
 				workerScanKey := types.NamespacedName{Namespace: namespace, Name: rhcos4e8profile.Name + "-worker"}
@@ -1877,7 +1877,7 @@ func TestE2E(t *testing.T) {
 				}
 
 				if workerScan.Spec.Debug != true {
-					t.Errorf("Expected that the settings set debug to true in workers scan")
+					E2EErrorf(t, "Expected that the settings set debug to true in workers scan")
 				}
 
 				return nil
@@ -1920,7 +1920,7 @@ func TestE2E(t *testing.T) {
 
 				err := mcTctx.createE2EPool()
 				if err != nil {
-					t.Errorf("Cannot create subpool for this test")
+					E2EErrorf(t, "Cannot create subpool for this test")
 					return err
 				}
 
@@ -1948,7 +1948,7 @@ func TestE2E(t *testing.T) {
 				workersNoRootLoginsRemName := fmt.Sprintf("%s-no-direct-root-logins", workerScanName)
 				err = waitForRemediationToBeAutoApplied(t, f, workersNoRootLoginsRemName, namespace, poolBeforeRemediation)
 				if err != nil {
-					t.Errorf("Failed to wait for nodes to come back up after applying MC: %v", err)
+					E2EErrorf(t, "Failed to wait for nodes to come back up after applying MC: %v", err)
 					return err
 				}
 
@@ -2023,14 +2023,14 @@ func TestE2E(t *testing.T) {
 				// We need to wait for both the pool to update..
 				err = waitForMachinePoolUpdate(t, f, testPoolName, dummyAction, poolHasNoMc, nil)
 				if err != nil {
-					t.Errorf("Failed to wait for workers to come back up after deleting MC")
+					E2EErrorf(t, "Failed to wait for workers to come back up after deleting MC")
 					return err
 				}
 
 				// ..as well as the nodes
 				err = waitForNodesToBeReady(t, f)
 				if err != nil {
-					t.Errorf("Failed to wait for nodes to come back up after applying MC: %v", err)
+					E2EErrorf(t, "Failed to wait for nodes to come back up after applying MC: %v", err)
 					return err
 				}
 
@@ -2075,7 +2075,7 @@ func TestE2E(t *testing.T) {
 
 				err := mcTctx.createE2EPool()
 				if err != nil {
-					t.Errorf("Cannot create subpool for this test")
+					E2EErrorf(t, "Cannot create subpool for this test")
 					return err
 				}
 
@@ -2119,7 +2119,7 @@ func TestE2E(t *testing.T) {
 
 				err = waitForNodesToBeReady(t, f)
 				if err != nil {
-					t.Errorf("Failed to wait for nodes to come back up after applying MC: %v", err)
+					E2EErrorf(t, "Failed to wait for nodes to come back up after applying MC: %v", err)
 					return err
 				}
 
@@ -2140,7 +2140,7 @@ func TestE2E(t *testing.T) {
 				err = f.Client.Get(goctx.TODO(), mcName, mcOne)
 
 				if mcOne.Generation == mcBoth.Generation {
-					t.Errorf("Expected that the MC generation changes. Got: %d, Expected: %d", mcOne.Generation, mcBoth.Generation)
+					E2EErrorf(t, "Expected that the MC generation changes. Got: %d, Expected: %d", mcOne.Generation, mcBoth.Generation)
 				}
 
 				// When we unapply the second remediation, the MC should be deleted, too
@@ -2152,7 +2152,7 @@ func TestE2E(t *testing.T) {
 				mcShouldntExist := &mcfgv1.MachineConfig{}
 				err = f.Client.Get(goctx.TODO(), mcName, mcShouldntExist)
 				if err == nil {
-					t.Errorf("MC %s unexpectedly found", mcName)
+					E2EErrorf(t, "MC %s unexpectedly found", mcName)
 				}
 
 				return nil
@@ -2209,7 +2209,7 @@ func TestE2E(t *testing.T) {
 				// Ensure that all the scans in the suite have finished and are marked as Done
 				err = waitForSuiteScansStatus(t, f, namespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultInconsistent)
 				if err != nil {
-					t.Errorf("Got an unexpected status")
+					E2EErrorf(t, "Got an unexpected status")
 				}
 
 				if err := f.KubeClient.CoreV1().Pods(namespace).Delete(goctx.TODO(), pod.Name, metav1.DeleteOptions{}); err != nil {
@@ -2528,7 +2528,7 @@ func TestE2E(t *testing.T) {
 
 				err := mcTctx.createE2EPool()
 				if err != nil {
-					t.Errorf("Cannot create subpool for this test")
+					E2EErrorf(t, "Cannot create subpool for this test")
 					return err
 				}
 
@@ -2552,7 +2552,7 @@ func TestE2E(t *testing.T) {
 
 				err = waitForNodesToBeReady(t, f)
 				if err != nil {
-					t.Errorf("Failed to wait for nodes to come back up after applying MC: %v", err)
+					E2EErrorf(t, "Failed to wait for nodes to come back up after applying MC: %v", err)
 					return err
 				}
 
@@ -2597,7 +2597,7 @@ func TestE2E(t *testing.T) {
 
 				err = waitForNodesToBeReady(t, f)
 				if err != nil {
-					t.Errorf("Failed to wait for nodes to come back up after applying MC: %v", err)
+					E2EErrorf(t, "Failed to wait for nodes to come back up after applying MC: %v", err)
 					return err
 				}
 
@@ -2619,7 +2619,7 @@ func TestE2E(t *testing.T) {
 
 				err = waitForNodesToBeReady(t, f)
 				if err != nil {
-					t.Errorf("Failed to wait for nodes to come back up after unapplying MC: %v", err)
+					E2EErrorf(t, "Failed to wait for nodes to come back up after unapplying MC: %v", err)
 					return err
 				}
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -2386,7 +2386,7 @@ func TestE2E(t *testing.T) {
 				defer func() {
 					err := f.KubeClient.CoreV1().Secrets("openshift-config").Delete(goctx.TODO(), "htpass", metav1.DeleteOptions{})
 					if err != nil {
-						t.Logf("could not clean up openshift-config/htpass test secret: %v", err)
+						E2ELogf(t, "could not clean up openshift-config/htpass test secret: %v", err)
 					}
 				}()
 
@@ -2416,7 +2416,7 @@ func TestE2E(t *testing.T) {
 
 				err = f.Client.Update(goctx.TODO(), oauthUpdate)
 				if err != nil {
-					t.Logf("error updating idp: %v", err)
+					E2ELogf(t, "error updating idp: %v", err)
 					return err
 				}
 
@@ -2424,7 +2424,7 @@ func TestE2E(t *testing.T) {
 					fetchedOauth := &configv1.OAuth{}
 					err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "cluster"}, fetchedOauth)
 					if err != nil {
-						t.Logf("error restoring idp: %v", err)
+						E2ELogf(t, "error restoring idp: %v", err)
 					} else {
 						oauth := fetchedOauth.DeepCopy()
 						// Make sure it's cleared out
@@ -2433,7 +2433,7 @@ func TestE2E(t *testing.T) {
 						}
 						err = f.Client.Update(goctx.TODO(), oauth)
 						if err != nil {
-							t.Logf("error restoring idp: %v", err)
+							E2ELogf(t, "error restoring idp: %v", err)
 						}
 					}
 				}()

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1796,33 +1796,33 @@ func initContainerCompleted(t *testing.T, c kubernetes.Interface, name, namespac
 			return false, err
 		}
 		if apierrors.IsNotFound(err) {
-			t.Logf("Pod %s not found yet", name)
+			E2ELogf(t, "Pod %s not found yet", name)
 			return false, nil
 		}
 
 		for _, initStatus := range pod.Status.InitContainerStatuses {
-			t.Log(initStatus)
+			E2ELog(t, initStatus)
 			// the init container must have passed the readiness probe
 			if initStatus.Ready == false {
-				t.Log("Init container not ready yet")
+				E2ELog(t, "Init container not ready yet")
 				return false, nil
 			}
 
 			// the init container must have terminated
 			if initStatus.State.Terminated == nil {
-				t.Log("Init container did not terminate yet")
+				E2ELog(t, "Init container did not terminate yet")
 				return false, nil
 			}
 
 			if initStatus.State.Terminated.ExitCode != 0 {
 				return true, errors.New("the init container failed")
 			} else {
-				t.Logf("init container in pod %s has finished", name)
+				E2ELogf(t, "init container in pod %s has finished", name)
 				return true, nil
 			}
 		}
 
-		t.Logf("init container in pod %s not finished yet", name)
+		E2ELogf(t, "init container in pod %s not finished yet", name)
 		return false, nil
 	}
 }

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -77,8 +77,8 @@ func E2ELogf(t *testing.T, format string, args ...interface{}) {
 	t.Logf(fmt.Sprintf("%s: %s", time.Now().Format(time.RFC3339), format), args...)
 }
 
-func E2ELog(t *testing.T, format string) {
-	t.Log(fmt.Sprintf("%s: %s", time.Now().Format(time.RFC3339), format))
+func E2ELog(t *testing.T, args ...interface{}) {
+	t.Log(fmt.Sprintf("%s: %s", time.Now().Format(time.RFC3339), fmt.Sprint(args...)))
 }
 
 func getObjNameFromTest(t *testing.T) string {


### PR DESCRIPTION
- e2e: Use E2ELog and E2ELogf consistently
   - e2e: Introduce E2EErrorf with a clear prefix