### PR TITLE
Revert "remove .dockerignore file"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Exclude test files
+*_test.go
+tests/
+.git/
+build/_output
+build/_test
+_output
+README.md


### PR DESCRIPTION
This re-adds the .dockerignore file.

It, however, stops ignoring the `deploy/` directory as it's needed for
the bundle image.

This dockerignore ensures that we don't build the tests as part of the
container build.

It was originally removed because of a bug in podman which is no longer an issue.

This reverts commit 3d8e6168279217a0114738cad63713c4c1fc8691.