### PR TITLE
scan: Add container memory resource requests for log-collector and scanner

### DIFF
--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -3,6 +3,7 @@ package compliancescan
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"path"
 	"strings"
 
@@ -23,6 +24,9 @@ const (
 	apiResourceCollectorSA  = "api-resource-collector"
 	tailoringCMVolumeName   = "tailoring"
 	tailoringNotFoundPrefix = "Tailoring ConfigMap not found: "
+
+	logCollectorRequiredMemory = "200Mi"
+	scapScannerRequiredMemory  = "500Mi"
 )
 
 func (r *ReconcileComplianceScan) createScanPods(instance *compv1alpha1.ComplianceScan, nodes corev1.NodeList, logger logr.Logger) error {
@@ -154,6 +158,11 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 						AllowPrivilegeEscalation: &falseP,
 						ReadOnlyRootFilesystem:   &trueP,
 					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse(logCollectorRequiredMemory),
+						},
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "report-dir",
@@ -176,6 +185,11 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 						ReadOnlyRootFilesystem: &trueP,
 						// TODO(jaosorior): Figure out if the default
 						// seccomp profile is sufficient here.
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse(scapScannerRequiredMemory),
+						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -371,6 +385,11 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 						AllowPrivilegeEscalation: &falseP,
 						ReadOnlyRootFilesystem:   &trueP,
 					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse(logCollectorRequiredMemory),
+						},
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "report-dir",
@@ -391,6 +410,11 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &falseP,
 						ReadOnlyRootFilesystem:   &trueP,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse(scapScannerRequiredMemory),
+						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{


### PR DESCRIPTION
Since both the log-collector and scanner containers are quite memory
intensive, it makes sense to help kubelet in scheduling them only to
nodes that have a sufficient amount of memory.

The initial numbers were based on observing the pods using "oc adm top
pods" as well as some observations using valgrind and asking openscap
developers.