### PR TITLE
Remove outputType logic from TailoredProfile

### DIFF
--- a/deploy/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
@@ -78,13 +78,6 @@ spec:
               extends:
                 description: Points to the name of the profile to extend
                 type: string
-              outputType:
-                description: Defines the type of output that the tailored profile
-                  will do.
-                enum:
-                - ConfigMap
-                - Policy
-                type: string
               setValues:
                 description: Sets the referenced variables to selected values
                 items:
@@ -122,8 +115,7 @@ spec:
                 description: The XCCDF ID of the tailored profile
                 type: string
               outputRef:
-                description: Points to the generated resource of the type specified
-                  in "outputType"
+                description: Points to the generated resource
                 properties:
                   name:
                     type: string

--- a/pkg/apis/compliance/v1alpha1/tailoredprofile_types.go
+++ b/pkg/apis/compliance/v1alpha1/tailoredprofile_types.go
@@ -6,17 +6,6 @@ import (
 
 // FIXME: move name/rationale to a common struct with an interface?
 
-type TailoredProfileOutputType string
-
-const (
-	// PolicyOutput specifies that the TailoredProfile should
-	// generate a Policy object.
-	PolicyOutput TailoredProfileOutputType = "Policy"
-	// ConfigMapOutput specifies that the TailoredProfile should
-	// generate a ConfigMap object (default).
-	ConfigMapOutput TailoredProfileOutputType = "ConfigMap"
-)
-
 // RuleReferenceSpec specifies a rule to be selected/deselected, as well as the reason why
 type RuleReferenceSpec struct {
 	// Name of the rule that's being referenced
@@ -43,9 +32,6 @@ type TailoredProfileSpec struct {
 	Title string `json:"title,omitempty"`
 	// Overwrites the description of the extended profile (optional)
 	Description string `json:"description,omitempty"`
-	// Defines the type of output that the tailored profile will do.
-	// +kubebuilder:validation:Enum=ConfigMap;Policy
-	OutputType TailoredProfileOutputType `json:"outputType,omitempty"`
 	// Enables the referenced rules
 	// +optional
 	// +nullable
@@ -76,7 +62,7 @@ const (
 type TailoredProfileStatus struct {
 	// The XCCDF ID of the tailored profile
 	ID string `json:"id,omitempty"`
-	// Points to the generated resource of the type specified in "outputType"
+	// Points to the generated resource
 	OutputRef OutputRef `json:"outputRef,omitempty"`
 	// The current state of the tailored profile
 	State        TailoredProfileState `json:"state,omitempty"`

--- a/pkg/controller/scansettingbinding/scansettingbinding_controller_test.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller_test.go
@@ -85,7 +85,6 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 				Extends:     profRhcosE8.Name,
 				Title:       "testing TP",
 				Description: "some desc",
-				OutputType:  compv1alpha1.ConfigMapOutput,
 				DisableRules: []compv1alpha1.RuleReferenceSpec{
 					{
 						Name:      "rhcos4-no-empty-passwords",

--- a/pkg/controller/tailoredprofile/tailoredprofile_controller.go
+++ b/pkg/controller/tailoredprofile/tailoredprofile_controller.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -189,26 +188,6 @@ func (r *ReconcileTailoredProfile) validateTailoredProfile(tp *compliancev1alpha
 		return false, nil
 	}
 
-	switch tp.Spec.OutputType {
-	case compliancev1alpha1.ConfigMapOutput: // Do nothing, we're good
-	case compliancev1alpha1.PolicyOutput: // Do nothing, we're good
-	case "":
-		tpCopy := tp.DeepCopy()
-		tpCopy.Spec.OutputType = compliancev1alpha1.ConfigMapOutput
-		// Update, which will requeue
-		return false, r.client.Update(context.TODO(), tpCopy)
-	default:
-		err := r.updateTailoredProfileStatusError(
-			tp,
-			fmt.Errorf(".spec.outputType is invalid (accepted values: ConfigMap"),
-		)
-		if err != nil {
-			return false, err
-		}
-		// don't return an error in the reconciler. The error will surface via the CR's status
-		return false, nil
-	}
-
 	return true, nil
 }
 
@@ -290,19 +269,7 @@ func (r *ReconcileTailoredProfile) getProfileBundleFromProfile(p *compliancev1al
 	return &pb, err
 }
 
-func (r *ReconcileTailoredProfile) ensureOutputObject(tp *compliancev1alpha1.TailoredProfile, cm *corev1.ConfigMap, pb *compliancev1alpha1.ProfileBundle, logger logr.Logger) (reconcile.Result, error) {
-	switch tp.Spec.OutputType {
-	case compliancev1alpha1.ConfigMapOutput:
-		return r.ensureConfigMapOutputObject(tp, cm, logger)
-	case compliancev1alpha1.PolicyOutput:
-		return r.ensurePolicyOutputObject(tp, cm, pb, logger)
-	default:
-		logger.Info("WARNING: unkown output type. We shouldn't get here as this should have been validated already")
-	}
-	return reconcile.Result{}, nil
-}
-
-func (r *ReconcileTailoredProfile) ensureConfigMapOutputObject(tp *compliancev1alpha1.TailoredProfile, tpcm *corev1.ConfigMap, logger logr.Logger) (reconcile.Result, error) {
+func (r *ReconcileTailoredProfile) ensureOutputObject(tp *compliancev1alpha1.TailoredProfile, tpcm *corev1.ConfigMap, pb *compliancev1alpha1.ProfileBundle, logger logr.Logger) (reconcile.Result, error) {
 	// Set TailoredProfile instance as the owner and controller
 	if err := controllerutil.SetControllerReference(tp, tpcm, r.scheme); err != nil {
 		return reconcile.Result{}, err
@@ -334,102 +301,6 @@ func (r *ReconcileTailoredProfile) ensureConfigMapOutputObject(tp *compliancev1a
 
 	// ConfigMap already exists - don't requeue
 	logger.Info("Skip reconcile: ConfigMap already exists", "ConfigMap.Namespace", found.Namespace, "ConfigMap.Name", found.Name)
-	return reconcile.Result{}, nil
-}
-
-func (r *ReconcileTailoredProfile) ensurePolicyOutputObject(tp *compliancev1alpha1.TailoredProfile, tpcm *corev1.ConfigMap, pb *compliancev1alpha1.ProfileBundle, logger logr.Logger) (reconcile.Result, error) {
-	objKey := types.NamespacedName{Name: tp.GetName(), Namespace: tp.GetNamespace()}
-	// reset namespace
-	tpcm.SetNamespace("")
-	cmUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tpcm)
-	if err != nil {
-		updateErr := r.updateTailoredProfileStatusError(
-			tp,
-			fmt.Errorf("Couldn't convert ConfigMap to Unstructured: %s", err),
-		)
-		return reconcile.Result{}, updateErr
-	}
-
-	// TODO(jaosorior): Import library and use actual object instead of unstructured
-	suiteObj := map[string]interface{}{
-		"apiVersion": "compliance.openshift.io/v1alpha1",
-		"kind":       "ComplianceSuite",
-		"metadata": map[string]interface{}{
-			"name": objKey.Name,
-		},
-		"spec": map[string]interface{}{
-			"schedule":              "0 1 * * *",
-			"autoApplyRemediations": false,
-			"scans": []interface{}{
-				map[string]interface{}{
-					"name":         objKey.Name + "-worker-scan",
-					"profile":      xccdf.GetXCCDFProfileID(tp),
-					"content":      pb.Spec.ContentFile,
-					"contentImage": pb.Spec.ContentImage,
-					"nodeSelector": map[string]interface{}{
-						"node-role.kubernetes.io/worker": "",
-					},
-					"tailoringConfigMap": map[string]interface{}{
-						"name": tpcm.GetName(),
-					},
-				},
-			},
-		},
-	}
-
-	// TODO(jaosorior): Import library and use actual object instead of unstructured
-	policyObj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "policy.mcm.ibm.com/v1alpha1",
-			"kind":       "Policy",
-			"metadata": map[string]interface{}{
-				"name":      objKey.Name,
-				"namespace": objKey.Namespace,
-			},
-			"spec": map[string]interface{}{
-				"disabled":          false,
-				"remediationAction": "inform",
-				"namespaces": map[string]interface{}{
-					"exclude": []interface{}{"kube-*"},
-					"include": []interface{}{"default"},
-				},
-				"policy-templates": []interface{}{
-					map[string]interface{}{
-						"objectDefinition": cmUnstructured,
-					},
-					map[string]interface{}{
-						"objectDefinition": suiteObj,
-					},
-				},
-			},
-		},
-	}
-	// Check if this ConfigMap already exists
-	found := policyObj.DeepCopy()
-	err = r.client.Get(context.TODO(), objKey, found)
-	if err != nil && errors.IsNotFound(err) {
-		// update status
-		err = r.updateTailoredProfileStatusReady(tp, tpcm)
-		if err != nil {
-			logger.Error(err, "Couldn't update TailoredProfile status")
-			return reconcile.Result{}, err
-		}
-
-		// create Policy
-		logger.Info("Creating a new Policy", "Policy.Namespace", objKey.Namespace, "Policy.Name", objKey.Name)
-		err = r.client.Create(context.TODO(), policyObj)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		// Policy created successfully - don't requeue
-		return reconcile.Result{}, nil
-	} else if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	// Policy already exists - don't requeue
-	logger.Info("Skip reconcile: Policy already exists", "Policy.Namespace", found.GetNamespace(), "Policy.Name", found.GetName())
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
This was meant to create RHACM policies from a tailored profile. While
it was a good idea for a POC, it was never really supported, tested nor
documented. So let's remove it.