### PR TITLE
e2e: Disable parallel testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ E2E_SKIP_CONTAINER_BUILD?=false
 # Pass extra flags to the e2e test run.
 # e.g. to run a specific test in the e2e test suite, do:
 # 	make e2e E2E_GO_TEST_FLAGS="-v -run TestE2E/TestScanWithNodeSelectorFiltersCorrectly"
-E2E_GO_TEST_FLAGS?=-test.v -test.timeout 120m -test.p 2
+E2E_GO_TEST_FLAGS?=-test.v -test.timeout 140m -test.p 2
 
 # Specifies the image path to use for the content in the tests
 DEFAULT_CONTENT_IMAGE_PATH=quay.io/complianceascode/ocp4:latest

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -217,13 +217,15 @@ func executeTests(t *testing.T, tests ...testExecution) {
 	// defer deleting the profiles or else the test namespace get stuck in Terminating
 	defer f.Client.Delete(goctx.TODO(), ocp4Pb)
 
-	t.Run("Parallel tests", func(t *testing.T) {
+	t.Run("ExParallel tests", func(t *testing.T) {
 		for _, test := range tests {
 			// Don't loose test reference
 			test := test
 			if test.IsParallel {
 				t.Run(test.Name, func(tt *testing.T) {
-					tt.Parallel()
+					// FIXME(jaosorior): re-enable parallel tests once we get
+					// over the resource issues.
+					// tt.Parallel()
 					if err := test.TestFn(tt, f, ctx, mcTctx, ns); err != nil {
 						tt.Error(err)
 					}


### PR DESCRIPTION
This removes the e2e parallel tests in favor of a serial approach.

This is motivated by the fact that we're dealing with resource issues
and the kubelet de-scheduling pods or waiting too long to do so.

In face of this, this PR also increases the overall test timeout.