### PR TITLE
Enable OCP-provided monitoring services

### DIFF
--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -160,6 +160,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
     olm.skipRange: '>=0.1.17 <0.1.26'
+    operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/openshift/compliance-operator


### PR DESCRIPTION
This enables the label `operatorframework.io/cluster-monitoring: "true"`
in the ClusterServiceVersion. This will enable automatic monitoring
setup in the namespace. [1]

[1] https://github.com/openshift/enhancements/blob/master/enhancements/olm/olm-managed-operator-metrics.md

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>