### PR TITLE
profileparser: parallelize rule and variable parsing

### DIFF
--- a/pkg/profileparser/profileparser_suite_test.go
+++ b/pkg/profileparser/profileparser_suite_test.go
@@ -1,11 +1,12 @@
 package profileparser
 
 import (
+	"testing"
+
 	compapis "github.com/openshift/compliance-operator/pkg/apis"
 	cmpv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/pkg/profileparser/profileparser_test.go
+++ b/pkg/profileparser/profileparser_test.go
@@ -598,3 +598,21 @@ var _ = Describe("Testing CPE string parsing in isolation", func() {
 		})
 	})
 })
+
+var _ = Describe("Performance", func() {
+	BeforeEach(func() {
+		Expect(pInput.contentDom).NotTo(BeNil())
+	})
+
+	Context("Testing parsing profiles", func() {
+		Measure("it should parse profiles efficiently", func(b Benchmarker) {
+			rtime := b.Time("runtime", func() {
+				err := ParseBundle(pInput.contentDom, pInput.pb, pInput.pcfg)
+				Expect(err).To(BeNil())
+			})
+
+			Ω(rtime.Seconds()).Should(BeNumerically("<", 1.0), "ParseProfilesAndDo() shouldn't take too long.")
+		}, 1000)
+
+	})
+})


### PR DESCRIPTION
This introduces a simple benchmark test that runs the profile parser
1000 times.

Initially, this resulted in:

    Average Time: 0.173s ± 0.019s

This PR then parallelizes the parsing of rules and variables, using 4
workers for this. With the PR, the 1000 sample run gave:

    Average Time: 0.130s ± 0.014s

Which is ~24% improvement.