### PR TITLE
Add an explicit MANUAL compliancecheck result status

### DIFF
--- a/doc/crds.md
+++ b/doc/crds.md
@@ -231,6 +231,8 @@ Where:
 	* **FAIL**: Which indicates that the check ran to completion and failed.
 	* **INFO**: Which indicates that the check ran to completion and found
       something not severe enough to be considered error.
+	* **MANUAL**: Which indicates that the check does not have a way to
+        automatically assess success or failure and must be checked manually.
     * **INCONSISTENT**: Which indicates that different nodes report different
       results.
 	* **ERROR**: Which indicates that the check ran, but could not complete

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -41,6 +41,8 @@ const (
 	CheckResultFail ComplianceCheckStatus = "FAIL"
 	// The check ran to completion and found something not severe enough to be considered error
 	CheckResultInfo ComplianceCheckStatus = "INFO"
+	// The check ran to completion and found something not severe enough to be considered error
+	CheckResultManual ComplianceCheckStatus = "MANUAL"
 	// The check ran, but could not complete properly
 	CheckResultError ComplianceCheckStatus = "ERROR"
 	// The check didn't run because it is not applicable or not selected

--- a/pkg/utils/parse_arf_result.go
+++ b/pkg/utils/parse_arf_result.go
@@ -187,11 +187,13 @@ func mapComplianceCheckResultStatus(result *xmldom.Node) (compv1alpha1.Complianc
 		// Unknown state is when the rule runs to completion, but then the results can't be interpreted
 	case "error", "unknown":
 		return compv1alpha1.CheckResultError, nil
-		// We map both notchecked and info to Info. Notchecked means the rule does not even have a check,
-		// and the administratos must inspect the rule manually (e.g. disable something in BIOS),
+		// Notchecked means the rule does not even have a check,
+		// and the administrators must inspect the rule manually (e.g. disable something in BIOS),
+	case "notchecked":
+		return compv1alpha1.CheckResultManual, nil
 		// informational means that the rule has a check which failed, but the severity is low, depending
 		// on the environment (e.g. disable USB support completely from the kernel cmdline)
-	case "notchecked", "informational":
+	case "informational":
 		return compv1alpha1.CheckResultInfo, nil
 		// We map notapplicable to Skipped. Notapplicable means the rule was selected
 		// but does not apply to the current configuration (e.g. arch-specific),

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1479,11 +1479,26 @@ func TestE2E(t *testing.T) {
 						Namespace: namespace,
 					},
 					ID:       "xccdf_org.ssgproject.content_rule_wireless_disable_in_bios",
-					Status:   compv1alpha1.CheckResultInfo,
+					Status:   compv1alpha1.CheckResultManual,
 					Severity: compv1alpha1.CheckResultSeverityUnknown, // yes, it's really uknown in the DS
 				}
 
 				err = assertHasCheck(f, suiteName, workerScanName, checkWifiInBios)
+				if err != nil {
+					return err
+				}
+
+				checkVsyscall := compv1alpha1.ComplianceCheckResult{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s-coreos-vsyscall-kernel-argument", workerScanName),
+						Namespace: namespace,
+					},
+					ID:       "xccdf_org.ssgproject.content_rule_coreos_vsyscall_kernel_argument",
+					Status:   compv1alpha1.CheckResultInfo,
+					Severity: compv1alpha1.CheckResultSeverityMedium, // yes, it's really uknown in the DS
+				}
+
+				err = assertHasCheck(f, suiteName, workerScanName, checkVsyscall)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
We were mapping both notchecked and info coming from the XCCFD results
to INFO in compliancecheckresult. This is confusing as users want to
generally know what do they need to check manually.

Therefore let's add a separate MANUAL status for checks that couldn't
have been evaluated by SCAP.