### PR TITLE
api-resource-collector: Treat NotFound errors as non-fatal

### DIFF
--- a/cmd/manager/scap.go
+++ b/cmd/manager/scap.go
@@ -238,7 +238,7 @@ func fetch(client *kubernetes.Clientset, objects []string) (map[string][]byte, [
 			LOG("Fetching URI: '%s'", uri)
 			req := client.RESTClient().Get().RequestURI(uri)
 			stream, err := req.Stream(context.TODO())
-			if meta.IsNoMatchError(err) || kerrors.IsForbidden(err) {
+			if meta.IsNoMatchError(err) || kerrors.IsForbidden(err) || kerrors.IsNotFound(err) {
 				DBG("Encountered non-fatal error to be persisted in the scan: %s", err)
 				warnings = append(warnings, err.Error())
 				return nil


### PR DESCRIPTION
This will issue a warning if an object is not found by the
api-resource-collector. The scan will eventually detect that the object
is not there and give an appropriate result, e.g. "NON-COMPLIANT"