### PR TITLE
Add clarification about supported OpenShift version

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,3 +332,5 @@ Platform scans
 
 Current testing has been done on OpenShift (OCP). The project is open to
 getting other platforms tested, so volunteers are needed for this.
+
+The current supported versions of OpenShift are 4.6 and up.


### PR DESCRIPTION
We only support 4.6 up, so we should clarify this in the docs.

Closes #542

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>