### PR TITLE
e2e: A bunch of minor code cleanups

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -96,7 +96,7 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
-				if err := assertMustHaveParsedRules(t, f, namespace, pbName); err != nil {
+				if err := assertMustHaveParsedRules(f, pbName); err != nil {
 					return err
 				}
 
@@ -201,7 +201,7 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
-				if err := assertMustHaveParsedRules(t, f, namespace, pbName); err != nil {
+				if err := assertMustHaveParsedRules(f, pbName); err != nil {
 					return err
 				}
 
@@ -307,7 +307,7 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
-				if err := assertMustHaveParsedRules(t, f, namespace, pbName); err != nil {
+				if err := assertMustHaveParsedRules(f, pbName); err != nil {
 					return err
 				}
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -197,7 +197,7 @@ func TestE2E(t *testing.T) {
 				// Note that when an update happens through an imagestream tag, the operator doesn't get
 				// a notification about it... It all happens on the Kube Deployment's side.
 				// So we don't need to wait for the profile bundle's statuses
-				if err := waitForDeploymentContentUpdate(t, f, namespace, pbName, modifiedImageDigest); err != nil {
+				if err := waitForDeploymentContentUpdate(t, f, pbName, modifiedImageDigest); err != nil {
 					return err
 				}
 
@@ -303,7 +303,7 @@ func TestE2E(t *testing.T) {
 				// Note that when an update happens through an imagestream tag, the operator doesn't get
 				// a notification about it... It all happens on the Kube Deployment's side.
 				// So we don't need to wait for the profile bundle's statuses
-				if err := waitForDeploymentContentUpdate(t, f, namespace, pbName, modifiedImageDigest); err != nil {
+				if err := waitForDeploymentContentUpdate(t, f, pbName, modifiedImageDigest); err != nil {
 					return err
 				}
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -340,9 +340,6 @@ func TestE2E(t *testing.T) {
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				const (
 					unexistentImage     = "bad-namespace/bad-image:latest"
-					removedRule         = "chronyd-no-chronyc-network"
-					unlinkedRule        = "chronyd-client-only"
-					moderateProfileName = "moderate"
 				)
 
 				pbName := getObjNameFromTest(t)
@@ -374,9 +371,6 @@ func TestE2E(t *testing.T) {
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
 				const (
 					noTagImage          = "bad-namespace/bad-image"
-					removedRule         = "chronyd-no-chronyc-network"
-					unlinkedRule        = "chronyd-client-only"
-					moderateProfileName = "moderate"
 				)
 
 				pbName := getObjNameFromTest(t)

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1519,7 +1519,7 @@ func waitForDeploymentContentUpdate(t *testing.T, f *framework.Framework, namesp
 	return nil
 }
 
-func assertMustHaveParsedRules(t *testing.T, f *framework.Framework, namespace, name string) error {
+func assertMustHaveParsedRules(f *framework.Framework, name string) error {
 	var rl compv1alpha1.RuleList
 	lo := &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -311,9 +311,9 @@ func replaceNamespaceFromManifest(t *testing.T, namespace string, namespacedManP
 	if namespacedManPath == nil {
 		t.Fatal("Error: no namespaced manifest given as test argument. operator-sdk might have changed.")
 	}
-	path := *namespacedManPath
+	manPath := *namespacedManPath
 	// #nosec
-	read, err := ioutil.ReadFile(path)
+	read, err := ioutil.ReadFile(manPath)
 	if err != nil {
 		t.Fatalf("Error reading namespaced manifest file: %s", err)
 	}
@@ -321,7 +321,7 @@ func replaceNamespaceFromManifest(t *testing.T, namespace string, namespacedManP
 	newContents := strings.Replace(string(read), "openshift-compliance", namespace, -1)
 
 	// #nosec
-	err = ioutil.WriteFile(path, []byte(newContents), 644)
+	err = ioutil.WriteFile(manPath, []byte(newContents), 644)
 	if err != nil {
 		t.Fatalf("Error writing namespaced manifest file: %s", err)
 	}

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1888,7 +1888,7 @@ func getReadyProfileBundle(t *testing.T, f *framework.Framework, name, namespace
 	return pb, nil
 }
 
-func writeToArtifactsDir(t *testing.T, f *framework.Framework, dir, scan, pod, container, log string) error {
+func writeToArtifactsDir(dir, scan, pod, container, log string) error {
 	logPath := path.Join(dir, fmt.Sprintf("%s_%s_%s.log", scan, pod, container))
 	logFile, err := os.Create(logPath)
 	if err != nil {
@@ -1940,7 +1940,7 @@ func logContainerOutput(t *testing.T, f *framework.Framework, namespace, name st
 				if len(logs) == 0 {
 					E2ELogf(t, "no logs for %s/%s", pod.Name, con)
 				} else {
-					err := writeToArtifactsDir(t, f, artifacts, name, pod.Name, con, logs)
+					err := writeToArtifactsDir(artifacts, name, pod.Name, con, logs)
 					if err != nil {
 						E2ELogf(t, "error writing logs for %s/%s: %v", pod.Name, con, err)
 					} else {

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1441,7 +1441,7 @@ func findRuleReference(profile *compv1alpha1.Profile, ruleName string) bool {
 	return false
 }
 
-func waitForDeploymentContentUpdate(t *testing.T, f *framework.Framework, namespace, name, imgDigest string) error {
+func waitForDeploymentContentUpdate(t *testing.T, f *framework.Framework, name, imgDigest string) error {
 	lo := &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"profile-bundle": name,


### PR DESCRIPTION
It seems like GoLand update makes some warnings more prominent since a
recent upgrade, so fixing them makes my editor a little less colorful.