### PR TITLE
Add Disconnected support annotation to CSV

### DIFF
--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -2,6 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
+    operators.openshift.io/infrastructure-features: '["Disconnected"]'
     alm-examples: |-
       [
         {


### PR DESCRIPTION
This is to advertise disconnected support per https://docs.openshift.com/container-platform/4.6/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs