### PR TITLE
Don't build binary with `-race` flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ test-broken-content-image:
 build: fmt manager ## Build the compliance-operator binary
 
 manager:
-	$(GO) build -race -o $(TARGET) github.com/openshift/compliance-operator/cmd/manager
+	$(GO) build -o $(TARGET) github.com/openshift/compliance-operator/cmd/manager
 
 .PHONY: operator-sdk
 operator-sdk: $(GOPATH)/bin/operator-sdk


### PR DESCRIPTION
Per the docs[1], this flag is what's been causing out excessive memory
usage on the compliance-operator side. Let's remove it.

[1] https://golang.org/doc/articles/race_detector.html#Runtime_Overheads

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>