### PR TITLE
e2e test fixing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ E2E_SKIP_CONTAINER_BUILD?=false
 # Pass extra flags to the e2e test run.
 # e.g. to run a specific test in the e2e test suite, do:
 # 	make e2e E2E_GO_TEST_FLAGS="-v -run TestE2E/TestScanWithNodeSelectorFiltersCorrectly"
-E2E_GO_TEST_FLAGS?=-test.v -test.timeout 120m -test.p 2
+E2E_GO_TEST_FLAGS?=-test.v -test.timeout 120m
 
 # Specifies the image path to use for the content in the tests
 DEFAULT_CONTENT_IMAGE_PATH=quay.io/complianceascode/ocp4:latest

--- a/tests/e2e/constants.go
+++ b/tests/e2e/constants.go
@@ -7,6 +7,8 @@ const (
 	timeout                       = time.Minute * 20
 	cleanupRetryInterval          = time.Second * 1
 	cleanupTimeout                = time.Minute * 5
+	machineOperationTimeout       = time.Minute * 25
+	machineOperationRetryInterval = time.Second * 10
 	workerPoolName                = "worker"
 	testPoolName                  = "e2e"
 	rhcosContentFile              = "ssg-rhcos4-ds.xml"

--- a/tests/e2e/constants.go
+++ b/tests/e2e/constants.go
@@ -4,7 +4,7 @@ import "time"
 
 const (
 	retryInterval                 = time.Second * 5
-	timeout                       = time.Minute * 15
+	timeout                       = time.Minute * 20
 	cleanupRetryInterval          = time.Second * 1
 	cleanupTimeout                = time.Minute * 5
 	workerPoolName                = "worker"

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -833,8 +833,7 @@ func waitForMachinePoolUpdate(t *testing.T, f *framework.Framework, name string,
 		return err
 	}
 
-	// Should we make this configurable? Maybe 5 minutes is not enough time for slower clusters?
-	err = wait.PollImmediate(10*time.Second, 20*time.Minute, func() (bool, error) {
+	err = wait.PollImmediate(machineOperationRetryInterval, machineOperationTimeout, func() (bool, error) {
 		pool := &mcfgv1.MachineConfigPool{}
 		err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: name}, pool)
 		if err != nil {
@@ -885,7 +884,7 @@ func waitForMachinePoolUpdate(t *testing.T, f *framework.Framework, name string,
 // waitForNodesToBeReady waits until all the nodes in the cluster have
 // reached the expected machineConfig.
 func waitForNodesToBeReady(t *testing.T, f *framework.Framework) error {
-	err := wait.PollImmediate(10*time.Second, timeout, func() (bool, error) {
+	err := wait.PollImmediate(machineOperationRetryInterval, machineOperationTimeout, func() (bool, error) {
 		var nodes corev1.NodeList
 
 		f.Client.List(goctx.TODO(), &nodes, &client.ListOptions{})
@@ -929,7 +928,7 @@ func waitForNodesToHaveARenderedPool(t *testing.T, f *framework.Framework, nodes
 	}
 
 	E2ELogf(t, "We'll wait for the nodes to reach %s\n", pool.Spec.Configuration.Name)
-	return wait.PollImmediate(10*time.Second, timeout, func() (bool, error) {
+	return wait.PollImmediate(machineOperationRetryInterval, machineOperationTimeout, func() (bool, error) {
 		for _, loopNode := range nodes {
 			node := &corev1.Node{}
 			err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: loopNode.Name}, node)
@@ -1222,7 +1221,7 @@ func unPauseMachinePoolAndWait(t *testing.T, f *framework.Framework, poolName st
 
 	// When the pool updates, we need to wait for the machines to pick up the new rendered
 	// config
-	err = wait.PollImmediate(10*time.Second, 20*time.Minute, func() (bool, error) {
+	err = wait.PollImmediate(machineOperationRetryInterval, machineOperationTimeout, func() (bool, error) {
 		pool := &mcfgv1.MachineConfigPool{}
 		err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: poolName}, pool)
 		if err != nil {
@@ -1384,7 +1383,7 @@ func createMCPObject(f *framework.Framework, newPoolNodeLabel, oldPoolName, newP
 }
 
 func waitForPoolCondition(t *testing.T, f *framework.Framework, conditionType mcfgv1.MachineConfigPoolConditionType, newPoolName string) error {
-	return wait.PollImmediate(10*time.Second, 20*time.Minute, func() (bool, error) {
+	return wait.PollImmediate(machineOperationRetryInterval, machineOperationTimeout, func() (bool, error) {
 		pool := mcfgv1.MachineConfigPool{}
 		err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: newPoolName}, &pool)
 		if err != nil {


### PR DESCRIPTION
This reverts commit a97ca526e8c25747c6f6bc950e93444af5d06276. Which was "Limit parallelism in our go test invocation".

With the reasoning that this limitation isn't really doing what it should.

It also increases the timeouts in the e2e tests.