### PR TITLE
feat: add role to api-resource-collector for CIS Benchmark for OpenShift

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -327,6 +327,16 @@ metadata:
   name: api-resource-collector
 rules:
 - apiGroups:
+  - operator.openshift.io
+  resources:
+  - ingresscontrollers
+  - kubeapiservers
+  - openshiftapiservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - config.openshift.io
   resources:
   - operatorhubs


### PR DESCRIPTION
[Section 4.2.13 of CIS Benchmark for OpenShift](https://github.com/ComplianceAsCode/content/pull/6435) checks cipher suites of ingress operator, kubeapi server operator and openshift api server operator.  This PR permits the API resource collector to read and update the resources of the operators to check/remediate their configurations.
