### PR TITLE
Add flag to auto update remediations

### DIFF
--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -47,6 +47,11 @@ spec:
                 description: Defines whether or not the remediations should be applied
                   automatically
                 type: boolean
+              autoUpdateRemediations:
+                description: Defines whether or not the remediations should be updated
+                  automatically. This is done by deleting the "outdated" object from
+                  the remediation.
+                type: boolean
               scans:
                 description: Contains a list of the scans to execute on the cluster
                 items:

--- a/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
@@ -27,6 +27,11 @@ spec:
             description: Defines whether or not the remediations should be applied
               automatically
             type: boolean
+          autoUpdateRemediations:
+            description: Defines whether or not the remediations should be updated
+              automatically. This is done by deleting the "outdated" object from the
+              remediation.
+            type: boolean
           debug:
             description: Enable debug logging of workloads and OpenSCAP
             type: boolean

--- a/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
@@ -77,6 +77,9 @@ type ComplianceScanStatusWrapper struct {
 type ComplianceSuiteSettings struct {
 	// Defines whether or not the remediations should be applied automatically
 	AutoApplyRemediations bool `json:"autoApplyRemediations,omitempty"`
+	// Defines whether or not the remediations should be updated automatically.
+	// This is done by deleting the "outdated" object from the remediation.
+	AutoUpdateRemediations bool `json:"autoUpdateRemediations,omitempty"`
 	// Defines a schedule for the scans to run. This is in cronjob format.
 	// Note the scan will still be triggered immediately, and the scheduled
 	// scans will start running only after the initial results are ready.
@@ -202,6 +205,13 @@ func (s *ComplianceSuite) ShouldApplyRemediations() bool {
 	return s.ApplyRemediationsAnnotationSet()
 }
 
+func (s *ComplianceSuite) ShouldRemoveOutdated() bool {
+	if s.Spec.AutoUpdateRemediations {
+		return true
+	}
+	return s.RemoveOutdatedAnnotationSet()
+}
+
 func (s *ComplianceSuite) ApplyRemediationsAnnotationSet() bool {
 	annotations := s.GetAnnotations()
 	if annotations == nil {
@@ -211,7 +221,7 @@ func (s *ComplianceSuite) ApplyRemediationsAnnotationSet() bool {
 	return ok
 }
 
-func (s *ComplianceSuite) RemoveOutdated() bool {
+func (s *ComplianceSuite) RemoveOutdatedAnnotationSet() bool {
 	annotations := s.GetAnnotations()
 	if annotations == nil {
 		return false

--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -501,12 +501,12 @@ func (r *ReconcileComplianceSuite) reconcileRemediations(suite *compv1alpha1.Com
 		}
 	}
 
-	if suite.ApplyRemediationsAnnotationSet() || suite.RemoveOutdated() {
+	if suite.ApplyRemediationsAnnotationSet() || suite.RemoveOutdatedAnnotationSet() {
 		suiteCopy := suite.DeepCopy()
 		if suite.ApplyRemediationsAnnotationSet() {
 			delete(suiteCopy.Annotations, compv1alpha1.ApplyRemediationsAnnotation)
 		}
-		if suite.RemoveOutdated() {
+		if suite.RemoveOutdatedAnnotationSet() {
 			delete(suiteCopy.Annotations, compv1alpha1.RemoveOutdatedAnnotation)
 		}
 		updateErr := r.client.Update(context.TODO(), suiteCopy)
@@ -600,5 +600,5 @@ func (r *ReconcileComplianceSuite) getAffectedMcfgPool(scan *compv1alpha1.Compli
 }
 
 func remediationNeedsOutdatedRemoval(rem *compv1alpha1.ComplianceRemediation, suite *compv1alpha1.ComplianceSuite) bool {
-	return suite.RemoveOutdated() && rem.Status.ApplicationState == compv1alpha1.RemediationOutdated
+	return suite.ShouldRemoveOutdated() && rem.Status.ApplicationState == compv1alpha1.RemediationOutdated
 }


### PR DESCRIPTION
Similarly to the `autoApplyRemediations` flag, this adds a flag called
`autoUpdateRemediations` to the ComplianceSuite. This ensures that the
ComplianceSuite will automatically handle outdated remediations, thus
removing this burden from administrators.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>