### PR TITLE
Output relevant object in warnings

### DIFF
--- a/cmd/manager/scap.go
+++ b/cmd/manager/scap.go
@@ -286,7 +286,8 @@ func fetch(client *kubernetes.Clientset, objects []string) (map[string][]byte, [
 			stream, err := req.Stream(context.TODO())
 			if meta.IsNoMatchError(err) || kerrors.IsForbidden(err) || kerrors.IsNotFound(err) {
 				DBG("Encountered non-fatal error to be persisted in the scan: %s", err)
-				warnings = append(warnings, err.Error())
+				objerr := fmt.Errorf("could not fetch %s: %w", uri, err)
+				warnings = append(warnings, objerr.Error())
 				return nil
 			} else if err != nil {
 				return err


### PR DESCRIPTION
If an object couldn't be fetched (for whatever reason) the warning was
fairly cryptic. This exposes the URI that was tried, so users can debug
more easily what the issue is.

Closes: https://github.com/openshift/compliance-operator/issues/555

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>