### PR TITLE
Release v0.1.27

### DIFF
--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.26'
+    olm.skipRange: '>=0.1.17 <0.1.27'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.26
+  name: compliance-operator.v0.1.27
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1058,10 +1058,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.4
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.26
+                  value: quay.io/compliance-operator/compliance-operator:0.1.27
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.26
+                image: quay.io/compliance-operator/compliance-operator:0.1.27
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources: {}
@@ -1247,6 +1247,16 @@ spec:
         serviceAccountName: api-resource-collector
       - rules:
         - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - restricted
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: resultserver
+      - rules:
+        - apiGroups:
           - ""
           resources:
           - events
@@ -1358,4 +1368,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.26
+  version: 0.1.27

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancecheckresults_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancecheckresults_crd.yaml
@@ -36,6 +36,11 @@ spec:
           id:
             description: A unique identifier of a check
             type: string
+          instructions:
+            description: How to evaluate if the rule status manually. If no automatic
+              test is present, the rule status will be MANUAL and the administrator
+              should follow these instructions.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client


### PR DESCRIPTION
* Dependency handling for remediations
* resultserver now has its own ServiceAccount so we can bind it to a specific SCC.
* ComplianceChecks with automated remediations are now appropriately labeled.