### PR TITLE
Set resource requests and limits for ProfileBundle workload

### DIFF
--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -423,6 +424,16 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *a
 								AllowPrivilegeEscalation: &falseP,
 								ReadOnlyRootFilesystem:   &trueP,
 							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("10Mi"),
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("50Mi"),
+									corev1.ResourceCPU:    resource.MustParse("250m"),
+								},
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "content-dir",
@@ -436,6 +447,16 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *a
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: &falseP,
 								ReadOnlyRootFilesystem:   &trueP,
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("20Mi"),
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("200Mi"),
+									corev1.ResourceCPU:    resource.MustParse("1000m"),
+								},
 							},
 							Command: []string{
 								"compliance-operator", "profileparser",
@@ -471,6 +492,16 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *a
 							# Waits for the sleep infinity running in the background and always returns zero
 							wait
 							`},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("1Mi"),
+									corev1.ResourceCPU:    resource.MustParse("20m"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("2Mi"),
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+								},
+							},
 						},
 					},
 					ServiceAccountName: "profileparser",


### PR DESCRIPTION
This is a hardening measure and ensures that the operator doesn't become
a noisy neighbour.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>