### PR TITLE
Add short names to all CRDs

### DIFF
--- a/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
@@ -8,6 +8,10 @@ spec:
     kind: ComplianceCheckResult
     listKind: ComplianceCheckResultList
     plural: compliancecheckresults
+    shortNames:
+    - ccr
+    - checkresults
+    - checkresult
     singular: compliancecheckresult
   scope: Namespaced
   versions:

--- a/deploy/crds/compliance.openshift.io_complianceremediations_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_complianceremediations_crd.yaml
@@ -8,6 +8,11 @@ spec:
     kind: ComplianceRemediation
     listKind: ComplianceRemediationList
     plural: complianceremediations
+    shortNames:
+    - cr
+    - remediations
+    - remediation
+    - rems
     singular: complianceremediation
   scope: Namespaced
   versions:

--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -8,6 +8,9 @@ spec:
     kind: ComplianceScan
     listKind: ComplianceScanList
     plural: compliancescans
+    shortNames:
+    - scans
+    - scan
     singular: compliancescan
   scope: Namespaced
   versions:

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -8,6 +8,9 @@ spec:
     kind: ComplianceSuite
     listKind: ComplianceSuiteList
     plural: compliancesuites
+    shortNames:
+    - suites
+    - suite
     singular: compliancesuite
   scope: Namespaced
   versions:

--- a/deploy/crds/compliance.openshift.io_profilebundles_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_profilebundles_crd.yaml
@@ -8,6 +8,8 @@ spec:
     kind: ProfileBundle
     listKind: ProfileBundleList
     plural: profilebundles
+    shortNames:
+    - pb
     singular: profilebundle
   scope: Namespaced
   versions:

--- a/deploy/crds/compliance.openshift.io_profiles_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_profiles_crd.yaml
@@ -8,6 +8,9 @@ spec:
     kind: Profile
     listKind: ProfileList
     plural: profiles
+    shortNames:
+    - profs
+    - prof
     singular: profile
   scope: Namespaced
   versions:

--- a/deploy/crds/compliance.openshift.io_scansettingbindings_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_scansettingbindings_crd.yaml
@@ -8,6 +8,8 @@ spec:
     kind: ScanSettingBinding
     listKind: ScanSettingBindingList
     plural: scansettingbindings
+    shortNames:
+    - ssb
     singular: scansettingbinding
   scope: Namespaced
   versions:

--- a/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
@@ -8,6 +8,8 @@ spec:
     kind: ScanSetting
     listKind: ScanSettingList
     plural: scansettings
+    shortNames:
+    - ss
     singular: scansetting
   scope: Namespaced
   versions:

--- a/deploy/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
@@ -8,6 +8,9 @@ spec:
     kind: TailoredProfile
     listKind: TailoredProfileList
     plural: tailoredprofiles
+    shortNames:
+    - tp
+    - tprof
     singular: tailoredprofile
   scope: Namespaced
   versions:

--- a/deploy/crds/compliance.openshift.io_variables_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_variables_crd.yaml
@@ -8,6 +8,8 @@ spec:
     kind: Variable
     listKind: VariableList
     plural: variables
