### PR TITLE
e2e: Enhancements to the rotation-checker pod

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1631,9 +1631,10 @@ func getRotationCheckerWorkload(namespace, rawResultName string) *corev1.Pod {
 			RestartPolicy: corev1.RestartPolicyOnFailure,
 			Containers: []corev1.Container{
 				{
-					Name:    "checker",
-					Image:   "registry.access.redhat.com/ubi8/ubi-minimal",
-					Command: []string{"/bin/bash", "-c", "ls /raw-results | grep -v 'lost+found'"},
+					Name:            "checker",
+					Image:           "registry.access.redhat.com/ubi8/ubi-minimal",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"/bin/bash", "-c", "ls /raw-results | grep -v 'lost+found'"},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "raw-results",


### PR DESCRIPTION
The testScheduledSuite tends to take a long time. We've noticed this
happens because it might take a long time to schedule the
rotation-checker pod. This pod will merely mount the PVC from the scan
and list the current results. We use this to verify that rotation has
indeed happened.

The hope is that by changing the rotation policy to PullIfNotPresent,
the image will already be in the node and the pod will have a faster
scheduling time