### PR TITLE
Add dependency handling for remediations

### DIFF
--- a/pkg/controller/complianceremediation/complianceremediation_controller_test.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller_test.go
@@ -262,6 +262,10 @@ var _ = Describe("Testing complianceremediation controller", func() {
 				// reflects an admin having removed it.
 				err = reconciler.client.Update(context.TODO(), remediationinstance)
 				Expect(err).NotTo(HaveOccurred())
+				// mock that the remediation was applied
+				remediationinstance.Status.ApplicationState = compv1alpha1.RemediationApplied
+				err = reconciler.client.Status().Update(context.TODO(), remediationinstance)
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should remove the outdated remediation label", func() {


### PR DESCRIPTION
This adds the ability for the compliance operator to handle dependencies
in remediations.

These remediations are defined in the content through kubernetes
annotations which look as follows:

```
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  annotations:
    complianceascode.io/depends-on: {{{ XCCDF ID }}}
  spec:
    config:
...
```

Multiple XCCDF ID's can be specified by separating with comma's.

these XCCDF ID's refer to rules that the remediation depends on, these
rules will take the form of ComplianceCheckResults.

The annotation will be read in the operator, and persisted to the
remediation objects with the following format:

```
  annotations:
    compliance.openshift.io/depends-on: {{{ XCCDF ID }}}
```

When reconciling the remediation, the operator will only apply it if all
the dependencies are met. If they are not, it won't apply the
remediation and output a relevant event. If they are, it'll annotate the
remediation with the following key: `compliance.openshift.io/dependencies-met`

If a remediation has un-met dependencies, this also adds a label to the
remediation object that allows users to filter the remediations
appropraitely: `compliance.openshift.io/has-unmet-dependencies`

Co-Authored-By: Jakub Hrozek <jhrozek@redhat.com>