### PR TITLE
scan: Include the exact openscap version in scanner output

### DIFF
--- a/pkg/controller/compliancescan/config.go
+++ b/pkg/controller/compliancescan/config.go
@@ -111,7 +111,7 @@ cmd+=($CONTENT)
 # The whole purpose of the shell entrypoint is to semi-atomically
 # move the results file when the command is done so the log collector
 # picks up the whole thing and not a partial file
-echo "Running oscap-chroot as ${cmd[@]}"
+echo "Running oscap-chroot $(rpm -q openscap-scanner) as ${cmd[@]}"
 "${cmd[@]}" &> $REPORT_DIR/cmd_output 
 rv=$?
 echo "The scanner returned $rv"


### PR DESCRIPTION
The message looks like:
```
Running oscap-chroot openscap-scanner-1.3.4-4.el8.x86_64 as oscap-chroot
/host xccdf eval --verbose INFO --fetch-remote-resources --profile
xccdf_org.ssgproject.content_profile_cis-node --results-arf
/tmp/report-arf.xml --rule
xccdf_org.ssgproject.content_rule_api_server_cmdline_param_basic_auth
/content/ssg-ocp4-ds.xml
```