### PR TITLE
Fixes necessary for etcd encryption remediation

### DIFF
--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -277,7 +277,12 @@ func createOrUpdateOneResult(crClient *complianceCrClient, owner metav1.Object, 
 	return nil
 }
 
-func canCreateRemediation(scan *compv1alpha1.ComplianceScan) (bool, string) {
+func canCreateRemediation(scan *compv1alpha1.ComplianceScan, obj runtime.Object) (bool, string) {
+	// FIXME(jaosorior): Figure out a more pluggable way of adding these sorts of special cases
+	if obj.GetObjectKind().GroupVersionKind().Kind != "MachineConfig" {
+		return true, ""
+	}
+
 	role := utils.GetFirstNodeRole(scan.Spec.NodeSelector)
 	if role == "" {
 		return false, "ComplianceScan's nodeSelector doesn't have any role. Ideally this needs to match a MachineConfigPool"
@@ -366,7 +371,9 @@ func createResults(crClient *complianceCrClient, scan *compv1alpha1.ComplianceSc
 			continue
 		}
 
-		if canCreate, why := canCreateRemediation(scan); !canCreate {
+		remTargetObj := pr.Remediation.Spec.Current.Object
+
+		if canCreate, why := canCreateRemediation(scan, remTargetObj); !canCreate {
 			// Only issue event once.
 			if !remediationNotPossibleEventIssued {
 				log.Info(why)
@@ -376,7 +383,6 @@ func createResults(crClient *complianceCrClient, scan *compv1alpha1.ComplianceSc
 			continue
 		}
 
-		remTargetObj := pr.Remediation.Spec.Current.Object
 		remLabels := getRemediationLabels(scan, remTargetObj)
 
 		// The state even if set in the object would have been overwritten by the call to

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -159,6 +159,19 @@ rules:
   verbs:
   - get
   - list
+# These are needed for the CIS benchmark
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  resourceNames:
+  - cluster
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
This PR ads the necessary fixes for us to be able to write an automated
remediationf or the encryption provider.

This fixes:

* The aggregator, as it now can fully apply remediations other than
  machineconfigs even if no nodeSelector was used.
* The operator's clusterrole; since it now has permissions to get and modify
  the apiservers object called `cluster`