### PR TITLE
Bug 1920577: Rename the SKIP state of ComplianceCheckResult to NOT-APPLICABLE

### DIFF
--- a/doc/crds.md
+++ b/doc/crds.md
@@ -246,7 +246,7 @@ Where:
       results.
 	* **ERROR**: Which indicates that the check ran, but could not complete
       properly.
-	* **SKIP**: Which indicates that the check didn't run because it is not
+	* **NOTAPPLICABLE**: Which indicates that the check didn't run because it is not
       applicable or not selected.
 
 This object is owned by the scan that created it, as seen in the

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -51,7 +51,7 @@ const (
 	// The check ran, but could not complete properly
 	CheckResultError ComplianceCheckStatus = "ERROR"
 	// The check didn't run because it is not applicable or not selected
-	CheckResultSkipped ComplianceCheckStatus = "SKIP"
+	CheckResultNotApplicable ComplianceCheckStatus = "NOT-APPLICABLE"
 	// The check reports different results from different sources, typically cluster nodes
 	CheckResultInconsistent ComplianceCheckStatus = "INCONSISTENT"
 	// The check didn't yield a usable result

--- a/pkg/utils/parse_arf_result.go
+++ b/pkg/utils/parse_arf_result.go
@@ -263,7 +263,7 @@ func mapComplianceCheckResultStatus(result *xmldom.Node) (compv1alpha1.Complianc
 		// We map notapplicable to Skipped. Notapplicable means the rule was selected
 		// but does not apply to the current configuration (e.g. arch-specific),
 	case "notapplicable":
-		return compv1alpha1.CheckResultSkipped, nil
+		return compv1alpha1.CheckResultNotApplicable, nil
 	case "notselected":
 		// We map notselected to nothing, as the test wasn't included in the benchmark
 		return compv1alpha1.CheckResultNoResult, nil


### PR DESCRIPTION
The SKIP status was not really easy to understand. The hope is that
NOT-APPLICABLE will convey the meaning better.

Jira: [OCPBUGSM-23776](https://issues.redhat.com/browse/OCPBUGSM-23776)