### PR TITLE
Bug 1902249: Fix tailored Platform scans

### DIFF
--- a/cmd/manager/scap.go
+++ b/cmd/manager/scap.go
@@ -47,6 +47,7 @@ type scapContentDataStream struct {
 	client *kubernetes.Clientset
 	// Staging objects
 	dataStream *utils.XMLDocument
+	tailoring  *utils.XMLDocument
 	resources  []string
 	found      map[string][]byte
 }
@@ -58,18 +59,31 @@ func NewDataStreamResourceFetcher(client *kubernetes.Clientset) ResourceFetcher 
 }
 
 func (c *scapContentDataStream) LoadSource(path string) error {
-	f, err := openNonEmptyFile(path)
-	if err != nil {
-		return err
-	}
-	// #nosec
-	defer f.Close()
-	xml, err := parseContent(f)
+	xml, err := c.loadContent(path)
 	if err != nil {
 		return err
 	}
 	c.dataStream = xml
 	return nil
+}
+
+func (c *scapContentDataStream) LoadTailoring(path string) error {
+	xml, err := c.loadContent(path)
+	if err != nil {
+		return err
+	}
+	c.tailoring = xml
+	return nil
+}
+
+func (c *scapContentDataStream) loadContent(path string) (*utils.XMLDocument, error) {
+	f, err := openNonEmptyFile(path)
+	if err != nil {
+		return nil, err
+	}
+	// #nosec
+	defer f.Close()
+	return parseContent(f)
 }
 
 func parseContent(f *os.File) (*utils.XMLDocument, error) {
@@ -118,15 +132,31 @@ func openNonEmptyFile(filename string) (*os.File, error) {
 }
 
 func (c *scapContentDataStream) FigureResources(profile string) error {
-	found := getResourcePaths(c.dataStream, profile)
-	if len(found) == 0 {
-		fmt.Printf("no valid checks found in datastream\n")
-	}
 	// Always stage the clusteroperators/openshift-apiserver object for version detection.
-	paths := []string{"/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver"}
-	paths = append(paths, found...)
+	found := []string{"/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver"}
+	effectiveProfile := profile
 
-	c.resources = paths
+	if c.tailoring != nil {
+		selected := getResourcePaths(c.tailoring, c.dataStream, profile)
+		if len(selected) == 0 {
+			fmt.Printf("no valid checks found in tailoring\n")
+		}
+		found = append(found, selected...)
+		// Overwrite profile so the next search uses the extended profile
+		effectiveProfile = c.getExtendedProfileFromTailoring(c.tailoring, profile)
+		// No profile is being extended
+		if effectiveProfile == "" {
+			c.resources = found
+			return nil
+		}
+	}
+
+	selected := getResourcePaths(c.dataStream, c.dataStream, effectiveProfile)
+	if len(selected) == 0 {
+		fmt.Printf("no valid checks found in profile\n")
+	}
+	found = append(found, selected...)
+	c.resources = found
 	return nil
 }
 
@@ -158,13 +188,13 @@ func getPathFromWarningXML(in string) string {
 
 // Collect the resource paths for objects that this scan needs to obtain.
 // The profile will have a series of "selected" checks that we grab all of the path info from.
-func getResourcePaths(ds *utils.XMLDocument, profile string) []string {
+func getResourcePaths(profileDefs *utils.XMLDocument, ruleDefs *utils.XMLDocument, profile string) []string {
 	out := []string{}
 	selectedChecks := []string{}
 
 	// First we find the Profile node, to locate the enabled checks.
 	DBG("Using profile %s", profile)
-	nodes := ds.Root.Query("//Profile")
+	nodes := profileDefs.Root.Query("//Profile")
 	for _, node := range nodes {
 		profileID := node.GetAttributeValue("id")
 		if profileID != profile {
@@ -184,7 +214,7 @@ func getResourcePaths(ds *utils.XMLDocument, profile string) []string {
 		}
 	}
 
-	checkDefinitions := ds.Root.Query("//Rule")
+	checkDefinitions := ruleDefs.Root.Query("//Rule")
 	if len(checkDefinitions) == 0 {
 		DBG("WARNING: No rules to query (invalid datastream)")
 		return out
@@ -219,6 +249,22 @@ func getResourcePaths(ds *utils.XMLDocument, profile string) []string {
 	}
 
 	return out
+}
+
+func (c *scapContentDataStream) getExtendedProfileFromTailoring(ds *utils.XMLDocument, tailoredProfile string) string {
+	nodes := ds.Root.Query("//Profile")
+	for _, node := range nodes {
+		tailoredProfileID := node.GetAttributeValue("id")
+		if tailoredProfileID != tailoredProfile {
+			continue
+		}
+
+		profileID := node.GetAttributeValue("extends")
+		if profileID != "" {
+			return profileID
+		}
+	}
+	return ""
 }
 
 func (c *scapContentDataStream) FetchResources() ([]string, error) {

--- a/cmd/manager/scap_test.go
+++ b/cmd/manager/scap_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Testing SCAP parsing and storage", func() {
 
 		It("Gets the appropriate resource URIs", func() {
 			expected := []string{"/apis/config.openshift.io/v1/oauths/cluster"}
-			got := getResourcePaths(contentDS, "xccdf_org.ssgproject.content_profile_platform-moderate")
+			got := getResourcePaths(contentDS, contentDS, "xccdf_org.ssgproject.content_profile_platform-moderate")
 			Expect(got).To(Equal(expected))
 		})
 	})

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -758,6 +758,66 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		testExecution{
+			Name:       "TestSingleTailoredPlatformScanSucceeds",
+			IsParallel: true,
+			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {
+				tailoringCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-tailored-platform-scan-succeeds-cm",
+						Namespace: namespace,
+					},
+					Data: map[string]string{
+						"tailoring.xml": `<?xml version="1.0" encoding="UTF-8"?>
+<xccdf-1.2:Tailoring xmlns:xccdf-1.2="http://checklists.nist.gov/xccdf/1.2" id="xccdf_compliance.openshift.io_tailoring_tailoredplatformprofile">
+  <xccdf-1.2:benchmark href="/content/ssg-ocp4-ds.xml"></xccdf-1.2:benchmark>
+  <xccdf-1.2:version time="2020-11-27T11:58:27Z">1</xccdf-1.2:version>
+  <xccdf-1.2:Profile id="xccdf_compliance.openshift.io_profile_test-tailoredplatformprofile">
+    <xccdf-1.2:title override="true">Test Tailored Platform profile</xccdf-1.2:title>
+    <xccdf-1.2:description override="true">This is a test for platform profile tailoring</xccdf-1.2:description>
+    <xccdf-1.2:select idref="xccdf_org.ssgproject.content_rule_scheduler_no_bind_address" selected="true"></xccdf-1.2:select>
+  </xccdf-1.2:Profile>
+</xccdf-1.2:Tailoring>`,
+					},
+				}
+
+				err := f.Client.Create(goctx.TODO(), tailoringCM, getCleanupOpts(ctx))
+				if err != nil {
+					return err
+				}
+
+				exampleComplianceScan := &compv1alpha1.ComplianceScan{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-single-tailored-platform-scan-succeeds",
+						Namespace: namespace,
+					},
+					Spec: compv1alpha1.ComplianceScanSpec{
+						ScanType:     compv1alpha1.ScanTypePlatform,
+						ContentImage: contentImagePath,
+						Profile:      "xccdf_compliance.openshift.io_profile_test-tailoredplatformprofile",
+						Rule:         "xccdf_org.ssgproject.content_rule_scheduler_no_bind_address",
+						Content:      ocpContentFile,
+						TailoringConfigMap: &compv1alpha1.TailoringConfigMapRef{
+							Name: tailoringCM.Name,
+						},
+						ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
+							Debug: true,
+						},
+					},
+				}
+				// use Context's create helper to create the object and add a cleanup function for the new object
+				err = f.Client.Create(goctx.TODO(), exampleComplianceScan, getCleanupOpts(ctx))
+				if err != nil {
+					return err
+				}
+				err = waitForScanStatus(t, f, namespace, exampleComplianceScan.Name, compv1alpha1.PhaseDone)
+				if err != nil {
+					return err
+				}
+
+				return scanResultIsExpected(t, f, namespace, exampleComplianceScan.Name, compv1alpha1.ResultCompliant)
+			},
+		},
+		testExecution{
 			Name:       "TestScanWithNodeSelectorFiltersCorrectly",
 			IsParallel: true,
 			TestFn: func(t *testing.T, f *framework.Framework, ctx *framework.Context, mcTctx *mcTestCtx, namespace string) error {


### PR DESCRIPTION
We had code duplication between two functions that were setting up the
environment variables for the scans. When adding the tailoring support,
we forgot to add it to the function that sets up environment for the
platform scans.

This patch removes the code duplication and makes sure that the expected
environment is set up for both node and platform scans.

It also fixes the api-resource-collector to take into account when tailoring is required
and fetch the appropriate resources.

Closes: https://github.com/openshift/compliance-operator/pull/511