### PR TITLE
Track imagestream when using `deploy-local` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,6 +325,7 @@ deploy-local: namespace image-to-cluster deploy-crds ## Deploy the operator from
 	$(SED) 's%$(IMAGE_REPO)/$(APP_NAME):latest%$(RELATED_IMAGE_OPERATOR_PATH)%' deploy/operator.yaml
 	@oc apply -n $(NAMESPACE) -f deploy/
 	@$(SED) 's%$(RELATED_IMAGE_OPERATOR_PATH)%$(IMAGE_REPO)/$(APP_NAME):latest%' deploy/operator.yaml
+	@oc set triggers -n $(NAMESPACE) deployment/compliance-operator --from-image openshift/compliance-operator:latest -c compliance-operator
 
 .PHONY: deploy-crds
 deploy-crds:


### PR DESCRIPTION
This ensures that subsequent updates to the imagestream get
automatically picked up by the deployment when using `deploy-local`.

So, when developing and pushing images to the cluster, it'll always use
the latest image.