### PR TITLE
make: Don't use cache when building the openscap image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ operator-image:
 
 .PHONY: openscap-image
 openscap-image:
-	$(RUNTIME) build -t $(RELATED_IMAGE_OPENSCAP_PATH):$(TAG) $(OPENSCAP_DOCKER_CONTEXT)
+	$(RUNTIME) build --no-cache -t $(RELATED_IMAGE_OPENSCAP_PATH):$(TAG) $(OPENSCAP_DOCKER_CONTEXT)
 
 .PHONY: bundle-image
 bundle-image:


### PR DESCRIPTION
We seldom rebuild the openscap image and when we do, we usually change
the contents of one of the repos that the image references, not the
image itself. Therefore it's safer even if a bit slower to use
--no-cache for the build and make sure the new packages are always
pulled from the repository.