### PR TITLE
Label ComplianceCheck CRs that have automated remediations

### DIFF
--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -297,12 +297,15 @@ func getRemediationLabels(scan *compv1alpha1.ComplianceScan, obj runtime.Object)
 	return labels
 }
 
-func getCheckResultLabels(cr *compv1alpha1.ComplianceCheckResult, resultLabels map[string]string, scan *compv1alpha1.ComplianceScan) map[string]string {
+func getCheckResultLabels(pr *utils.ParseResult, resultLabels map[string]string, scan *compv1alpha1.ComplianceScan) map[string]string {
 	labels := make(map[string]string)
 	labels[compv1alpha1.ComplianceScanLabel] = scan.Name
 	labels[compv1alpha1.SuiteLabel] = scan.Labels[compv1alpha1.SuiteLabel]
-	labels[compv1alpha1.ComplianceCheckResultStatusLabel] = string(cr.Status)
-	labels[compv1alpha1.ComplianceCheckResultSeverityLabel] = string(cr.Severity)
+	labels[compv1alpha1.ComplianceCheckResultStatusLabel] = string(pr.CheckResult.Status)
+	labels[compv1alpha1.ComplianceCheckResultSeverityLabel] = string(pr.CheckResult.Severity)
+	if pr.Remediation != nil {
+		labels[compv1alpha1.ComplianceCheckResultHasRemediation] = ""
+	}
 
 	for k, v := range resultLabels {
 		labels[k] = v
@@ -337,7 +340,7 @@ func createResults(crClient *complianceCrClient, scan *compv1alpha1.ComplianceSc
 			continue
 		}
 
-		checkResultLabels := getCheckResultLabels(pr.CheckResult, pr.Labels, scan)
+		checkResultLabels := getCheckResultLabels(&pr.ParseResult, pr.Labels, scan)
 		checkResultAnnotations := getCheckResultAnnotations(pr.CheckResult, pr.Annotations)
 
 		crkey := getObjKey(pr.CheckResult.GetName(), pr.CheckResult.GetNamespace())

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -364,6 +364,22 @@ For instance:
 oc get complianceremediations -l compliance.openshift.io/suite=example-compliancesuite
 ```
 
+Not all `ComplianceCheckResult` objects create `ComplianceRemediation`
+objects, only those that can be remediated automatically do. A
+`ComplianceCheckResult` object has a related remediation if it's labeled
+with the `compliance.openshift.io/automated-remediation` label, the
+name of the remediation is the same as the name of the check. To list all
+failing checks that can be remediated automatically, call:
+```
+oc get compliancecheckresults -l 'compliance.openshift.io/check-status in (FAIL),compliance.openshift.io/automated-remediation'
+```
+and to list those that must be remediated manually:
+```
+oc get compliancecheckresults -l 'compliance.openshift.io/check-status in (FAIL),!compliance.openshift.io/automated-remediation'
+```
+The manual remediation steps are typically stored in the `ComplianceCheckResult`'s
+`description` attribute.
+
 ### The `ProfileBundle` object
 OpenSCAP content for consumption by the Compliance Operator is distributed
 as container images. In order to make it easier for users to discover what

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -14,6 +14,11 @@ type ComplianceCheckStatus string
 const ComplianceCheckResultStatusLabel = "compliance.openshift.io/check-status"
 const ComplianceCheckResultSeverityLabel = "compliance.openshift.io/check-severity"
 
+// ComplianceCheckResultLabel defines a label that will be included in the
+// ComplianceCheckResult objects. It indicates whether the result has an automated
+// remediation or not.
+const ComplianceCheckResultHasRemediation = "compliance.openshift.io/automated-remediation"
+
 // ComplianceCheckInconsistentLabel signifies that the check's results were not consistent
 // across the target nodes
 const ComplianceCheckInconsistentLabel = "compliance.openshift.io/inconsistent-check"

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1487,11 +1487,15 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
+				assertCheckRemediation(f, checkWifiInBios.Name, checkWifiInBios.Namespace, false)
 
 				checkVsyscall := compv1alpha1.ComplianceCheckResult{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("%s-coreos-vsyscall-kernel-argument", workerScanName),
 						Namespace: namespace,
+						Labels: 	map[string]string{
+							compv1alpha1.ComplianceCheckResultHasRemediation: "",
+						},
 					},
 					ID:       "xccdf_org.ssgproject.content_rule_coreos_vsyscall_kernel_argument",
 					Status:   compv1alpha1.CheckResultInfo,
@@ -1502,6 +1506,8 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
+				// even INFO checks generate remediations, make sure the check was labeled appropriately
+				assertCheckRemediation(f, checkVsyscall.Name, checkVsyscall.Namespace, true)
 
 				return nil
 			},


### PR DESCRIPTION
Our users have a hard time figuring out which ComplianceCheck findings
can be remediated automatically. Let's add a label so that they can
filter out checks that have a remediation.

Jira: [CMP-855](https://issues.redhat.com/browse/CMP-855)