### PR TITLE
Add resource requests and limits for suite rerunner

### DIFF
--- a/pkg/controller/compliancesuite/suitererunner.go
+++ b/pkg/controller/compliancesuite/suitererunner.go
@@ -10,6 +10,7 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -132,6 +133,16 @@ func getRerunner(suite *compv1alpha1.ComplianceSuite) *batchv1beta1.CronJob {
 										"compliance-operator", "suitererunner",
 										"--name", suite.GetName(),
 										"--namespace", suite.GetNamespace(),
+									},
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceMemory: resource.MustParse("10Mi"),
+											corev1.ResourceCPU:    resource.MustParse("100m"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceMemory: resource.MustParse("50Mi"),
+											corev1.ResourceCPU:    resource.MustParse("250m"),
+										},
 									},
 								},
 							},


### PR DESCRIPTION
This is a hardening measure and ensures that the operator doesn't become
a noisy neighbour.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>