### PR TITLE
Release v0.1.27

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Step one: build compliance-operator
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
 
 WORKDIR /go/src/github.com/openshift/compliance-operator
 

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,5 +1,5 @@
 # Step one: build compliance-operator
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
 
 WORKDIR /go/src/github.com/openshift/compliance-operator
 
@@ -10,7 +10,7 @@ COPY . .
 RUN make manager
 
 # Step two: containerize compliance-operator
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.ci.openshift.org/ocp/4.6:base
 
 ENV OPERATOR=/usr/local/bin/compliance-operator \
     USER_UID=1001 \

--- a/README.md
+++ b/README.md
@@ -118,10 +118,8 @@ ocp4-cis          2m50s
 ocp4-cis-node     2m50s
 ocp4-e8           2m50s
 ocp4-moderate     2m50s
-ocp4-ncp          2m50s
 rhcos4-e8         2m46s
 rhcos4-moderate   2m46s
-rhcos4-ncp        2m46s
 ```
 
 ### Platform and Node scan types
@@ -225,10 +223,10 @@ to `true`:
 $ oc edit -n $NAMESPACE complianceremediation/workers-scan-no-direct-root-logins
 ```
 
-The operator then aggregates all applied remediations and create a
-`MachineConfig` object per scan. This `MachineConfig` object is rendered
-to a `MachinePool` and the `MachineConfigDeamon` running on nodes in that
-pool pushes the configuration to the nodes and reboots the nodes.
+The operator then creates a `MachineConfig` object per remediation. This
+`MachineConfig` object is rendered to a `MachinePool` and the
+`MachineConfigDeamon` running on nodes in that pool pushes the configuration
+to the nodes and reboots the nodes.
 
 You can watch the node status with:
 ```

--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -297,12 +297,15 @@ func getRemediationLabels(scan *compv1alpha1.ComplianceScan, obj runtime.Object)
 	return labels
 }
 
-func getCheckResultLabels(cr *compv1alpha1.ComplianceCheckResult, resultLabels map[string]string, scan *compv1alpha1.ComplianceScan) map[string]string {
+func getCheckResultLabels(pr *utils.ParseResult, resultLabels map[string]string, scan *compv1alpha1.ComplianceScan) map[string]string {
 	labels := make(map[string]string)
 	labels[compv1alpha1.ComplianceScanLabel] = scan.Name
 	labels[compv1alpha1.SuiteLabel] = scan.Labels[compv1alpha1.SuiteLabel]
-	labels[compv1alpha1.ComplianceCheckResultStatusLabel] = string(cr.Status)
-	labels[compv1alpha1.ComplianceCheckResultSeverityLabel] = string(cr.Severity)
+	labels[compv1alpha1.ComplianceCheckResultStatusLabel] = string(pr.CheckResult.Status)
+	labels[compv1alpha1.ComplianceCheckResultSeverityLabel] = string(pr.CheckResult.Severity)
+	if pr.Remediation != nil {
+		labels[compv1alpha1.ComplianceCheckResultHasRemediation] = ""
+	}
 
 	for k, v := range resultLabels {
 		labels[k] = v
@@ -337,7 +340,7 @@ func createResults(crClient *complianceCrClient, scan *compv1alpha1.ComplianceSc
 			continue
 		}
 
-		checkResultLabels := getCheckResultLabels(pr.CheckResult, pr.Labels, scan)
+		checkResultLabels := getCheckResultLabels(&pr.ParseResult, pr.Labels, scan)
 		checkResultAnnotations := getCheckResultAnnotations(pr.CheckResult, pr.Annotations)
 
 		crkey := getObjKey(pr.CheckResult.GetName(), pr.CheckResult.GetNamespace())

--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -265,10 +265,6 @@ func ensureSupportedProfileBundle(ctx context.Context, crclient client.Client, p
 	return nil
 }
 
-func profileBundlesDiffer(ref, other *compv1alpha1.ProfileBundle) bool {
-	return ref.Spec.ContentFile != other.Spec.ContentFile || ref.Spec.ContentImage != other.Spec.ContentImage
-}
-
 func ensureDefaultScanSettings(ctx context.Context, crclient client.Client, namespaceList []string) error {
 	var lastErr error
 	for _, ns := range namespaceList {

--- a/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
@@ -35,6 +35,11 @@ spec:
           id:
             description: A unique identifier of a check
             type: string
+          instructions:
+            description: How to evaluate if the rule status manually. If no automatic
+              test is present, the rule status will be MANUAL and the administrator
+              should follow these instructions.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -160,6 +160,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
     olm.skipRange: '>=0.1.17 <0.1.26'
+    operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/openshift/compliance-operator

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.26'
+    olm.skipRange: '>=0.1.17 <0.1.27'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.26
+  name: compliance-operator.v0.1.27
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1058,10 +1058,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.4
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.26
+                  value: quay.io/compliance-operator/compliance-operator:0.1.27
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.26
+                image: quay.io/compliance-operator/compliance-operator:0.1.27
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources: {}
@@ -1247,6 +1247,16 @@ spec:
         serviceAccountName: api-resource-collector
       - rules:
         - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - restricted
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: resultserver
+      - rules:
+        - apiGroups:
           - ""
           resources:
           - events
@@ -1358,4 +1368,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.26
+  version: 0.1.27

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancecheckresults_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancecheckresults_crd.yaml
@@ -36,6 +36,11 @@ spec:
           id:
             description: A unique identifier of a check
             type: string
+          instructions:
+            description: How to evaluate if the rule status manually. If no automatic
+              test is present, the rule status will be MANUAL and the administrator
+              should follow these instructions.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -220,6 +220,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: resultserver
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - restricted
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: remediation-aggregator
 rules:
 - apiGroups:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -97,3 +97,16 @@ roleRef:
   kind: Role
   name: profileparser
   apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: resultserver
+subjects:
+- kind: ServiceAccount
+  name: resultserver
+  namespace: openshift-compliance
+roleRef:
+  kind: Role
+  name: resultserver
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -27,3 +27,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: profileparser
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: resultserver

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -231,6 +231,8 @@ Where:
 	* **FAIL**: Which indicates that the check ran to completion and failed.
 	* **INFO**: Which indicates that the check ran to completion and found
       something not severe enough to be considered error.
+	* **MANUAL**: Which indicates that the check does not have a way to
+        automatically assess success or failure and must be checked manually.
     * **INCONSISTENT**: Which indicates that different nodes report different
       results.
 	* **ERROR**: Which indicates that the check ran, but could not complete

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -364,6 +364,22 @@ For instance:
 oc get complianceremediations -l compliance.openshift.io/suite=example-compliancesuite
 ```
 
