### PR TITLE
Fix init container content defaulting for OCP builds

### DIFF
--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -233,7 +233,7 @@ func addMetrics(ctx context.Context, cfg *rest.Config) {
 }
 
 func ensureDefaultProfileBundles(ctx context.Context, crclient client.Client, namespaceList []string) error {
-	pbimg := utils.GetComponentImage(utils.DEFAULT_PROFILE_BUNDLES)
+	pbimg := utils.GetComponentImage(utils.CONTENT)
 	var lastErr error
 	for _, prod := range defaultProducts {
 		for _, ns := range namespaceList {

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -930,7 +930,7 @@ func getConfigMapForNodeName(scanName, nodeName string) string {
 }
 
 func getInitContainerImage(scanSpec *compv1alpha1.ComplianceScanSpec, logger logr.Logger) string {
-	image := DefaultContentContainerImage
+	image := utils.GetComponentImage(utils.CONTENT)
 
 	if scanSpec.ContentImage != "" {
 		image = scanSpec.ContentImage

--- a/pkg/utils/images.go
+++ b/pkg/utils/images.go
@@ -7,7 +7,7 @@ type ComplianceComponent uint
 const (
 	OPENSCAP = iota
 	OPERATOR
-	DEFAULT_PROFILE_BUNDLES
+	CONTENT
 )
 
 var componentDefaults = []struct {


### PR DESCRIPTION
This lets init containers properly inherit the default from RELATED_IMAGE_PROFILE.