### PR TITLE
Set requests and limits for compliance operator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -23,6 +23,13 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
+          resources:
+            requests:
+              memory: "20Mi"
+              cpu: "250m"
+            limits:
+              memory: "200Mi"
+              cpu: "500m"
           env:
             - name: WATCH_NAMESPACE
               valueFrom:


### PR DESCRIPTION
This is a hardening measure and ensures that the operator doesn't become
a noisy neighbour.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>