+Not all `ComplianceCheckResult` objects create `ComplianceRemediation`
+objects, only those that can be remediated automatically do. A
+`ComplianceCheckResult` object has a related remediation if it's labeled
+with the `compliance.openshift.io/automated-remediation` label, the
+name of the remediation is the same as the name of the check. To list all
+failing checks that can be remediated automatically, call:
+```
+oc get compliancecheckresults -l 'compliance.openshift.io/check-status in (FAIL),compliance.openshift.io/automated-remediation'
+```
+and to list those that must be remediated manually:
+```
+oc get compliancecheckresults -l 'compliance.openshift.io/check-status in (FAIL),!compliance.openshift.io/automated-remediation'
+```
+The manual remediation steps are typically stored in the `ComplianceCheckResult`'s
+`description` attribute.
+
 ### The `ProfileBundle` object
 OpenSCAP content for consumption by the Compliance Operator is distributed
 as container images. In order to make it easier for users to discover what

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -213,6 +213,11 @@ description: |-
   authentication to privileged accounts. Users will first login, then escalate
   to privileged (root) access via su / sudo. This is required for FISMA Low
   and FISMA Moderate systems.
+instructions: |-
+  To ensure root may not directly login to the system over physical consoles,
+  run the following command:
+     cat /etc/securetty
+  If any output is returned, this is a finding.
 id: xccdf_org.ssgproject.content_rule_no_direct_root_logins
 severity: medium
 status: FAIL
