### PR TITLE
Backport release v0.1.29

### DIFF
--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -47,6 +47,11 @@ spec:
                 description: Defines whether or not the remediations should be applied
                   automatically
                 type: boolean
+              autoUpdateRemediations:
+                description: Defines whether or not the remediations should be updated
+                  automatically. This is done by deleting the "outdated" object from
+                  the remediation.
+                type: boolean
               scans:
                 description: Contains a list of the scans to execute on the cluster
                 items:

--- a/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
@@ -27,6 +27,11 @@ spec:
             description: Defines whether or not the remediations should be applied
               automatically
             type: boolean
+          autoUpdateRemediations:
+            description: Defines whether or not the remediations should be updated
+              automatically. This is done by deleting the "outdated" object from the
+              remediation.
+            type: boolean
           debug:
             description: Enable debug logging of workloads and OpenSCAP
             type: boolean

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.28'
+    olm.skipRange: '>=0.1.17 <0.1.29'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.28
+  name: compliance-operator.v0.1.29
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1058,10 +1058,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.4
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.28
+                  value: quay.io/compliance-operator/compliance-operator:0.1.29
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.28
+                image: quay.io/compliance-operator/compliance-operator:0.1.29
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources: {}
@@ -1368,4 +1368,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.28
+  version: 0.1.29

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancesuites_crd.yaml
@@ -48,6 +48,11 @@ spec:
                 description: Defines whether or not the remediations should be applied
                   automatically
                 type: boolean
+              autoUpdateRemediations:
+                description: Defines whether or not the remediations should be updated
+                  automatically. This is done by deleting the "outdated" object from
+                  the remediation.
+                type: boolean
               scans:
                 description: Contains a list of the scans to execute on the cluster
                 items:

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_scansettings_crd.yaml
@@ -28,6 +28,11 @@ spec:
             description: Defines whether or not the remediations should be applied
               automatically
             type: boolean
+          autoUpdateRemediations:
+            description: Defines whether or not the remediations should be updated
+              automatically. This is done by deleting the "outdated" object from the
+              remediation.
+            type: boolean
           debug:
             description: Enable debug logging of workloads and OpenSCAP
             type: boolean

--- a/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancesuite_types.go
@@ -77,6 +77,9 @@ type ComplianceScanStatusWrapper struct {
 type ComplianceSuiteSettings struct {
 	// Defines whether or not the remediations should be applied automatically
 	AutoApplyRemediations bool `json:"autoApplyRemediations,omitempty"`
+	// Defines whether or not the remediations should be updated automatically.
+	// This is done by deleting the "outdated" object from the remediation.
+	AutoUpdateRemediations bool `json:"autoUpdateRemediations,omitempty"`
 	// Defines a schedule for the scans to run. This is in cronjob format.
 	// Note the scan will still be triggered immediately, and the scheduled
 	// scans will start running only after the initial results are ready.
@@ -202,6 +205,13 @@ func (s *ComplianceSuite) ShouldApplyRemediations() bool {
 	return s.ApplyRemediationsAnnotationSet()
 }
 
+func (s *ComplianceSuite) ShouldRemoveOutdated() bool {
+	if s.Spec.AutoUpdateRemediations {
+		return true
+	}
+	return s.RemoveOutdatedAnnotationSet()
+}
+
 func (s *ComplianceSuite) ApplyRemediationsAnnotationSet() bool {
 	annotations := s.GetAnnotations()
 	if annotations == nil {
@@ -211,7 +221,7 @@ func (s *ComplianceSuite) ApplyRemediationsAnnotationSet() bool {
 	return ok
 }
 
-func (s *ComplianceSuite) RemoveOutdated() bool {
+func (s *ComplianceSuite) RemoveOutdatedAnnotationSet() bool {
 	annotations := s.GetAnnotations()
 	if annotations == nil {
 		return false

--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -501,12 +501,12 @@ func (r *ReconcileComplianceSuite) reconcileRemediations(suite *compv1alpha1.Com
 		}
 	}
 
-	if suite.ApplyRemediationsAnnotationSet() || suite.RemoveOutdated() {
+	if suite.ApplyRemediationsAnnotationSet() || suite.RemoveOutdatedAnnotationSet() {
 		suiteCopy := suite.DeepCopy()
 		if suite.ApplyRemediationsAnnotationSet() {
 			delete(suiteCopy.Annotations, compv1alpha1.ApplyRemediationsAnnotation)
 		}
-		if suite.RemoveOutdated() {
+		if suite.RemoveOutdatedAnnotationSet() {
 			delete(suiteCopy.Annotations, compv1alpha1.RemoveOutdatedAnnotation)
 		}
 		updateErr := r.client.Update(context.TODO(), suiteCopy)
@@ -600,5 +600,5 @@ func (r *ReconcileComplianceSuite) getAffectedMcfgPool(scan *compv1alpha1.Compli
 }
 
 func remediationNeedsOutdatedRemoval(rem *compv1alpha1.ComplianceRemediation, suite *compv1alpha1.ComplianceSuite) bool {
-	return suite.RemoveOutdated() && rem.Status.ApplicationState == compv1alpha1.RemediationOutdated
+	return suite.ShouldRemoveOutdated() && rem.Status.ApplicationState == compv1alpha1.RemediationOutdated
 }

--- a/pkg/controller/scansettingbinding/scansettingbinding_controller.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller.go
@@ -611,5 +611,5 @@ func suiteNeedsUpdate(have, found *compliancev1alpha1.ComplianceSuite) bool {
 }
 
 func scanSettingBindingStatusNeedsUpdate(ssb *compliancev1alpha1.ScanSettingBinding) bool {
-	return ssb.Status.Conditions.GetCondition("Ready") == nil || ssb.Status.OutputRef.Name == ""
+	return ssb.Status.Conditions.GetCondition("Ready") == nil || ssb.Status.OutputRef == nil || ssb.Status.OutputRef.Name == ""
 }

--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -737,6 +737,14 @@ func newStandardParser() *referenceParser {
 	if err != nil {
 		log.Error(err, "Could not register NIST-800-53 reference parser") // not much we can do here..
 	}
+	cocperr := p.registerStandard("CIS-OCP", `^https://www.cisecurity.org/benchmark/kubernetes/$`)
+	if cocperr != nil {
+		log.Error(cocperr, "Could not register CIS OpenShift reference parser") // not much we can do here..
+	}
+	crherr := p.registerStandard("CIS-RHEL", `^https://www.cisecurity.org/benchmark/red_hat_linux/$`)
+	if crherr != nil {
+		log.Error(crherr, "Could not register CIS Red Hat Linux reference parser") // not much we can do here..
+	}
 
 	p.registerFormatter(profileOperatorFormatter)
 	p.registerFormatter(rhacmFormatter)


### PR DESCRIPTION
* Add flag to auto-update remediations: autoUpdateRemediations
* Create "default-auto-apply" ScanSetting (auto applies remediations and auto-updates them too)
* Add CIS references: These now get annotated in the rules
* Fix nil dereference in ScanSettingBindings controller