### PR TITLE
refactor: Introduce scan type handler

### DIFF
--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +32,8 @@ const ScanFinalizer = "scan.finalizers.compliance.openshift.io"
 // results will be stored at
 const DefaultRawStorageSize = "1Gi"
 const DefaultStorageRotation = 3
+
+var ErrUnkownScanType = errors.New("Unknown scan type")
 
 // Represents the status of the compliance scan run.
 type ComplianceScanStatusPhase string
@@ -281,7 +283,7 @@ func (cs *ComplianceScan) GetScanTypeIfValid() (ComplianceScanType, error) {
 	if strings.ToLower(string(cs.Spec.ScanType)) == strings.ToLower(string(ScanTypeNode)) {
 		return ScanTypeNode, nil
 	}
-	return "", fmt.Errorf("Unknown scan type")
+	return "", ErrUnkownScanType
 }
 
 // GetScanType get's the scan type for a scan

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -5,14 +5,12 @@ import (
 	goerrors "errors"
 	"fmt"
 	"math"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -133,38 +131,51 @@ func (r *ReconcileComplianceScan) Reconcile(request reconcile.Request) (reconcil
 
 	// At this point, we make a copy of the instance, so we can modify it in the functions below.
 	scanToBeUpdated := instance.DeepCopy()
+	if cont, err := r.validate(instance, reqLogger); !cont || err != nil {
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{Requeue: true, RequeueAfter: requeueAfterDefault}, nil
+	}
 
-	// If no phase set, default to pending (the initial phase):
-	if scanToBeUpdated.Status.Phase == "" {
-		scanToBeUpdated.Status.Phase = compv1alpha1.PhasePending
+	handler, err := getScanTypeHandler(r, scanToBeUpdated, reqLogger)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if cont, err := handler.validate(); !cont || err != nil {
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{Requeue: true, RequeueAfter: requeueAfterDefault}, nil
 	}
 
 	switch scanToBeUpdated.Status.Phase {
 	case compv1alpha1.PhasePending:
 		return r.phasePendingHandler(scanToBeUpdated, reqLogger)
 	case compv1alpha1.PhaseLaunching:
-		return r.phaseLaunchingHandler(scanToBeUpdated, reqLogger)
+		return r.phaseLaunchingHandler(handler, reqLogger)
 	case compv1alpha1.PhaseRunning:
-		return r.phaseRunningHandler(scanToBeUpdated, reqLogger)
+		return r.phaseRunningHandler(handler, reqLogger)
 	case compv1alpha1.PhaseAggregating:
-		return r.phaseAggregatingHandler(scanToBeUpdated, reqLogger)
+		return r.phaseAggregatingHandler(handler, reqLogger)
 	case compv1alpha1.PhaseDone:
-		return r.phaseDoneHandler(scanToBeUpdated, reqLogger, dontDelete)
+		return r.phaseDoneHandler(handler, scanToBeUpdated, reqLogger, dontDelete)
 	}
 
 	// the default catch-all, just remove the request from the queue
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileComplianceScan) phasePendingHandler(instance *compv1alpha1.ComplianceScan, logger logr.Logger) (reconcile.Result, error) {
-	logger.Info("Phase: Pending")
-
-	// Remove annotation if needed
-	if instance.NeedsRescan() {
+// validate does validation on the scan and sets some defaults. This is run before any phase to avoid
+// folks modifying the scan in the middle of it and the operator not erroring out early enough.
+func (r *ReconcileComplianceScan) validate(instance *compv1alpha1.ComplianceScan, logger logr.Logger) (cont bool, valerr error) {
+	// If no phase set, default to pending (the initial phase):
+	if instance.Status.Phase == "" {
 		instanceCopy := instance.DeepCopy()
-		delete(instanceCopy.Annotations, compv1alpha1.ComplianceScanRescanAnnotation)
-		err := r.client.Update(context.TODO(), instanceCopy)
-		return reconcile.Result{}, err
+		instanceCopy.Status.Phase = compv1alpha1.PhasePending
+		updateErr := r.client.Status().Update(context.TODO(), instanceCopy)
+		return false, updateErr
 	}
 
 	// Set default scan type if missing
@@ -172,7 +183,7 @@ func (r *ReconcileComplianceScan) phasePendingHandler(instance *compv1alpha1.Com
 		instanceCopy := instance.DeepCopy()
 		instanceCopy.Spec.ScanType = compv1alpha1.ScanTypeNode
 		err := r.client.Update(context.TODO(), instanceCopy)
-		return reconcile.Result{}, err
+		return false, err
 	}
 
 	// validate scan type
@@ -184,7 +195,7 @@ func (r *ReconcileComplianceScan) phasePendingHandler(instance *compv1alpha1.Com
 		instanceCopy.Status.ErrorMessage = fmt.Sprintf("Scan type '%s' is not valid", instance.Spec.ScanType)
 		instanceCopy.Status.Phase = compv1alpha1.PhaseDone
 		updateErr := r.client.Status().Update(context.TODO(), instanceCopy)
-		return reconcile.Result{}, updateErr
+		return false, updateErr
 	}
 
 	// Set default storage if missing
@@ -192,14 +203,14 @@ func (r *ReconcileComplianceScan) phasePendingHandler(instance *compv1alpha1.Com
 		instanceCopy := instance.DeepCopy()
 		instanceCopy.Spec.RawResultStorage.Size = compv1alpha1.DefaultRawStorageSize
 		err := r.client.Update(context.TODO(), instanceCopy)
-		return reconcile.Result{}, err
+		return false, err
 	}
 
 	if len(instance.Spec.RawResultStorage.PVAccessModes) == 0 {
 		instanceCopy := instance.DeepCopy()
 		instanceCopy.Spec.RawResultStorage.PVAccessModes = defaultAccessMode
 		err := r.client.Update(context.TODO(), instanceCopy)
-		return reconcile.Result{}, err
+		return false, err
 	}
 
 	//validate raw storage size
@@ -209,26 +220,21 @@ func (r *ReconcileComplianceScan) phasePendingHandler(instance *compv1alpha1.Com
 		instanceCopy.Status.Result = compv1alpha1.ResultError
 		instanceCopy.Status.Phase = compv1alpha1.PhaseDone
 		err := r.client.Status().Update(context.TODO(), instanceCopy)
-		return reconcile.Result{}, err
+		return false, err
 	}
 
-	if instance.GetScanType() == compv1alpha1.ScanTypeNode {
-		var nodes corev1.NodeList
-		var err error
-		if nodes, err = getTargetNodes(r, instance); err != nil {
-			logger.Error(err, "Cannot get nodes")
-			return reconcile.Result{}, err
-		}
-		if len(nodes.Items) == 0 {
-			warning := "No nodes matched the nodeSelector"
-			logger.Info(warning)
-			r.recorder.Event(instance, corev1.EventTypeWarning, "NoMatchingNodes", warning)
-			instanceCopy := instance.DeepCopy()
-			instanceCopy.Status.Result = compv1alpha1.ResultNotApplicable
-			instanceCopy.Status.Phase = compv1alpha1.PhaseDone
-			err := r.updateStatusWithEvent(instanceCopy, logger)
-			return reconcile.Result{}, err
-		}
+	return true, nil
+}
+
+func (r *ReconcileComplianceScan) phasePendingHandler(instance *compv1alpha1.ComplianceScan, logger logr.Logger) (reconcile.Result, error) {
+	logger.Info("Phase: Pending")
+
+	// Remove annotation if needed
+	if instance.NeedsRescan() {
+		instanceCopy := instance.DeepCopy()
+		delete(instanceCopy.Annotations, compv1alpha1.ComplianceScanRescanAnnotation)
+		err := r.client.Update(context.TODO(), instanceCopy)
+		return reconcile.Result{}, err
 	}
 
 	// Update the scan instance, the next phase is running
@@ -246,55 +252,50 @@ func (r *ReconcileComplianceScan) phasePendingHandler(instance *compv1alpha1.Com
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileComplianceScan) phaseLaunchingHandler(instance *compv1alpha1.ComplianceScan, logger logr.Logger) (reconcile.Result, error) {
-	var nodes corev1.NodeList
+func (r *ReconcileComplianceScan) phaseLaunchingHandler(h scanTypeHandler, logger logr.Logger) (reconcile.Result, error) {
 	var err error
 
 	logger.Info("Phase: Launching")
 
-	err = createConfigMaps(r, scriptCmForScan(instance), envCmForScan(instance), envCmForPlatformScan(instance), instance)
+	scan := h.getScan()
+	err = createConfigMaps(r, scriptCmForScan(scan), envCmForScan(scan), envCmForPlatformScan(scan), scan)
 	if err != nil {
 		logger.Error(err, "Cannot create the configmaps")
 		return reconcile.Result{}, err
 	}
 
-	if nodes, err = getTargetNodes(r, instance); err != nil {
-		logger.Error(err, "Cannot get nodes")
-		return reconcile.Result{}, err
-	}
-
-	if err = r.handleRootCASecret(instance, logger); err != nil {
+	if err = r.handleRootCASecret(scan, logger); err != nil {
 		logger.Error(err, "Cannot create CA secret")
 		return reconcile.Result{}, err
 	}
 
-	if err = r.handleResultServerSecret(instance, logger); err != nil {
+	if err = r.handleResultServerSecret(scan, logger); err != nil {
 		logger.Error(err, "Cannot create result server cert secret")
 		return reconcile.Result{}, err
 	}
 
-	if err = r.handleResultClientSecret(instance, logger); err != nil {
+	if err = r.handleResultClientSecret(scan, logger); err != nil {
 		logger.Error(err, "Cannot create result client cert secret")
 		return reconcile.Result{}, err
 	}
 
-	if resume, err := r.handleRawResultsForScan(instance, logger); err != nil || !resume {
+	if resume, err := r.handleRawResultsForScan(scan, logger); err != nil || !resume {
 		if err != nil {
 			logger.Error(err, "Cannot create the PersistentVolumeClaims")
 		}
 		return reconcile.Result{}, err
 	}
 
-	if err = r.createResultServer(instance, logger); err != nil {
+	if err = r.createResultServer(scan, logger); err != nil {
 		logger.Error(err, "Cannot create result server")
 		return reconcile.Result{}, err
 	}
 
-	if err = r.createScanPods(instance, nodes, logger); err != nil {
+	if err = h.createScanWorkload(); err != nil {
 		if !common.IsRetriable(err) {
 			// Surface non-retriable errors to the CR
 			logger.Info("Updating scan status due to unretriable error")
-			scanCopy := instance.DeepCopy()
+			scanCopy := scan.DeepCopy()
 			scanCopy.Status.ErrorMessage = err.Error()
 			scanCopy.Status.Result = compv1alpha1.ResultError
 			scanCopy.Status.Phase = compv1alpha1.PhaseDone
@@ -307,8 +308,8 @@ func (r *ReconcileComplianceScan) phaseLaunchingHandler(instance *compv1alpha1.C
 	}
 
 	// if we got here, there are no new pods to be created, move to the next phase
-	instance.Status.Phase = compv1alpha1.PhaseRunning
-	err = r.client.Status().Update(context.TODO(), instance)
+	scan.Status.Phase = compv1alpha1.PhaseRunning
+	err = r.client.Status().Update(context.TODO(), scan)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -316,90 +317,23 @@ func (r *ReconcileComplianceScan) phaseLaunchingHandler(instance *compv1alpha1.C
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileComplianceScan) phaseRunningHandler(instance *compv1alpha1.ComplianceScan, logger logr.Logger) (reconcile.Result, error) {
-	var nodes corev1.NodeList
-	var err error
-
+func (r *ReconcileComplianceScan) phaseRunningHandler(h scanTypeHandler, logger logr.Logger) (reconcile.Result, error) {
 	logger.Info("Phase: Running")
 
-	switch instance.GetScanType() {
-	case compv1alpha1.ScanTypePlatform:
-		running, err := isPlatformScanPodRunning(r, instance, logger)
-		if errors.IsNotFound(err) {
-			// Let's go back to the previous state and make sure all the nodes are covered.
-			logger.Info("Phase: Running: The platform scan pod is missing. Going to state LAUNCHING to make sure we launch it",
-				"compliancescan")
-			instance.Status.Phase = compv1alpha1.PhaseLaunching
-			err = r.client.Status().Update(context.TODO(), instance)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
-			return reconcile.Result{}, nil
-		} else if err != nil {
-			return reconcile.Result{}, err
-		}
+	running, err := h.handleRunningScan()
 
-		if running {
-			// The platform scan pod is still running, go back to queue.
-			return reconcile.Result{Requeue: true, RequeueAfter: requeueAfterDefault}, err
-		}
-	case compv1alpha1.ScanTypeNode:
-		if nodes, err = getTargetNodes(r, instance); err != nil {
-			logger.Error(err, "Cannot get nodes")
-			return reconcile.Result{}, err
-		}
-
-		if len(nodes.Items) == 0 {
-			logger.Info("Warning: No eligible nodes. Check the nodeSelector.")
-		}
-
-		// On each eligible node..
-		for _, node := range nodes.Items {
-			var unschedulableErr *podUnschedulableError
-			running, err := isPodRunningInNode(r, instance, &node, logger)
-			if errors.IsNotFound(err) {
-				// Let's go back to the previous state and make sure all the nodes are covered.
-				logger.Info("Phase: Running: A pod is missing. Going to state LAUNCHING to make sure we launch it",
-					"compliancescan", instance.ObjectMeta.Name, "node", node.Name)
-				instance.Status.Phase = compv1alpha1.PhaseLaunching
-				err = r.client.Status().Update(context.TODO(), instance)
-				if err != nil {
-					return reconcile.Result{}, err
-				}
-				return reconcile.Result{}, nil
-			} else if goerrors.As(err, &unschedulableErr) {
-				// Create custom error message for this pod that couldn't be scheduled
-				cmName := getConfigMapForNodeName(instance.Name, node.Name)
-				errorReader := strings.NewReader(err.Error())
-				cm := utils.GetResultConfigMap(instance, cmName, "error-msg", node.Name,
-					errorReader, false, common.PodUnschedulableExitCode, "")
-				cmKey := types.NamespacedName{Name: cm.Name, Namespace: cm.Namespace}
-				foundcm := corev1.ConfigMap{}
-				cmGetErr := r.client.Get(context.TODO(), cmKey, &foundcm)
-				if errors.IsNotFound(cmGetErr) {
-					if cmCreateErr := r.client.Create(context.TODO(), cm); cmCreateErr != nil {
-						if !errors.IsAlreadyExists(cmCreateErr) {
-							return reconcile.Result{}, cmCreateErr
-						}
-					}
-				} else if cmGetErr != nil {
-					return reconcile.Result{}, cmGetErr
-				}
-
-				// We're good, the CM that tells us about this error is already there
-			} else if err != nil {
-				return reconcile.Result{}, err
-			}
-			if running {
-				// at least one pod is still running, just go back to the queue
-				return reconcile.Result{Requeue: true, RequeueAfter: requeueAfterDefault}, err
-			}
-		}
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if running {
+		// The platform scan pod is still running, go back to queue.
+		return reconcile.Result{Requeue: true, RequeueAfter: requeueAfterDefault}, nil
 	}
 
+	scan := h.getScan()
 	// if we got here, there are no pods running, move to the Aggregating phase
-	instance.Status.Phase = compv1alpha1.PhaseAggregating
-	err = r.client.Status().Update(context.TODO(), instance)
+	scan.Status.Phase = compv1alpha1.PhaseAggregating
+	err = r.client.Status().Update(context.TODO(), scan)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -407,18 +341,10 @@ func (r *ReconcileComplianceScan) phaseRunningHandler(instance *compv1alpha1.Com
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileComplianceScan) phaseAggregatingHandler(instance *compv1alpha1.ComplianceScan, logger logr.Logger) (reconcile.Result, error) {
+func (r *ReconcileComplianceScan) phaseAggregatingHandler(h scanTypeHandler, logger logr.Logger) (reconcile.Result, error) {
 	logger.Info("Phase: Aggregating")
-
-	var nodes corev1.NodeList
-	var err error
-
-	if nodes, err = getTargetNodes(r, instance); err != nil {
-		logger.Error(err, "Cannot get nodes")
-		return reconcile.Result{}, err
-	}
-
-	isReady, warnings, err := shouldLaunchAggregator(r, instance, nodes)
+	instance := h.getScan()
+	isReady, warnings, err := h.shouldLaunchAggregator()
 
 	if warnings != "" {
 		instance.Status.Warnings = warnings
@@ -464,7 +390,7 @@ func (r *ReconcileComplianceScan) phaseAggregatingHandler(instance *compv1alpha1
 
 	logger.Info("Moving on to the Done phase")
 
-	result, isReady, err := gatherResults(r, instance, nodes, logger)
+	result, isReady, err := gatherResults(r, h)
 
 	// We only wait if there are no errors.
 	if err == nil && !isReady {
@@ -482,29 +408,17 @@ func (r *ReconcileComplianceScan) phaseAggregatingHandler(instance *compv1alpha1
 	return reconcile.Result{}, err
 }
 
-func (r *ReconcileComplianceScan) phaseDoneHandler(instance *compv1alpha1.ComplianceScan, logger logr.Logger, doDelete bool) (reconcile.Result, error) {
-	var nodes corev1.NodeList
+func (r *ReconcileComplianceScan) phaseDoneHandler(h scanTypeHandler, instance *compv1alpha1.ComplianceScan, logger logr.Logger, doDelete bool) (reconcile.Result, error) {
 	var err error
 	logger.Info("Phase: Done")
 
 	// We need to remove resources before doing a re-scan
 	if doDelete || instance.NeedsRescan() {
 		logger.Info("Cleaning up scan's resources")
-		scantype, _ := instance.GetScanTypeIfValid()
-		switch scantype {
-		case compv1alpha1.ScanTypePlatform:
-			if err := r.deletePlatformScanPod(instance, logger); err != nil {
-				logger.Error(err, "Cannot delete platform scan pod")
-				return reconcile.Result{}, err
-			}
-		case compv1alpha1.ScanTypeNode:
-			if nodes, err = getTargetNodes(r, instance); err != nil {
-				logger.Error(err, "Cannot get nodes")
-				return reconcile.Result{}, err
-			}
-
-			if err := r.deleteScanPods(instance, nodes, logger); err != nil {
-				logger.Error(err, "Cannot delete scan pods")
+		// Don't try to clean up scan-type specific resources
+		// if it was an unknown scan type
+		if h != nil {
+			if err := h.cleanup(); err != nil {
 				return reconcile.Result{}, err
 			}
 		}
@@ -576,13 +490,18 @@ func (r *ReconcileComplianceScan) scanDeleteHandler(instance *compv1alpha1.Compl
 		logger.Info("The scan is being deleted")
 		scanToBeDeleted := instance.DeepCopy()
 
+		handler, err := getScanTypeHandler(r, scanToBeDeleted, logger)
+		if err != nil && !goerrors.Is(err, compv1alpha1.ErrUnkownScanType) {
+			return reconcile.Result{}, err
+		}
+
 		// Force remove rescan annotation since we're deleting the scan
 		if scanToBeDeleted.NeedsRescan() {
 			delete(scanToBeDeleted.Annotations, compv1alpha1.ComplianceScanRescanAnnotation)
 		}
 
 		// remove objects by forcing handling of phase DONE
-		if _, err := r.phaseDoneHandler(scanToBeDeleted, logger, doDelete); err != nil {
+		if _, err := r.phaseDoneHandler(handler, scanToBeDeleted, logger, doDelete); err != nil {
 			// if fail to delete the external dependency here, return with error
 			// so that it can be retried
 			return reconcile.Result{}, err
@@ -650,25 +569,6 @@ func (r *ReconcileComplianceScan) generateResultEventForScan(scan *compv1alpha1.
 			"The scan produced outdated remediations, please check for complianceremediation objects labeled with %s",
 			compv1alpha1.OutdatedRemediationLabel)
 	}
-}
-
-func getTargetNodes(r *ReconcileComplianceScan, instance *compv1alpha1.ComplianceScan) (corev1.NodeList, error) {
-	var nodes corev1.NodeList
-
-	switch instance.GetScanType() {
-	case compv1alpha1.ScanTypePlatform:
-		return nodes, nil // Nodes are only relevant to the node scan type. Return the empty node list otherwise.
-	case compv1alpha1.ScanTypeNode:
-		listOpts := client.ListOptions{
-			LabelSelector: labels.SelectorFromSet(instance.Spec.NodeSelector),
-		}
-
-		if err := r.client.List(context.TODO(), &nodes, &listOpts); err != nil {
-			return nodes, err
-		}
-	}
-
-	return nodes, nil
 }
 
 func (r *ReconcileComplianceScan) deleteScriptConfigMaps(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
@@ -767,134 +667,17 @@ func getNodeScanCM(r *ReconcileComplianceScan, instance *compv1alpha1.Compliance
 	return foundCM, err
 }
 
-// shouldLaunchAggregator is a check that tests whether the scanner already failed
-// hard in which case there might not be a reason to launch the aggregator pod, e.g.
-// in cases the content cannot be loaded at all
-func shouldLaunchAggregator(r *ReconcileComplianceScan, instance *compv1alpha1.ComplianceScan, nodes corev1.NodeList) (bool, string, error) {
-	var warnings string
-	switch instance.GetScanType() {
-	case compv1alpha1.ScanTypePlatform:
-		foundCM, err := getPlatformScanCM(r, instance)
-
-		// Could be a transient error, so we requeue if there's any
-		// error here.
-		if err != nil {
-			return false, "", nil
-		}
-
-		warns, ok := foundCM.Data["warnings"]
-		if ok {
-			warnings = warns
-		}
-
-		// NOTE: err is only set if there is an error in the scan run
-		err = checkScanUnknownError(foundCM)
-		if err != nil {
-			return true, warnings, err
-		}
-	case compv1alpha1.ScanTypeNode:
-		for _, node := range nodes.Items {
-			foundCM, err := getNodeScanCM(r, instance, node.Name)
-
-			// Could be a transient error, so we requeue if there's any
-			// error here.
-			if err != nil {
-				return false, "", nil
-			}
-
-			warns, ok := foundCM.Data["warnings"]
-			if ok {
-				warnings = warns
-			}
-
-			// NOTE: err is only set if there is an error in the scan run
-			err = checkScanUnknownError(foundCM)
-			if err != nil {
-				return true, warnings, err
-			}
-		}
-	}
-
-	return true, warnings, nil
-}
-
 // gatherResults will iterate the nodes in the scan and get the results
 // for the OpenSCAP check. If the results haven't yet been persisted in
 // the relevant ConfigMap, the a requeue will be requested since the
 // results are not ready.
-func gatherResults(r *ReconcileComplianceScan, instance *compv1alpha1.ComplianceScan, nodes corev1.NodeList, logger logr.Logger) (compv1alpha1.ComplianceScanStatusResult, bool, error) {
-	var lastNonCompliance compv1alpha1.ComplianceScanStatusResult
-	var result compv1alpha1.ComplianceScanStatusResult
-	compliant := true
-	isReady := true
+func gatherResults(r *ReconcileComplianceScan, h scanTypeHandler) (compv1alpha1.ComplianceScanStatusResult, bool, error) {
+	instance := h.getScan()
 
-	switch instance.GetScanType() {
-	case compv1alpha1.ScanTypePlatform:
-		foundCM, err := getPlatformScanCM(r, instance)
+	result, isReady, err := h.gatherResults()
 
-		// Could be a transient error, so we requeue if there's any
-		// error here.
-		if err != nil {
-			logger.Info("Platform scan has no result ConfigMap yet", "ComplianceScan.Name", instance.Name)
-			isReady = false
-			break
-		}
-
-		cmHasResult := scanResultReady(foundCM)
-		if cmHasResult == false {
-			logger.Info("Scan results not ready, retrying. If the issue persists, restart or recreate the scan", "ComplianceScan.Name", instance.Name)
-			isReady = false
-			break
-		}
-
-		// NOTE: err is only set if there is an error in the scan run
-		result, err = getScanResult(foundCM)
-
-		// we output the last result if it was an error
-		if result == compv1alpha1.ResultError {
-			logger.Info("Platform scan error", "errMsg", err)
-			return result, true, err
-		}
-		// Store the last non-compliance, so we can output that if
-		// there were no errors.
-		if result == compv1alpha1.ResultNonCompliant {
-			lastNonCompliance = result
-			compliant = false
-		}
-	case compv1alpha1.ScanTypeNode:
-		for _, node := range nodes.Items {
-			foundCM, err := getNodeScanCM(r, instance, node.Name)
-
-			// Could be a transient error, so we requeue if there's any
-			// error here.
-			if err != nil {
-				logger.Info("Node has no result ConfigMap yet", "node.Name", node.Name)
-				isReady = false
-				continue
-			}
-
-			cmHasResult := scanResultReady(foundCM)
-			if cmHasResult == false {
-				logger.Info("Scan results not ready, retrying. If the issue persists, restart or recreate the scan", "ComplianceScan.Name", instance.Name)
-				isReady = false
-				continue
-			}
-
-			// NOTE: err is only set if there is an error in the scan run
-			result, err = getScanResult(foundCM)
-
-			// we output the last result if it was an error
-			if result == compv1alpha1.ResultError {
-				logger.Info("Node scan error", "node.Name", node.Name, "errMsg", err)
-				return result, true, err
-			}
-			// Store the last non-compliance, so we can output that if
-			// there were no errors.
-			if result == compv1alpha1.ResultNonCompliant {
-				lastNonCompliance = result
-				compliant = false
-			}
-		}
+	if err != nil {
+		return result, isReady, err
 	}
 
 	// If there are any inconsistent results, always just return
@@ -913,9 +696,6 @@ func gatherResults(r *ReconcileComplianceScan, instance *compv1alpha1.Compliance
 				compv1alpha1.ComplianceCheckInconsistentLabel)
 	}
 
-	if !compliant {
-		return lastNonCompliance, isReady, nil
-	}
 	return result, isReady, nil
 }
 

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -25,28 +25,6 @@ const (
 	tailoringNotFoundPrefix = "Tailoring ConfigMap not found: "
 )
 
-func (r *ReconcileComplianceScan) createScanPods(instance *compv1alpha1.ComplianceScan, nodes corev1.NodeList, logger logr.Logger) error {
-	if instance.GetScanType() == compv1alpha1.ScanTypePlatform {
-		return r.createPlatformScanPod(instance, logger)
-	}
-	// ScanTypeNode
-	return r.createNodeScanPods(instance, nodes, logger)
-}
-
-func (r *ReconcileComplianceScan) createNodeScanPods(instance *compv1alpha1.ComplianceScan, nodes corev1.NodeList, logger logr.Logger) error {
-	// On each eligible node..
-	for _, node := range nodes.Items {
-		// ..schedule a pod..
-		logger.Info("Creating a pod for node", "Pod.Name", node.Name)
-		pod := newScanPodForNode(instance, &node, logger)
-		if err := r.launchScanPod(instance, pod, logger); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (r *ReconcileComplianceScan) createPlatformScanPod(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
 	logger.Info("Creating a Platform scan pod")
 	pod := newPlatformScanPod(instance, logger)
@@ -478,9 +456,9 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 	}
 }
 
-func (r *ReconcileComplianceScan) deleteScanPods(instance *compv1alpha1.ComplianceScan, nodes corev1.NodeList, logger logr.Logger) error {
+func (r *ReconcileComplianceScan) deleteScanPods(instance *compv1alpha1.ComplianceScan, nodes []corev1.Node, logger logr.Logger) error {
 	// On each eligible node..
-	for _, node := range nodes.Items {
+	for _, node := range nodes {
 		logger.Info("Deleting a pod on node", "node", node.Name)
 		pod := newScanPodForNode(instance, &node, logger)
 

--- a/pkg/controller/compliancescan/scantype.go
+++ b/pkg/controller/compliancescan/scantype.go
@@ -1,0 +1,375 @@
+package compliancescan
+
+import (
+	"context"
+	goerrors "errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/openshift/compliance-operator/pkg/controller/common"
+	"github.com/openshift/compliance-operator/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type scanTypeHandler interface {
+	validate() (bool, error)
+	getScan() *compv1alpha1.ComplianceScan
+	createScanWorkload() error
+	handleRunningScan() (bool, error)
+	// shouldLaunchAggregator is a check that tests whether the scanner already failed
+	// hard in which case there might not be a reason to launch the aggregator pod, e.g.
+	// in cases the content cannot be loaded at all
+	shouldLaunchAggregator() (bool, string, error)
+
+	// gatherResults will iterate the nodes in the scan and get the results
+	// for the OpenSCAP check. If the results haven't yet been persisted in
+	// the relevant ConfigMap, the a requeue will be requested since the
+	// results are not ready.
+	gatherResults() (compv1alpha1.ComplianceScanStatusResult, bool, error)
+	cleanup() error
+}
+
+func getScanTypeHandler(r *ReconcileComplianceScan, scan *compv1alpha1.ComplianceScan, logger logr.Logger) (scanTypeHandler, error) {
+	scantype, err := scan.GetScanTypeIfValid()
+	if err != nil {
+		return nil, err
+	}
+	switch scantype {
+	case compv1alpha1.ScanTypePlatform:
+		return newPlatformScanTypeHandler(r, scan, logger)
+	case compv1alpha1.ScanTypeNode:
+		return newNodeScanTypeHandler(r, scan, logger)
+	}
+	return nil, nil
+}
+
+type nodeScanTypeHandler struct {
+	r     *ReconcileComplianceScan
+	scan  *compv1alpha1.ComplianceScan
+	l     logr.Logger
+	nodes []corev1.Node
+}
+
+// newNodeScanTypeHandler creates a new instance of a scanTypeHandler.
+// Note that it assumes that the scan instance that's given is already a copy.
+func newNodeScanTypeHandler(r *ReconcileComplianceScan, scan *compv1alpha1.ComplianceScan, logger logr.Logger) (scanTypeHandler, error) {
+	nh := &nodeScanTypeHandler{
+		r:    r,
+		scan: scan,
+		l:    logger,
+	}
+
+	nodes, err := nh.getTargetNodes()
+	if err != nil {
+		nh.l.Error(err, "Cannot get nodes")
+		return nil, err
+	}
+	nh.nodes = nodes
+	return nh, nil
+}
+
+func (nh *nodeScanTypeHandler) getScan() *compv1alpha1.ComplianceScan {
+	return nh.scan
+}
+
+func (nh *nodeScanTypeHandler) getTargetNodes() ([]corev1.Node, error) {
+	var nodes corev1.NodeList
+
+	switch nh.scan.GetScanType() {
+	case compv1alpha1.ScanTypePlatform:
+		return nodes.Items, nil // Nodes are only relevant to the node scan type. Return the empty node list otherwise.
+	case compv1alpha1.ScanTypeNode:
+		listOpts := client.ListOptions{
+			LabelSelector: labels.SelectorFromSet(nh.scan.Spec.NodeSelector),
+		}
+
+		if err := nh.r.client.List(context.TODO(), &nodes, &listOpts); err != nil {
+			return nodes.Items, err
+		}
+	}
+
+	return nodes.Items, nil
+}
+
+func (nh *nodeScanTypeHandler) validate() (bool, error) {
+	if len(nh.nodes) == 0 {
+		warning := "No nodes matched the nodeSelector"
+		nh.l.Info(warning)
+		nh.r.recorder.Event(nh.scan, corev1.EventTypeWarning, "NoMatchingNodes", warning)
+		instanceCopy := nh.scan.DeepCopy()
+		instanceCopy.Status.Result = compv1alpha1.ResultNotApplicable
+		instanceCopy.Status.Phase = compv1alpha1.PhaseDone
+		err := nh.r.updateStatusWithEvent(instanceCopy, nh.l)
+		return false, err
+	}
+	nodeWarning := "Not continuing scan: Node is unschedulable"
+	for idx := range nh.nodes {
+		node := &nh.nodes[idx]
+		if node.Spec.Unschedulable {
+			nh.l.Info(nodeWarning, "Node.Name", node.GetName())
+			eventFmt := fmt.Sprintf("%s: %s", nodeWarning, node.GetName())
+			nh.r.recorder.Event(nh.scan, corev1.EventTypeWarning, "UnschedulableNode", eventFmt)
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (nh *nodeScanTypeHandler) createScanWorkload() error {
+	// On each eligible node..
+	for _, node := range nh.nodes {
+		// ..schedule a pod..
+		nh.l.Info("Creating a pod for node", "Pod.Name", node.Name)
+		pod := newScanPodForNode(nh.scan, &node, nh.l)
+		if err := nh.r.launchScanPod(nh.scan, pod, nh.l); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (nh *nodeScanTypeHandler) handleRunningScan() (bool, error) {
+	for _, node := range nh.nodes {
+		var unschedulableErr *podUnschedulableError
+		running, err := isPodRunningInNode(nh.r, nh.scan, &node, nh.l)
+		if errors.IsNotFound(err) {
+			// Let's go back to the previous state and make sure all the nodes are covered.
+			nh.l.Info("Phase: Running: A pod is missing. Going to state LAUNCHING to make sure we launch it",
+				"compliancescan", nh.scan.ObjectMeta.Name, "node", node.Name)
+			nh.scan.Status.Phase = compv1alpha1.PhaseLaunching
+			err = nh.r.client.Status().Update(context.TODO(), nh.scan)
+			if err != nil {
+				return true, err
+			}
+			return true, nil
+		} else if goerrors.As(err, &unschedulableErr) {
+			// Create custom error message for this pod that couldn't be scheduled
+			cmName := getConfigMapForNodeName(nh.scan.Name, node.Name)
+			errorReader := strings.NewReader(err.Error())
+			cm := utils.GetResultConfigMap(nh.scan, cmName, "error-msg", node.Name,
+				errorReader, false, common.PodUnschedulableExitCode, "")
+			cmKey := types.NamespacedName{Name: cm.Name, Namespace: cm.Namespace}
+			foundcm := corev1.ConfigMap{}
+			cmGetErr := nh.r.client.Get(context.TODO(), cmKey, &foundcm)
+
+			if errors.IsNotFound(cmGetErr) {
+				if cmCreateErr := nh.r.client.Create(context.TODO(), cm); cmCreateErr != nil {
+					if !errors.IsAlreadyExists(cmCreateErr) {
+						return true, cmCreateErr
+					}
+				}
+			} else if cmGetErr != nil {
+				return true, cmGetErr
+			}
+
+			// We're good, the CM that tells us about this error is already there
+			// let's continue to check the next pod
+		} else if err != nil {
+			return true, err
+		}
+		if running {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (nh *nodeScanTypeHandler) shouldLaunchAggregator() (bool, string, error) {
+	var warnings string
+	for _, node := range nh.nodes {
+		foundCM, err := getNodeScanCM(nh.r, nh.scan, node.Name)
+
+		// Could be a transient error, so we requeue if there's any
+		// error here.
+		if err != nil {
+			return false, "", nil
+		}
+
+		warns, ok := foundCM.Data["warnings"]
+		if ok {
+			warnings = warns
+		}
+
+		// NOTE: err is only set if there is an error in the scan run
+		err = checkScanUnknownError(foundCM)
+		if err != nil {
+			return true, warnings, err
+		}
+	}
+	return true, warnings, nil
+}
+
+func (nh *nodeScanTypeHandler) gatherResults() (compv1alpha1.ComplianceScanStatusResult, bool, error) {
+	var lastNonCompliance compv1alpha1.ComplianceScanStatusResult
+	var result compv1alpha1.ComplianceScanStatusResult
+	compliant := true
+	isReady := true
+
+	for _, node := range nh.nodes {
+		foundCM, err := getNodeScanCM(nh.r, nh.scan, node.Name)
+
+		// Could be a transient error, so we requeue if there's any
+		// error here. Note that we don't persist the error
+		if err != nil {
+			nh.l.Info("Node has no result ConfigMap yet", "node.Name", node.Name)
+			isReady = false
+			continue
+		}
+
+		cmHasResult := scanResultReady(foundCM)
+		if cmHasResult == false {
+			nh.l.Info("Scan results not ready, retrying. If the issue persists, restart or recreate the scan",
+				"ComplianceScan.Name", nh.scan.Name)
+			isReady = false
+			continue
+		}
+
+		// NOTE: err is only set if there is an error in the scan run
+		result, err = getScanResult(foundCM)
+
+		// we output the last result if it was an error
+		if result == compv1alpha1.ResultError {
+			nh.l.Info("Node scan error", "node.Name", node.Name, "errMsg", err)
+			return result, true, err
+		}
+		// Store the last non-compliance, so we can output that if
+		// there were no errors.
+		if result == compv1alpha1.ResultNonCompliant {
+			lastNonCompliance = result
+			compliant = false
+		}
+	}
+
+	if !compliant {
+		return lastNonCompliance, isReady, nil
+	}
+
+	return result, isReady, nil
+}
+
+func (nh *nodeScanTypeHandler) cleanup() error {
+	if err := nh.r.deleteScanPods(nh.scan, nh.nodes, nh.l); err != nil {
+		nh.l.Error(err, "Cannot delete scan pods")
+		return err
+	}
+	return nil
+}
+
+type platformScanTypeHandler struct {
+	r         *ReconcileComplianceScan
+	scan      *compv1alpha1.ComplianceScan
+	l         logr.Logger
+	platforms []corev1.Node
+}
+
+// newNodeScanTypeHandler creates a new instance of a scanTypeHandler.
+// Note that it assumes that the scan instance that's given is already a copy.
+func newPlatformScanTypeHandler(r *ReconcileComplianceScan, scan *compv1alpha1.ComplianceScan, logger logr.Logger) (scanTypeHandler, error) {
+	return &platformScanTypeHandler{
+		r:    r,
+		scan: scan,
+		l:    logger,
+	}, nil
+}
+
+func (ph *platformScanTypeHandler) getScan() *compv1alpha1.ComplianceScan {
+	return ph.scan
+}
+
+func (ph *platformScanTypeHandler) validate() (bool, error) {
+	return true, nil
+}
+
+func (ph *platformScanTypeHandler) createScanWorkload() error {
+	ph.l.Info("Creating a Platform scan pod")
+	pod := newPlatformScanPod(ph.scan, ph.l)
+	return ph.r.launchScanPod(ph.scan, pod, ph.l)
+}
+
+func (ph *platformScanTypeHandler) handleRunningScan() (bool, error) {
+	running, err := isPlatformScanPodRunning(ph.r, ph.scan, ph.l)
+	if errors.IsNotFound(err) {
+		// Let's go back to the previous state and make sure all the nodes are covered.
+		ph.l.Info("Phase: Running: The platform scan pod is missing. Going to state LAUNCHING to make sure we launch it",
+			"compliancescan")
+		ph.scan.Status.Phase = compv1alpha1.PhaseLaunching
+		err = ph.r.client.Status().Update(context.TODO(), ph.scan)
+		if err != nil {
+			return true, err
+		}
+		return true, nil
+	} else if err != nil {
+		return true, err
+	}
+	return running, nil
+}
+
+func (ph *platformScanTypeHandler) shouldLaunchAggregator() (bool, string, error) {
+	var warnings string
+	foundCM, err := getPlatformScanCM(ph.r, ph.scan)
+
+	// Could be a transient error, so we requeue if there's any
+	// error here.
+	if err != nil {
+		return false, "", nil
+	}
+
+	warns, ok := foundCM.Data["warnings"]
+	if ok {
+		warnings = warns
+	}
+
+	// NOTE: err is only set if there is an error in the scan run
+	err = checkScanUnknownError(foundCM)
+	if err != nil {
+		return true, warnings, err
+	}
+	return true, warnings, nil
+}
+
+func (ph *platformScanTypeHandler) gatherResults() (compv1alpha1.ComplianceScanStatusResult, bool, error) {
+	var result compv1alpha1.ComplianceScanStatusResult
+	isReady := true
+
+	foundCM, err := getPlatformScanCM(ph.r, ph.scan)
+
+	// Could be a transient error, so we requeue if there's any
+	// error here. Note that we don't persist the error.
+	if err != nil {
+		ph.l.Info("Platform scan has no result ConfigMap yet", "ComplianceScan.Name", ph.scan.Name)
+		isReady = false
+		return result, isReady, nil
+	}
+
+	cmHasResult := scanResultReady(foundCM)
+	if cmHasResult == false {
+		ph.l.Info("Scan results not ready, retrying. If the issue persists, restart or recreate the scan", "ComplianceScan.Name", ph.scan.Name)
+		isReady = false
+		return result, isReady, err
+	}
+
+	// NOTE: err is only set if there is an error in the scan run
+	result, err = getScanResult(foundCM)
+
+	// we output the last result if it was an error
+	if result == compv1alpha1.ResultError {
+		ph.l.Info("Platform scan error", "errMsg", err)
+	}
+	return result, isReady, err
+}
+
+func (ph *platformScanTypeHandler) cleanup() error {
+	if err := ph.r.deletePlatformScanPod(ph.scan, ph.l); err != nil {
+		ph.l.Error(err, "Cannot delete platform scan pod")
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This splits the scan handling in a per-type object. This way we won't
have the big switch code blocks that we used to, and this will be done
in object-specific functions.

The node scan type handler will gather the relevant nodes on the
validation phase (which now happens before any phase in the reconcile
loop) and so it'll always have that reference of those objects when it
needs it.

This also adds the extra validation that if a node is marked as Unschedulable,
the scan will issue an event and won't proceed.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>