@@ -221,7 +226,11 @@ status: FAIL
 Where:
 
 * **description**: Contains a description of what's being checked and why
-  that's being done.
+  that's being done. For checks that don't generate an automated remediation,
+  contains the steps to remediate the issue if it's failing.
+* **instructions**: How to evaluate if the rule status manually. If no automatic
+  test is present, the rule status will be MANUAL and the administrator should
+  follow these instructions.
 * **id**: Contains a reference to the XCCDF identifier of the rule as it is in
   the data-stream/content.
 * **severity**: Describes the severity of the check. The possible values are:

--- a/images/openscap/Dockerfile.ci
+++ b/images/openscap/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/origin/4.6:base
+FROM registry.ci.openshift.org/origin/4.6:base
 
 LABEL \
     name="openscap-ocp" \

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -81,6 +81,9 @@ type ComplianceCheckResult struct {
 	Severity ComplianceCheckResultSeverity `json:"severity"`
 	// A human-readable check description, what and why it does
 	Description string `json:"description,omitempty"`
+	// How to evaluate if the rule status manually. If no automatic test is present, the rule status will be MANUAL
+	// and the administrator should follow these instructions.
+	Instructions string `json:"instructions,omitempty"`
 }
 
 // IDToDNSFriendlyName gets the ID from the scan and returns a DNS

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -41,6 +41,8 @@ const (
 	CheckResultFail ComplianceCheckStatus = "FAIL"
 	// The check ran to completion and found something not severe enough to be considered error
 	CheckResultInfo ComplianceCheckStatus = "INFO"
+	// The check ran to completion and found something not severe enough to be considered error
+	CheckResultManual ComplianceCheckStatus = "MANUAL"
 	// The check ran, but could not complete properly
 	CheckResultError ComplianceCheckStatus = "ERROR"
 	// The check didn't run because it is not applicable or not selected

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -14,6 +14,11 @@ type ComplianceCheckStatus string
 const ComplianceCheckResultStatusLabel = "compliance.openshift.io/check-status"
 const ComplianceCheckResultSeverityLabel = "compliance.openshift.io/check-severity"
 
+// ComplianceCheckResultLabel defines a label that will be included in the
+// ComplianceCheckResult objects. It indicates whether the result has an automated
+// remediation or not.
+const ComplianceCheckResultHasRemediation = "compliance.openshift.io/automated-remediation"
+
 // ComplianceCheckInconsistentLabel signifies that the check's results were not consistent
 // across the target nodes
 const ComplianceCheckInconsistentLabel = "compliance.openshift.io/inconsistent-check"

--- a/pkg/controller/complianceremediation/complianceremediation_controller_test.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller_test.go
@@ -262,6 +262,10 @@ var _ = Describe("Testing complianceremediation controller", func() {
 				// reflects an admin having removed it.
 				err = reconciler.client.Update(context.TODO(), remediationinstance)
 				Expect(err).NotTo(HaveOccurred())
+				// mock that the remediation was applied
+				remediationinstance.Status.ApplicationState = compv1alpha1.RemediationApplied
+				err = reconciler.client.Status().Update(context.TODO(), remediationinstance)
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should remove the outdated remediation label", func() {

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift/compliance-operator/pkg/utils"
 )
 
-const resultserverSA = "default"
+const resultserverSA = "resultserver"
 
 // The result-server is a pod that listens for results from other pods and
 // stores them in a PVC.

--- a/pkg/utils/parse_arf_result.go
+++ b/pkg/utils/parse_arf_result.go
@@ -187,11 +187,13 @@ func mapComplianceCheckResultStatus(result *xmldom.Node) (compv1alpha1.Complianc
 		// Unknown state is when the rule runs to completion, but then the results can't be interpreted
 	case "error", "unknown":
 		return compv1alpha1.CheckResultError, nil
-		// We map both notchecked and info to Info. Notchecked means the rule does not even have a check,
-		// and the administratos must inspect the rule manually (e.g. disable something in BIOS),
+		// Notchecked means the rule does not even have a check,
+		// and the administrators must inspect the rule manually (e.g. disable something in BIOS),
+	case "notchecked":
+		return compv1alpha1.CheckResultManual, nil
 		// informational means that the rule has a check which failed, but the severity is low, depending
 		// on the environment (e.g. disable USB support completely from the kernel cmdline)
-	case "notchecked", "informational":
+	case "informational":
 		return compv1alpha1.CheckResultInfo, nil
 		// We map notapplicable to Skipped. Notapplicable means the rule was selected
 		// but does not apply to the current configuration (e.g. arch-specific),

--- a/pkg/utils/parse_arf_result_test.go
+++ b/pkg/utils/parse_arf_result_test.go
@@ -93,8 +93,9 @@ var _ = Describe("XCCDF parser", func() {
 
 		Context("First check metadata", func() {
 			const (
-				expID          = "xccdf_org.ssgproject.content_rule_selinux_policytype"
-				expDescription = "Configure SELinux Policy\n."
+				expID           = "xccdf_org.ssgproject.content_rule_selinux_policytype"
+				expDescription  = "Configure SELinux Policy\n."
+				expInstructions = "Check the file /etc/selinux/config and ensure the following line appears:\nSELINUXTYPE="
 			)
 
 			var (
@@ -121,6 +122,10 @@ var _ = Describe("XCCDF parser", func() {
 
 			It("Should have the expected description", func() {
 				Expect(check.Description).To(Equal(expDescription))
+			})
+
+			It("Should have the expected instructions", func() {
+				Expect(check.Instructions).To(Equal(expInstructions))
 			})
 		})
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1487,11 +1487,15 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
+				assertCheckRemediation(f, checkWifiInBios.Name, checkWifiInBios.Namespace, false)
 
 				checkVsyscall := compv1alpha1.ComplianceCheckResult{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("%s-coreos-vsyscall-kernel-argument", workerScanName),
 						Namespace: namespace,
+						Labels: 	map[string]string{
+							compv1alpha1.ComplianceCheckResultHasRemediation: "",
+						},
 					},
 					ID:       "xccdf_org.ssgproject.content_rule_coreos_vsyscall_kernel_argument",
 					Status:   compv1alpha1.CheckResultInfo,
@@ -1502,6 +1506,8 @@ func TestE2E(t *testing.T) {
 				if err != nil {
 					return err
 				}
+				// even INFO checks generate remediations, make sure the check was labeled appropriately
+				assertCheckRemediation(f, checkVsyscall.Name, checkVsyscall.Namespace, true)
 
 				return nil
 			},

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1479,11 +1479,26 @@ func TestE2E(t *testing.T) {
 						Namespace: namespace,
 					},
 					ID:       "xccdf_org.ssgproject.content_rule_wireless_disable_in_bios",
-					Status:   compv1alpha1.CheckResultInfo,
+					Status:   compv1alpha1.CheckResultManual,
 					Severity: compv1alpha1.CheckResultSeverityUnknown, // yes, it's really uknown in the DS
 				}
 
 				err = assertHasCheck(f, suiteName, workerScanName, checkWifiInBios)
+				if err != nil {
+					return err
+				}
+
+				checkVsyscall := compv1alpha1.ComplianceCheckResult{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s-coreos-vsyscall-kernel-argument", workerScanName),
+						Namespace: namespace,
+					},
+					ID:       "xccdf_org.ssgproject.content_rule_coreos_vsyscall_kernel_argument",
+					Status:   compv1alpha1.CheckResultInfo,
+					Severity: compv1alpha1.CheckResultSeverityMedium, // yes, it's really uknown in the DS
+				}
+
+				err = assertHasCheck(f, suiteName, workerScanName, checkVsyscall)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
* Dependency handling for remediations
* Resultserver now has its own ServiceAccount so we can bind it to a specific SCC.
* ComplianceChecks with automated remediations are now appropriately labeled.
* OCIL now surfaced to results as the `instructions` field
* checks requiring manual intervention now marked as `MANUAL`