### PR TITLE
Bug 1919311: Use a separate SA for resultserver

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -220,6 +220,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: resultserver
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - restricted
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: remediation-aggregator
 rules:
 - apiGroups:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -97,3 +97,16 @@ roleRef:
   kind: Role
   name: profileparser
   apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: resultserver
+subjects:
+- kind: ServiceAccount
+  name: resultserver
+  namespace: openshift-compliance
+roleRef:
+  kind: Role
+  name: resultserver
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -27,3 +27,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: profileparser
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: resultserver

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift/compliance-operator/pkg/utils"
 )
 
-const resultserverSA = "default"
+const resultserverSA = "resultserver"
 
 // The result-server is a pod that listens for results from other pods and
 // stores them in a PVC.


### PR DESCRIPTION
resultserver was relying on the "default" SA to apply the restricted SCC on
the resultserver pod. While this is OK in the general case, in environments
that bound the "default" SA to some other SCC than restricuted, this would
have broken the assumption by applying a different SCC and not propagating
settings like fsGroup to the pod.

Jira: [OCPBUGSM-23632](https://issues.redhat.com/browse/OCPBUGSM-23632)