### PR TITLE
api: Surface a new attribute instructions that contains OCIL

### DIFF
--- a/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
@@ -35,6 +35,11 @@ spec:
           id:
             description: A unique identifier of a check
             type: string
+          instructions:
+            description: How to evaluate if the rule status manually. If no automatic
+              test is present, the rule status will be MANUAL and the administrator
+              should follow these instructions.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -213,6 +213,11 @@ description: |-
   authentication to privileged accounts. Users will first login, then escalate
   to privileged (root) access via su / sudo. This is required for FISMA Low
   and FISMA Moderate systems.
+instructions: |-
+  To ensure root may not directly login to the system over physical consoles,
+  run the following command:
+     cat /etc/securetty
+  If any output is returned, this is a finding.
 id: xccdf_org.ssgproject.content_rule_no_direct_root_logins
 severity: medium
 status: FAIL
@@ -221,7 +226,11 @@ status: FAIL
 Where:
 
 * **description**: Contains a description of what's being checked and why
-  that's being done.
+  that's being done. For checks that don't generate an automated remediation,
+  contains the steps to remediate the issue if it's failing.
+* **instructions**: How to evaluate if the rule status manually. If no automatic
+  test is present, the rule status will be MANUAL and the administrator should
+  follow these instructions.
 * **id**: Contains a reference to the XCCDF identifier of the rule as it is in
   the data-stream/content.
 * **severity**: Describes the severity of the check. The possible values are:

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -81,6 +81,9 @@ type ComplianceCheckResult struct {
 	Severity ComplianceCheckResultSeverity `json:"severity"`
 	// A human-readable check description, what and why it does
 	Description string `json:"description,omitempty"`
+	// How to evaluate if the rule status manually. If no automatic test is present, the rule status will be MANUAL
+	// and the administrator should follow these instructions.
+	Instructions string `json:"instructions,omitempty"`
 }
 
 // IDToDNSFriendlyName gets the ID from the scan and returns a DNS

--- a/pkg/utils/parse_arf_result_test.go
+++ b/pkg/utils/parse_arf_result_test.go
@@ -93,8 +93,9 @@ var _ = Describe("XCCDF parser", func() {
 
 		Context("First check metadata", func() {
 			const (
-				expID          = "xccdf_org.ssgproject.content_rule_selinux_policytype"
-				expDescription = "Configure SELinux Policy\n."
+				expID           = "xccdf_org.ssgproject.content_rule_selinux_policytype"
+				expDescription  = "Configure SELinux Policy\n."
+				expInstructions = "Check the file /etc/selinux/config and ensure the following line appears:\nSELINUXTYPE="
 			)
 
 			var (
@@ -121,6 +122,10 @@ var _ = Describe("XCCDF parser", func() {
 
 			It("Should have the expected description", func() {
 				Expect(check.Description).To(Equal(expDescription))
+			})
+
+			It("Should have the expected instructions", func() {
+				Expect(check.Instructions).To(Equal(expInstructions))
 			})
 		})
 


### PR DESCRIPTION
Extends the ComplianceCheckResult API object with a new attribute
instructions that contains the OCIL attribute from OpenScap rule.

This attribute contains the manual checks for cases when a rule cannot
be evaluated with a OVAL check.