+    shortNames:
+    - var
     singular: variable
   scope: Namespaced
   versions:

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -71,7 +71,7 @@ const (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ComplianceCheckResult represent a result of a single compliance "test"
-// +kubebuilder:resource:path=compliancecheckresults,scope=Namespaced
+// +kubebuilder:resource:path=compliancecheckresults,scope=Namespaced,shortName=ccr;checkresults;checkresult
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=`.status`
 // +kubebuilder:printcolumn:name="Severity",type="string",JSONPath=`.severity`
 type ComplianceCheckResult struct {

--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -78,7 +78,7 @@ type ComplianceRemediationStatus struct {
 // cluster to fix the found issues.
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=complianceremediations,scope=Namespaced
+// +kubebuilder:resource:path=complianceremediations,scope=Namespaced,shortName=cr;remediations;remediation;rems
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=`.status.applicationState`
 type ComplianceRemediation struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -248,6 +248,7 @@ type StorageReference struct {
 // that apply to a certain nodeSelector, or the cluster itself.
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:path=compliancescans,scope=Namespaced,shortName=scans;scan
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Result",type="string",JSONPath=`.status.result`
 type ComplianceScan struct {

--- a/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
@@ -110,7 +110,7 @@ type ComplianceSuiteStatus struct {
 // cluster. These should help deployers achieve a certain compliance target.
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=compliancesuites,scope=Namespaced
+// +kubebuilder:resource:path=compliancesuites,scope=Namespaced,shortName=suites;suite
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Result",type="string",JSONPath=`.status.result`
 type ComplianceSuite struct {

--- a/pkg/apis/compliance/v1alpha1/profile_types.go
+++ b/pkg/apis/compliance/v1alpha1/profile_types.go
@@ -40,7 +40,7 @@ type ProfilePayload struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Profile is the Schema for the profiles API
-// +kubebuilder:resource:path=profiles,scope=Namespaced
+// +kubebuilder:resource:path=profiles,scope=Namespaced,shortName=profs;prof
 type Profile struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/compliance/v1alpha1/profilebundle_types.go
+++ b/pkg/apis/compliance/v1alpha1/profilebundle_types.go
@@ -55,7 +55,7 @@ type ProfileBundleStatus struct {
 
 // ProfileBundle is the Schema for the profilebundles API
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=profilebundles,scope=Namespaced
+// +kubebuilder:resource:path=profilebundles,scope=Namespaced,shortName=pb
 // +kubebuilder:printcolumn:name="ContentImage",type="string",JSONPath=`.spec.contentImage`
 // +kubebuilder:printcolumn:name="ContentFile",type="string",JSONPath=`.spec.contentFile`
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=`.status.dataStreamStatus`

--- a/pkg/apis/compliance/v1alpha1/scansetting_types.go
+++ b/pkg/apis/compliance/v1alpha1/scansetting_types.go
@@ -8,7 +8,7 @@ import (
 
 // ScanSetting is the Schema for the scansettings API
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=scansettings,scope=Namespaced
+// +kubebuilder:resource:path=scansettings,scope=Namespaced,shortName=ss
 type ScanSetting struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/compliance/v1alpha1/scansettingbinding_types.go
+++ b/pkg/apis/compliance/v1alpha1/scansettingbinding_types.go
@@ -17,7 +17,7 @@ type NamedObjectReference struct {
 // ScanSettingBinding is the Schema for the scansettingbindings API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=scansettingbindings,scope=Namespaced
+// +kubebuilder:resource:path=scansettingbindings,scope=Namespaced,shortName=ssb
 type ScanSettingBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/compliance/v1alpha1/tailoredprofile_types.go
+++ b/pkg/apis/compliance/v1alpha1/tailoredprofile_types.go
@@ -79,7 +79,7 @@ type OutputRef struct {
 
 // TailoredProfile is the Schema for the tailoredprofiles API
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=tailoredprofiles,scope=Namespaced
+// +kubebuilder:resource:path=tailoredprofiles,scope=Namespaced,shortName=tp;tprof
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=`.status.state`,description="State of the tailored profile"
 type TailoredProfile struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/compliance/v1alpha1/variable_types.go
+++ b/pkg/apis/compliance/v1alpha1/variable_types.go
@@ -49,7 +49,7 @@ type VariablePayload struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Variable describes a tunable in the XCCDF profile
-// +kubebuilder:resource:path=variables,scope=Namespaced
+// +kubebuilder:resource:path=variables,scope=Namespaced,shortName=var
 type Variable struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
This is a usability enhancement, as folks won't need to write the whole
object name any more, and instead can just refer to the short names.

e.g. instead of writing

```
oc get compliancesuites
```

folks can just do

`oc get suites` or `oc get suite`

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>