### PR TITLE
Release v0.1.25

### DIFF
--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,11 +159,11 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.24'
+    olm.skipRange: '>=0.1.17 <0.1.25'
     operatorframework.io/suggested-namespace: openshift-compliance
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.24
+  name: compliance-operator.v0.1.25
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1056,10 +1056,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.4
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.24
+                  value: quay.io/compliance-operator/compliance-operator:0.1.25
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.24
+                image: quay.io/compliance-operator/compliance-operator:0.1.25
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources: {}
@@ -1356,4 +1356,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.24
+  version: 0.1.25

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_tailoredprofiles_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_tailoredprofiles_crd.yaml
@@ -79,13 +79,6 @@ spec:
               extends:
                 description: Points to the name of the profile to extend
                 type: string
-              outputType:
-                description: Defines the type of output that the tailored profile
-                  will do.
-                enum:
-                - ConfigMap
-                - Policy
-                type: string
               setValues:
                 description: Sets the referenced variables to selected values
                 items:
@@ -123,8 +116,7 @@ spec:
                 description: The XCCDF ID of the tailored profile
                 type: string
               outputRef:
-                description: Points to the generated resource of the type specified
-                  in "outputType"
+                description: Points to the generated resource
                 properties:
                   name:
                     type: string


### PR DESCRIPTION
* Performance improvements (no longer building with the `-race` flag overhead)
* Fixed OUTDATED remediation flows (no longer leaves pools unpaused)
* Remediation application can be now done through annotations on the compliance suite