### PR TITLE
Allow the api-resource-collector to get clusterlogforwarder objects

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1041,3 +1041,14 @@ rules:
   - get
   - list
   - watch
+# Necessary for the CIS benchmark
+- apiGroups:
+  - logging.openshift.io
+  resources:
+  - clusterlogforwarders
+  resourceNames:
+  - instance
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
This is needed to check if log forwarding is enabled.