### PR TITLE
Add and fix relevant operator information in the CSV

### DIFF
--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -2,6 +2,11 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
+    "operatorframework.io/suggested-namespace": openshift-compliance
+    capabilities: Seamless Upgrades
+    categories: Monitoring,Security
+    repository: https://github.com/openshift/compliance-operator
+    support: Red Hat Inc.
     alm-examples: |-
       [
         {
@@ -157,7 +162,6 @@ metadata:
           }
         }
       ]
-    capabilities: Basic Install
   name: compliance-operator.v0.1.20
   namespace: placeholder
 spec:
@@ -1280,9 +1284,9 @@ spec:
     type: OwnNamespace
   - supported: true
     type: SingleNamespace
-  - supported: false
-    type: MultiNamespace
   - supported: true
+    type: MultiNamespace
+  - supported: false
     type: AllNamespaces
   keywords:
   - security


### PR DESCRIPTION
The CSV can display relevant information about the operator. We weren't
using this feature... So let's do it!

This adds information about the operator itself and it's capabilities.
This will help users find the operator in the OperatorHub.

It also sets the "suggested-namespace" annotation, which enables the OLM
to automatically create the required namespace.

Also, it fixes the installation capabilities to reflect what the
operator actually supports.