### PR TITLE
Remove the replaces attribute from the CSV (4.6 backport)

### DIFF
--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1299,5 +1299,5 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  replaces: compliance-operator.v0.1.19
+  replaces: compliance-operator.v0.1.17
   version: 0.1.20


### PR DESCRIPTION
This seems to be causing issues during the bundle import

(cherry picked from commit c323378f516f6d1c21ee5a02d084d3f9250a35db)