### PR TITLE
Use Fedora 33 as base for OpenSCAP images

### DIFF
--- a/images/openscap/Dockerfile
+++ b/images/openscap/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.fedoraproject.org/fedora-minimal:33
 
 LABEL \
     name="openscap-ocp" \
@@ -7,10 +7,6 @@ LABEL \
     io.k8s.description="OpenSCAP security scanner for scanning hosts through a host mount" \
     io.openshift.tags="compliance openscap scan" \
     io.openshift.wants="scap-content"
-
-# The repo will only be needed until RHEL-8.2 comes out
-COPY \
-    jhrozek-openscap-1.3.4-epel-8.repo /etc/yum.repos.d/
 
 RUN true \
     && microdnf install -y openscap-scanner \

--- a/images/openscap/Dockerfile.ci
+++ b/images/openscap/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/origin/4.6:base
+FROM registry.fedoraproject.org/fedora-minimal:33
 
 LABEL \
     name="openscap-ocp" \
@@ -7,10 +7,6 @@ LABEL \
     io.k8s.description="OpenSCAP security scanner for scanning hosts through a host mount" \
     io.openshift.tags="compliance openscap scan" \
     io.openshift.wants="scap-content"
-
-# The repo will only be needed until RHEL-8.2 comes out
-COPY \
-    jhrozek-openscap-1.3.4-epel-8.repo /etc/yum.repos.d/
 
 RUN true \
     && microdnf install -y openscap-scanner \

--- a/images/openscap/Dockerfile.maint-1.3
+++ b/images/openscap/Dockerfile.maint-1.3
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.fedoraproject.org/fedora-minimal:33
 
 LABEL \
     name="openscap-ocp" \
@@ -7,10 +7,6 @@ LABEL \
     io.k8s.description="OpenSCAP security scanner for scanning hosts through a host mount - test version" \
     io.openshift.tags="compliance openscap scan" \
     io.openshift.wants="scap-content"
-
-# The repo is only for testing. Used to create quay.io/compliance-operator/openscap-ocp:1.3.3
-COPY \
-    mrogers-openscap-with-yaml-epel-8.repo /etc/yum.repos.d/
 
 RUN true \
     && microdnf install -y openscap-scanner \


### PR DESCRIPTION
This will only apply upstream, and ensures that we get the latest fixes
from OpenSCAP.