### PR TITLE
Replace xmldom by xmlquery for profile parsing

### DIFF
--- a/cmd/manager/profileparser.go
+++ b/cmd/manager/profileparser.go
@@ -8,9 +8,9 @@ import (
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	"github.com/antchfx/xmlquery"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/spf13/cobra"
-	"github.com/subchen/go-xmldom"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -42,11 +42,6 @@ func defineProfileParserFlags(cmd *cobra.Command) {
 	// Add flags registered by imported packages (e.g. glog and
 	// controller-runtime)
 	flags.AddGoFlagSet(flag.CommandLine)
-}
-
-// XMLDocument is a wrapper that keeps the interface XML-parser-agnostic
-type XMLDocument struct {
-	*xmldom.Document
 }
 
 func newParserConfig(cmd *cobra.Command) *profileparser.ParserConfig {
@@ -140,7 +135,7 @@ func runProfileParser(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	bufContentFile := bufio.NewReader(contentFile)
-	contentDom, err := xmldom.Parse(bufContentFile)
+	contentDom, err := xmlquery.Parse(bufContentFile)
 	if err != nil {
 		log.Error(err, "Couldn't read the content XML")
 		updateProfileBundleStatus(pcfg, pb, fmt.Errorf("Couldn't read content XML: %s", err))

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.14
 
 require (
 	github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559 // indirect
+	github.com/antchfx/xmlquery v1.3.5
+	github.com/antchfx/xpath v1.1.11 // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2
 	github.com/clarketm/json v1.14.1
 	github.com/coreos/ignition v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,13 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aliyun/aliyun-oss-go-sdk v2.0.4+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
+github.com/antchfx/xmlquery v1.3.5 h1:I7TuBRqsnfFuL11ruavGm911Awx9IqSdiU6W/ztSmVw=
+github.com/antchfx/xmlquery v1.3.5/go.mod h1:64w0Xesg2sTaawIdNqMB+7qaW/bSqkQm+ssPaCMWNnc=
 github.com/antchfx/xpath v0.0.0-20170515025933-1f3266e77307 h1:C735MoY/X+UOx6SECmHk5pVOj51h839Ph13pEoY8UmU=
 github.com/antchfx/xpath v0.0.0-20170515025933-1f3266e77307/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
+github.com/antchfx/xpath v1.1.10/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
+github.com/antchfx/xpath v1.1.11 h1:WOFtK8TVAjLm3lbgqeP0arlHpvCEeTANeWZ/csPpJkQ=
+github.com/antchfx/xpath v1.1.11/go.mod h1:i54GszH55fYfBmoZXapTHN8T8tkcHfRgLyVwwqzXNcs=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6 h1:uZuxRZCz65cG1o6K/xUqImNcYKtmk9ylqaH0itMSvzA=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -1364,6 +1369,7 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/pkg/xccdf/tailoring_test.go
+++ b/pkg/xccdf/tailoring_test.go
@@ -1,8 +1,10 @@
 package xccdf
 
 import (
+	"strings"
+
+	"github.com/antchfx/xmlquery"
 	cmpv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
-	"github.com/subchen/go-xmldom"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
@@ -15,17 +17,17 @@ type tailoredValue struct {
 }
 
 func findVariablesInTailoring(tailoring string) ([]tailoredValue, error) {
-	tailoringDom, err := xmldom.ParseXML(tailoring)
+	tailoringDom, err := xmlquery.Parse(strings.NewReader(tailoring))
 	if err != nil {
 		return nil, err
 	}
 
 	tailoredVars := []tailoredValue{}
-	tailoringVarNodes := tailoringDom.Root.Query("//set-value")
+	tailoringVarNodes := tailoringDom.SelectElements("//xccdf-1.2:set-value")
 	for _, tVarNode := range tailoringVarNodes {
 		tailoredVars = append(tailoredVars, tailoredValue{
-			ID:    tVarNode.GetAttributeValue("idref"),
-			Value: tVarNode.Text,
+			ID:    tVarNode.SelectAttr("idref"),
+			Value: tVarNode.InnerText(),
 		})
 	}
 

--- a/vendor/github.com/antchfx/xmlquery/.gitignore
+++ b/vendor/github.com/antchfx/xmlquery/.gitignore
@@ -1,0 +1,32 @@
+# vscode
+.vscode
+debug
+*.test
+
+./build
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/antchfx/xmlquery/.travis.yml
+++ b/vendor/github.com/antchfx/xmlquery/.travis.yml
@@ -1,0 +1,17 @@
+language: go
+
+go:
+  - 1.9.x
+  - 1.12.x
+  - 1.13.x
+  - 1.14.x
+  - 1.15.x
+
+install:
+  - go get golang.org/x/net/html/charset
+  - go get github.com/antchfx/xpath
+  - go get github.com/mattn/goveralls
+  - go get github.com/golang/groupcache
+
+script:
+  - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/vendor/github.com/antchfx/xmlquery/LICENSE
+++ b/vendor/github.com/antchfx/xmlquery/LICENSE
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/antchfx/xmlquery/README.md
+++ b/vendor/github.com/antchfx/xmlquery/README.md
@@ -1,0 +1,262 @@
+xmlquery
+====
+[![Build Status](https://travis-ci.org/antchfx/xmlquery.svg?branch=master)](https://travis-ci.org/antchfx/xmlquery)
+[![Coverage Status](https://coveralls.io/repos/github/antchfx/xmlquery/badge.svg?branch=master)](https://coveralls.io/github/antchfx/xmlquery?branch=master)
+[![GoDoc](https://godoc.org/github.com/antchfx/xmlquery?status.svg)](https://godoc.org/github.com/antchfx/xmlquery)
+[![Go Report Card](https://goreportcard.com/badge/github.com/antchfx/xmlquery)](https://goreportcard.com/report/github.com/antchfx/xmlquery)
+
+Overview
+===
+
+`xmlquery` is an XPath query package for XML documents, allowing you to extract 
+data or evaluate from XML documents with an XPath expression.
+
+`xmlquery` has a built-in query object caching feature that caches recently used
+XPATH query strings. Enabling caching can avoid recompile XPath expression for 
+each query. 
+
+Change Logs
+===
+
+2020-08-??
+- Add XML stream loading and parsing support.
+
+2019-11-11 
+- Add XPath query caching.
+
+2019-10-05 
+- Add new methods compatible with invalid XPath expression error: `QueryAll` and `Query`.
+- Add `QuerySelector` and `QuerySelectorAll` methods, support for reused query objects.
+- PR [#12](https://github.com/antchfx/xmlquery/pull/12) (Thanks @FrancescoIlario)
+- PR [#11](https://github.com/antchfx/xmlquery/pull/11) (Thanks @gjvnq)
+
+2018-12-23
+- Added XML output including comment nodes. [#9](https://github.com/antchfx/xmlquery/issues/9)
+
+2018-12-03
+- Added support to attribute name with namespace prefix and XML output. [#6](https://github.com/antchfx/xmlquery/issues/6)
+
+Installation
+====
+```
+ $ go get github.com/antchfx/xmlquery
+```
+
+Getting Started
+===
+
+### Find specified XPath query.
+
+```go
+list, err := xmlquery.QueryAll(doc, "a")
+if err != nil {
+	panic(err)
+}
+```
+
+#### Parse an XML from URL.
+
+```go
+doc, err := xmlquery.LoadURL("http://www.example.com/sitemap.xml")
+```
+
+#### Parse an XML from string.
+
+```go
+s := `<?xml version="1.0" encoding="utf-8"?><rss version="2.0"></rss>`
+doc, err := xmlquery.Parse(strings.NewReader(s))
+```
+
+#### Parse an XML from io.Reader.
+
+```go
+f, err := os.Open("../books.xml")
+doc, err := xmlquery.Parse(f)
+```
+
+#### Parse an XML in a stream fashion (simple case without elements filtering).
+
+```go
+f, err := os.Open("../books.xml")
+p, err := xmlquery.CreateStreamParser(f, "/bookstore/book")
+for {
+	n, err := p.Read()
+	if err == io.EOF {
+		break
+	}
+	if err != nil {
+		...
+	}
+}
+```
+
+#### Parse an XML in a stream fashion (simple case advanced element filtering).
+
+```go
+f, err := os.Open("../books.xml")
+p, err := xmlquery.CreateStreamParser(f, "/bookstore/book", "/bookstore/book[price>=10]")
+for {
+	n, err := p.Read()
+	if err == io.EOF {
+		break
+	}
+	if err != nil {
+		...
+	}
+}
+```
+
+#### Find authors of all books in the bookstore.
+
+```go
+list := xmlquery.Find(doc, "//book//author")
+// or
+list := xmlquery.Find(doc, "//author")
+```
+
+#### Find the second book.
+
+```go
+book := xmlquery.FindOne(doc, "//book[2]")
+```
+
+#### Find all book elements and only get `id` attribute. (New Feature)
+
+```go
+list := xmlquery.Find(doc,"//book/@id")
+```
+
+#### Find all books with id `bk104`.
+
+```go
+list := xmlquery.Find(doc, "//book[@id='bk104']")
+```
+
+#### Find all books with price less than 5.
+
+```go
+list := xmlquery.Find(doc, "//book[price<5]")
+```
+
+#### Evaluate total price of all books.
+
+```go
+expr, err := xpath.Compile("sum(//book/price)")
+price := expr.Evaluate(xmlquery.CreateXPathNavigator(doc)).(float64)
+fmt.Printf("total price: %f\n", price)
+```
+
+#### Evaluate number of all book elements.
+
+```go
+expr, err := xpath.Compile("count(//book)")
+price := expr.Evaluate(xmlquery.CreateXPathNavigator(doc)).(float64)
+```
+
+FAQ
+====
+
+#### `Find()` vs `QueryAll()`, which is better?
+
+`Find` and `QueryAll` both do the same thing: searches all of matched XML nodes.
+`Find` panics if provided with an invalid XPath query, while `QueryAll` returns
+an error.
+
+#### Can I save my query expression object for the next query?
+
+Yes, you can. We provide `QuerySelector` and `QuerySelectorAll` methods; they 
+accept your query expression object.
+
+Caching a query expression object avoids recompiling the XPath query 
+expression, improving query performance.
+
+#### Create XML document.
+
+```go
+doc := &xmlquery.Node{
+	Type: xmlquery.DeclarationNode,
+	Data: "xml",
+	Attr: []xml.Attr{
+		xml.Attr{Name: xml.Name{Local: "version"}, Value: "1.0"},
+	},
+}
+root := &xmlquery.Node{
+	Data: "rss",
+	Type: xmlquery.ElementNode,
+}
+doc.FirstChild = root
+channel := &xmlquery.Node{
+	Data: "channel",
+	Type: xmlquery.ElementNode,
+}
+root.FirstChild = channel
+title := &xmlquery.Node{
+	Data: "title",
+	Type: xmlquery.ElementNode,
+}
+title_text := &xmlquery.Node{
+	Data: "W3Schools Home Page",
+	Type: xmlquery.TextNode,
+}
+title.FirstChild = title_text
+channel.FirstChild = title
+fmt.Println(doc.OutputXML(true))
+// <?xml version="1.0"?><rss><channel><title>W3Schools Home Page</title></channel></rss>
+```
+
+Quick Tutorial
+===
+
+```go
+import (
+	"github.com/antchfx/xmlquery"
+)
+
+func main(){
+	s := `<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+<channel>
+  <title>W3Schools Home Page</title>
+  <link>https://www.w3schools.com</link>
+  <description>Free web building tutorials</description>
+  <item>
+    <title>RSS Tutorial</title>
+    <link>https://www.w3schools.com/xml/xml_rss.asp</link>
+    <description>New RSS tutorial on W3Schools</description>
+  </item>
+  <item>
+    <title>XML Tutorial</title>
+    <link>https://www.w3schools.com/xml</link>
+    <description>New XML tutorial on W3Schools</description>
+  </item>
+</channel>
+</rss>`
+
+	doc, err := xmlquery.Parse(strings.NewReader(s))
+	if err != nil {
+		panic(err)
+	}
+	channel := xmlquery.FindOne(doc, "//channel")
+	if n := channel.SelectElement("title"); n != nil {
+		fmt.Printf("title: %s\n", n.InnerText())
+	}
+	if n := channel.SelectElement("link"); n != nil {
+		fmt.Printf("link: %s\n", n.InnerText())
+	}
+	for i, n := range xmlquery.Find(doc, "//item/title") {
+		fmt.Printf("#%d %s\n", i, n.InnerText())
+	}
+}
+```
+
+List of supported XPath query packages
+===
+| Name                                              | Description                               |
+| ------------------------------------------------- | ----------------------------------------- |
+| [htmlquery](https://github.com/antchfx/htmlquery) | XPath query package for HTML documents    |
+| [xmlquery](https://github.com/antchfx/xmlquery)   | XPath query package for XML documents     |
+| [jsonquery](https://github.com/antchfx/jsonquery) | XPath query package for JSON documents    |
+
+ Questions
+===
+Please let me know if you have any questions

--- a/vendor/github.com/antchfx/xmlquery/books.xml
+++ b/vendor/github.com/antchfx/xmlquery/books.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" ?>
+<bookstore specialty="novel">
+   <book id="bk101">
+      <author>Gambardella, Matthew</author>
+      <title>XML Developer's Guide</title>
+      <genre>Computer</genre>
+      <price>44.95</price>
+      <publish_date>2000-10-01</publish_date>
+      <description>An in-depth look at creating applications 
+      with XML.</description>
+   </book>
+   <book id="bk102">
+      <author>Ralls, Kim</author>
+      <title>Midnight Rain</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-12-16</publish_date>
+      <description>A former architect battles corporate zombies, 
+      an evil sorceress, and her own childhood to become queen 
+      of the world.</description>
+   </book>
+   <book id="bk103">
+      <author>Corets, Eva</author>
+      <title>Maeve Ascendant</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-11-17</publish_date>
+      <description>After the collapse of a nanotechnology 
+      society in England, the young survivors lay the 
+      foundation for a new society.</description>
+   </book>
+   <book id="bk104">
+      <author>Corets, Eva</author>
+      <title>Oberon's Legacy</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-03-10</publish_date>
+      <description>In post-apocalypse England, the mysterious 
+      agent known only as Oberon helps to create a new life 
+      for the inhabitants of London. Sequel to Maeve 
+      Ascendant.</description>
+   </book>
+   <book id="bk105">
+      <author>Corets, Eva</author>
+      <title>The Sundered Grail</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-09-10</publish_date>
+      <description>The two daughters of Maeve, half-sisters, 
+      battle one another for control of England. Sequel to 
+      Oberon's Legacy.</description>
+   </book>
+   <book id="bk106">
+      <author>Randall, Cynthia</author>
+      <title>Lover Birds</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-09-02</publish_date>
+      <description>When Carla meets Paul at an ornithology 
+      conference, tempers fly as feathers get ruffled.</description>
+   </book>
+   <book id="bk107">
+      <author>Thurman, Paula</author>
+      <title>Splish Splash</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>A deep sea diver finds true love twenty 
+      thousand leagues beneath the sea.</description>
+   </book>
+   <book id="bk108">
+      <author>Knorr, Stefan</author>
+      <title>Creepy Crawlies</title>
+      <genre>Horror</genre>
+      <price>4.95</price>
+      <publish_date>2000-12-06</publish_date>
+      <description>An anthology of horror stories about roaches,
+      centipedes, scorpions  and other insects.</description>
+   </book>
+   <book id="bk109">
+      <author>Kress, Peter</author>
+      <title>Paradox Lost</title>
+      <genre>Science Fiction</genre>
+      <price>6.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>After an inadvertant trip through a Heisenberg
+      Uncertainty Device, James Salway discovers the problems 
+      of being quantum.</description>
+   </book>
+   <book id="bk110">
+      <author>O'Brien, Tim</author>
+      <title>Microsoft .NET: The Programming Bible</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-09</publish_date>
+      <description>Microsoft's .NET initiative is explored in 
+      detail in this deep programmer's reference.</description>
+   </book>
+   <book id="bk111">
+      <author>O'Brien, Tim</author>
+      <title>MSXML3: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-01</publish_date>
+      <description>The Microsoft MSXML3 parser is covered in 
+      detail, with attention to XML DOM interfaces, XSLT processing, 
+      SAX and more.</description>
+   </book>
+   <book id="bk112">
+      <author>Galos, Mike</author>
+      <title>Visual Studio 7: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>49.95</price>
+      <publish_date>2001-04-16</publish_date>
+      <description>Microsoft Visual Studio 7 is explored in depth,
+      looking at how Visual Basic, Visual C++, C#, and ASP+ are 
+      integrated into a comprehensive development 
+      environment.</description>
+   </book>
+</bookstore>

--- a/vendor/github.com/antchfx/xmlquery/cache.go
+++ b/vendor/github.com/antchfx/xmlquery/cache.go
@@ -1,0 +1,43 @@
+package xmlquery
+
+import (
+	"sync"
+
+	"github.com/golang/groupcache/lru"
+
+	"github.com/antchfx/xpath"
+)
+
+// DisableSelectorCache will disable caching for the query selector if value is true.
+var DisableSelectorCache = false
+
+// SelectorCacheMaxEntries allows how many selector object can be caching. Default is 50.
+// Will disable caching if SelectorCacheMaxEntries <= 0.
+var SelectorCacheMaxEntries = 50
+
+var (
+	cacheOnce  sync.Once
+	cache      *lru.Cache
+	cacheMutex sync.Mutex
+)
+
+func getQuery(expr string) (*xpath.Expr, error) {
+	if DisableSelectorCache || SelectorCacheMaxEntries <= 0 {
+		return xpath.Compile(expr)
+	}
+	cacheOnce.Do(func() {
+		cache = lru.New(SelectorCacheMaxEntries)
+	})
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
+	if v, ok := cache.Get(expr); ok {
+		return v.(*xpath.Expr), nil
+	}
+	v, err := xpath.Compile(expr)
+	if err != nil {
+		return nil, err
+	}
+	cache.Add(expr, v)
+	return v, nil
+
+}

--- a/vendor/github.com/antchfx/xmlquery/cached_reader.go
+++ b/vendor/github.com/antchfx/xmlquery/cached_reader.go
@@ -1,0 +1,69 @@
+package xmlquery
+
+import (
+	"bufio"
+)
+
+type cachedReader struct {
+	buffer *bufio.Reader
+	cache []byte
+	cacheCap int
+	cacheLen int
+	caching bool
+}
+
+func newCachedReader(r *bufio.Reader) *cachedReader {
+	return &cachedReader{
+		buffer:   r,
+		cache:    make([]byte, 4096),
+		cacheCap: 4096,
+		cacheLen: 0,
+		caching:  false,
+	}
+}
+
+func (c *cachedReader) StartCaching() {
+	c.cacheLen = 0
+	c.caching = true
+}
+
+func (c *cachedReader) ReadByte() (byte, error) {
+	if !c.caching {
+		return c.buffer.ReadByte()
+	}
+	b, err := c.buffer.ReadByte()
+	if err != nil {
+		return b, err
+	}
+	if c.cacheLen < c.cacheCap {
+		c.cache[c.cacheLen] = b
+		c.cacheLen++
+	}
+	return b, err
+}
+
+func (c *cachedReader) Cache() []byte {
+	return c.cache[:c.cacheLen]
+}
+
+func (c *cachedReader) StopCaching() {
+	c.caching = false
+}
+
+func (c *cachedReader) Read(p []byte) (int, error) {
+	n, err := c.buffer.Read(p)
+	if err != nil {
+		return n, err
+	}
+	if c.caching && c.cacheLen < c.cacheCap {
+		for i := 0; i < n; i++ {
+			c.cache[c.cacheLen] = p[i]
+			c.cacheLen++
+			if c.cacheLen >= c.cacheCap {
+				break
+			}
+		}
+	}
+	return n, err
+}
+

--- a/vendor/github.com/antchfx/xmlquery/go.mod
+++ b/vendor/github.com/antchfx/xmlquery/go.mod
@@ -1,0 +1,9 @@
+module github.com/antchfx/xmlquery
+
+go 1.14
+
+require (
+	github.com/antchfx/xpath v1.1.10
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
+	golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc
+)

--- a/vendor/github.com/antchfx/xmlquery/go.sum
+++ b/vendor/github.com/antchfx/xmlquery/go.sum
@@ -1,0 +1,14 @@
+github.com/antchfx/xpath v1.1.10 h1:cJ0pOvEdN/WvYXxvRrzQH9x5QWKpzHacYO8qzCcDYAg=
+github.com/antchfx/xpath v1.1.10/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc h1:zK/HqS5bZxDptfPJNq8v7vJfXtkU7r9TLIoSr1bXaP4=
+golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/vendor/github.com/antchfx/xmlquery/node.go
+++ b/vendor/github.com/antchfx/xmlquery/node.go
@@ -1,0 +1,232 @@
+package xmlquery
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+// A NodeType is the type of a Node.
+type NodeType uint
+
+const (
+	// DocumentNode is a document object that, as the root of the document tree,
+	// provides access to the entire XML document.
+	DocumentNode NodeType = iota
+	// DeclarationNode is the document type declaration, indicated by the
+	// following tag (for example, <!DOCTYPE...> ).
+	DeclarationNode
+	// ElementNode is an element (for example, <item> ).
+	ElementNode
+	// TextNode is the text content of a node.
+	TextNode
+	// CharDataNode node <![CDATA[content]]>
+	CharDataNode
+	// CommentNode a comment (for example, <!-- my comment --> ).
+	CommentNode
+	// AttributeNode is an attribute of element.
+	AttributeNode
+)
+
+type Attr struct {
+	Name         xml.Name
+	Value        string
+	NamespaceURI string
+}
+
+// A Node consists of a NodeType and some Data (tag name for
+// element nodes, content for text) and are part of a tree of Nodes.
+type Node struct {
+	Parent, FirstChild, LastChild, PrevSibling, NextSibling *Node
+
+	Type         NodeType
+	Data         string
+	Prefix       string
+	NamespaceURI string
+	Attr         []Attr
+
+	level int // node level in the tree
+}
+
+// InnerText returns the text between the start and end tags of the object.
+func (n *Node) InnerText() string {
+	var output func(*bytes.Buffer, *Node)
+	output = func(buf *bytes.Buffer, n *Node) {
+		switch n.Type {
+		case TextNode, CharDataNode:
+			buf.WriteString(n.Data)
+		case CommentNode:
+		default:
+			for child := n.FirstChild; child != nil; child = child.NextSibling {
+				output(buf, child)
+			}
+		}
+	}
+
+	var buf bytes.Buffer
+	output(&buf, n)
+	return buf.String()
+}
+
+func (n *Node) sanitizedData(preserveSpaces bool) string {
+	if preserveSpaces {
+		return strings.Trim(n.Data, "\n\t")
+	}
+	return strings.TrimSpace(n.Data)
+}
+
+func calculatePreserveSpaces(n *Node, pastValue bool) bool {
+	if attr := n.SelectAttr("xml:space"); attr == "preserve" {
+		return true
+	} else if attr == "default" {
+		return false
+	}
+	return pastValue
+}
+
+func outputXML(buf *bytes.Buffer, n *Node, preserveSpaces bool) {
+	preserveSpaces = calculatePreserveSpaces(n, preserveSpaces)
+	switch n.Type {
+	case TextNode:
+		xml.EscapeText(buf, []byte(n.sanitizedData(preserveSpaces)))
+		return
+	case CharDataNode:
+		buf.WriteString("<![CDATA[")
+		buf.WriteString(n.Data)
+		buf.WriteString("]]>")
+		return
+	case CommentNode:
+		buf.WriteString("<!--")
+		buf.WriteString(n.Data)
+		buf.WriteString("-->")
+		return
+	case DeclarationNode:
+		buf.WriteString("<?" + n.Data)
+	default:
+		if n.Prefix == "" {
+			buf.WriteString("<" + n.Data)
+		} else {
+			buf.WriteString("<" + n.Prefix + ":" + n.Data)
+		}
+	}
+
+	for _, attr := range n.Attr {
+		if attr.Name.Space != "" {
+			buf.WriteString(fmt.Sprintf(` %s:%s=`, attr.Name.Space, attr.Name.Local))
+		} else {
+			buf.WriteString(fmt.Sprintf(` %s=`, attr.Name.Local))
+		}
+		buf.WriteByte('"')
+		xml.EscapeText(buf, []byte(attr.Value))
+		buf.WriteByte('"')
+	}
+	if n.Type == DeclarationNode {
+		buf.WriteString("?>")
+	} else {
+		buf.WriteString(">")
+	}
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		outputXML(buf, child, preserveSpaces)
+	}
+	if n.Type != DeclarationNode {
+		if n.Prefix == "" {
+			buf.WriteString(fmt.Sprintf("</%s>", n.Data))
+		} else {
+			buf.WriteString(fmt.Sprintf("</%s:%s>", n.Prefix, n.Data))
+		}
+	}
+}
+
+// OutputXML returns the text that including tags name.
+func (n *Node) OutputXML(self bool) string {
+	var buf bytes.Buffer
+	if self {
+		outputXML(&buf, n, false)
+	} else {
+		for n := n.FirstChild; n != nil; n = n.NextSibling {
+			outputXML(&buf, n, false)
+		}
+	}
+
+	return buf.String()
+}
+
+// AddAttr adds a new attribute specified by 'key' and 'val' to a node 'n'.
+func AddAttr(n *Node, key, val string) {
+	var attr Attr
+	if i := strings.Index(key, ":"); i > 0 {
+		attr = Attr{
+			Name:  xml.Name{Space: key[:i], Local: key[i+1:]},
+			Value: val,
+		}
+	} else {
+		attr = Attr{
+			Name:  xml.Name{Local: key},
+			Value: val,
+		}
+	}
+
+	n.Attr = append(n.Attr, attr)
+}
+
+// AddChild adds a new node 'n' to a node 'parent' as its last child.
+func AddChild(parent, n *Node) {
+	n.Parent = parent
+	n.NextSibling = nil
+	if parent.FirstChild == nil {
+		parent.FirstChild = n
+		n.PrevSibling = nil
+	} else {
+		parent.LastChild.NextSibling = n
+		n.PrevSibling = parent.LastChild
+	}
+
+	parent.LastChild = n
+}
+
+// AddSibling adds a new node 'n' as a sibling of a given node 'sibling'.
+// Note it is not necessarily true that the new node 'n' would be added
+// immediately after 'sibling'. If 'sibling' isn't the last child of its
+// parent, then the new node 'n' will be added at the end of the sibling
+// chain of their parent.
+func AddSibling(sibling, n *Node) {
+	for t := sibling.NextSibling; t != nil; t = t.NextSibling {
+		sibling = t
+	}
+	n.Parent = sibling.Parent
+	sibling.NextSibling = n
+	n.PrevSibling = sibling
+	n.NextSibling = nil
+	if sibling.Parent != nil {
+		sibling.Parent.LastChild = n
+	}
+}
+
+// RemoveFromTree removes a node and its subtree from the document
+// tree it is in. If the node is the root of the tree, then it's no-op.
+func RemoveFromTree(n *Node) {
+	if n.Parent == nil {
+		return
+	}
+	if n.Parent.FirstChild == n {
+		if n.Parent.LastChild == n {
+			n.Parent.FirstChild = nil
+			n.Parent.LastChild = nil
+		} else {
+			n.Parent.FirstChild = n.NextSibling
+			n.NextSibling.PrevSibling = nil
+		}
+	} else {
+		if n.Parent.LastChild == n {
+			n.Parent.LastChild = n.PrevSibling
+			n.PrevSibling.NextSibling = nil
+		} else {
+			n.PrevSibling.NextSibling = n.NextSibling
+			n.NextSibling.PrevSibling = n.PrevSibling
+		}
+	}
+	n.Parent = nil
+	n.PrevSibling = nil
+	n.NextSibling = nil
+}

--- a/vendor/github.com/antchfx/xmlquery/parse.go
+++ b/vendor/github.com/antchfx/xmlquery/parse.go
@@ -1,0 +1,340 @@
+package xmlquery
+
+import (
+	"bufio"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/antchfx/xpath"
+	"golang.org/x/net/html/charset"
+)
+
+var xmlMIMERegex = regexp.MustCompile(`(?i)((application|image|message|model)/((\w|\.|-)+\+?)?|text/)(wb)?xml`)
+
+// LoadURL loads the XML document from the specified URL.
+func LoadURL(url string) (*Node, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	// Make sure the Content-Type has a valid XML MIME type
+	if xmlMIMERegex.MatchString(resp.Header.Get("Content-Type")) {
+		return Parse(resp.Body)
+	}
+	return nil, fmt.Errorf("invalid XML document(%s)", resp.Header.Get("Content-Type"))
+}
+
+// Parse returns the parse tree for the XML from the given Reader.
+func Parse(r io.Reader) (*Node, error) {
+	p := createParser(r)
+	for {
+		_, err := p.parse()
+		if err == io.EOF {
+			return p.doc, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+type parser struct {
+	decoder             *xml.Decoder
+	doc                 *Node
+	space2prefix        map[string]string
+	level               int
+	prev                *Node
+	streamElementXPath  *xpath.Expr   // Under streaming mode, this specifies the xpath to the target element node(s).
+	streamElementFilter *xpath.Expr   // If specified, it provides further filtering on the target element.
+	streamNode          *Node         // Need to remember the last target node So we can clean it up upon next Read() call.
+	streamNodePrev      *Node         // Need to remember target node's prev so upon target node removal, we can restore correct prev.
+	reader              *cachedReader // Need to maintain a reference to the reader, so we can determine whether a node contains CDATA.
+}
+
+func createParser(r io.Reader) *parser {
+	reader := newCachedReader(bufio.NewReader(r))
+	p := &parser{
+		decoder:      xml.NewDecoder(reader),
+		doc:          &Node{Type: DocumentNode},
+		space2prefix: make(map[string]string),
+		level:        0,
+		reader:       reader,
+	}
+	// http://www.w3.org/XML/1998/namespace is bound by definition to the prefix xml.
+	p.space2prefix["http://www.w3.org/XML/1998/namespace"] = "xml"
+	p.decoder.CharsetReader = charset.NewReaderLabel
+	p.prev = p.doc
+	return p
+}
+
+func (p *parser) parse() (*Node, error) {
+	var streamElementNodeCounter int
+
+	for {
+		tok, err := p.decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		switch tok := tok.(type) {
+		case xml.StartElement:
+			if p.level == 0 {
+				// mising XML declaration
+				node := &Node{Type: DeclarationNode, Data: "xml", level: 1}
+				AddChild(p.prev, node)
+				p.level = 1
+				p.prev = node
+			}
+			// https://www.w3.org/TR/xml-names/#scoping-defaulting
+			for _, att := range tok.Attr {
+				if att.Name.Local == "xmlns" {
+					p.space2prefix[att.Value] = ""
+				} else if att.Name.Space == "xmlns" {
+					p.space2prefix[att.Value] = att.Name.Local
+				}
+			}
+
+			if tok.Name.Space != "" {
+				if _, found := p.space2prefix[tok.Name.Space]; !found {
+					return nil, errors.New("xmlquery: invalid XML document, namespace is missing")
+				}
+			}
+
+			attributes := make([]Attr, len(tok.Attr))
+			for i, att := range tok.Attr {
+				name := att.Name
+				if prefix, ok := p.space2prefix[name.Space]; ok {
+					name.Space = prefix
+				}
+				attributes[i] = Attr{
+					Name:         name,
+					Value:        att.Value,
+					NamespaceURI: att.Name.Space,
+				}
+			}
+
+			node := &Node{
+				Type:         ElementNode,
+				Data:         tok.Name.Local,
+				Prefix:       p.space2prefix[tok.Name.Space],
+				NamespaceURI: tok.Name.Space,
+				Attr:         attributes,
+				level:        p.level,
+			}
+
+			if p.level == p.prev.level {
+				AddSibling(p.prev, node)
+			} else if p.level > p.prev.level {
+				AddChild(p.prev, node)
+			} else if p.level < p.prev.level {
+				for i := p.prev.level - p.level; i > 1; i-- {
+					p.prev = p.prev.Parent
+				}
+				AddSibling(p.prev.Parent, node)
+			}
+			// If we're in the streaming mode, we need to remember the node if it is the target node
+			// so that when we finish processing the node's EndElement, we know how/what to return to
+			// caller. Also we need to remove the target node from the tree upon next Read() call so
+			// memory doesn't grow unbounded.
+			if p.streamElementXPath != nil {
+				if p.streamNode == nil {
+					if QuerySelector(p.doc, p.streamElementXPath) != nil {
+						p.streamNode = node
+						p.streamNodePrev = p.prev
+						streamElementNodeCounter = 1
+					}
+				} else {
+					streamElementNodeCounter++
+				}
+			}
+			p.prev = node
+			p.level++
+			p.reader.StartCaching()
+		case xml.EndElement:
+			p.level--
+			// If we're in streaming mode, and we already have a potential streaming
+			// target node identified (p.streamNode != nil) then we need to check if
+			// this is the real one we want to return to caller.
+			if p.streamNode != nil {
+				streamElementNodeCounter--
+				if streamElementNodeCounter == 0 {
+					// Now we know this element node is the at least passing the initial
+					// p.streamElementXPath check and is a potential target node candidate.
+					// We need to have 1 more check with p.streamElementFilter (if given) to
+					// ensure it is really the element node we want.
+					// The reason we need a two-step check process is because the following
+					// situation:
+					//   <AAA><BBB>b1</BBB></AAA>
+					// And say the p.streamElementXPath = "/AAA/BBB[. != 'b1']". Now during
+					// xml.StartElement time, the <BBB> node is still empty, so it will pass
+					// the p.streamElementXPath check. However, eventually we know this <BBB>
+					// shouldn't be returned to the caller. Having a second more fine-grained
+					// filter check ensures that. So in this case, the caller should really
+					// setup the stream parser with:
+					//   streamElementXPath = "/AAA/BBB["
+					//   streamElementFilter = "/AAA/BBB[. != 'b1']"
+					if p.streamElementFilter == nil || QuerySelector(p.doc, p.streamElementFilter) != nil {
+						return p.streamNode, nil
+					}
+					// otherwise, this isn't our target node, clean things up.
+					// note we also remove the underlying *Node from the node tree, to prevent
+					// future stream node candidate selection error.
+					RemoveFromTree(p.streamNode)
+					p.prev = p.streamNodePrev
+					p.streamNode = nil
+					p.streamNodePrev = nil
+				}
+			}
+		case xml.CharData:
+			p.reader.StopCaching()
+			// First, normalize the cache...
+			cached := strings.ToUpper(string(p.reader.Cache()))
+			nodeType := TextNode
+			if strings.HasPrefix(cached, "<![CDATA[") {
+				nodeType = CharDataNode
+			}
+
+			node := &Node{Type: nodeType, Data: string(tok), level: p.level}
+			if p.level == p.prev.level {
+				AddSibling(p.prev, node)
+			} else if p.level > p.prev.level {
+				AddChild(p.prev, node)
+			} else if p.level < p.prev.level {
+				for i := p.prev.level - p.level; i > 1; i-- {
+					p.prev = p.prev.Parent
+				}
+				AddSibling(p.prev.Parent, node)
+			}
+			p.reader.StartCaching()
+		case xml.Comment:
+			node := &Node{Type: CommentNode, Data: string(tok), level: p.level}
+			if p.level == p.prev.level {
+				AddSibling(p.prev, node)
+			} else if p.level > p.prev.level {
+				AddChild(p.prev, node)
+			} else if p.level < p.prev.level {
+				for i := p.prev.level - p.level; i > 1; i-- {
+					p.prev = p.prev.Parent
+				}
+				AddSibling(p.prev.Parent, node)
+			}
+		case xml.ProcInst: // Processing Instruction
+			if p.prev.Type != DeclarationNode {
+				p.level++
+			}
+			node := &Node{Type: DeclarationNode, Data: tok.Target, level: p.level}
+			pairs := strings.Split(string(tok.Inst), " ")
+			for _, pair := range pairs {
+				pair = strings.TrimSpace(pair)
+				if i := strings.Index(pair, "="); i > 0 {
+					AddAttr(node, pair[:i], strings.Trim(pair[i+1:], `"`))
+				}
+			}
+			if p.level == p.prev.level {
+				AddSibling(p.prev, node)
+			} else if p.level > p.prev.level {
+				AddChild(p.prev, node)
+			}
+			p.prev = node
+		case xml.Directive:
+		}
+	}
+}
+
+// StreamParser enables loading and parsing an XML document in a streaming
+// fashion.
+type StreamParser struct {
+	p *parser
+}
+
+// CreateStreamParser creates a StreamParser. Argument streamElementXPath is
+// required.
+// Argument streamElementFilter is optional and should only be used in advanced
+// scenarios.
+//
+// Scenario 1: simple case:
+//  xml := `<AAA><BBB>b1</BBB><BBB>b2</BBB></AAA>`
+//  sp, err := CreateStreamParser(strings.NewReader(xml), "/AAA/BBB")
+//  if err != nil {
+//      panic(err)
+//  }
+//  for {
+//      n, err := sp.Read()
+//      if err != nil {
+//          break
+//      }
+//      fmt.Println(n.OutputXML(true))
+//  }
+// Output will be:
+//   <BBB>b1</BBB>
+//   <BBB>b2</BBB>
+//
+// Scenario 2: advanced case:
+//  xml := `<AAA><BBB>b1</BBB><BBB>b2</BBB></AAA>`
+//  sp, err := CreateStreamParser(strings.NewReader(xml), "/AAA/BBB", "/AAA/BBB[. != 'b1']")
+//  if err != nil {
+//      panic(err)
+//  }
+//  for {
+//      n, err := sp.Read()
+//      if err != nil {
+//          break
+//      }
+//      fmt.Println(n.OutputXML(true))
+//  }
+// Output will be:
+//   <BBB>b2</BBB>
+//
+// As the argument names indicate, streamElementXPath should be used for
+// providing xpath query pointing to the target element node only, no extra
+// filtering on the element itself or its children; while streamElementFilter,
+// if needed, can provide additional filtering on the target element and its
+// children.
+//
+// CreateStreamParser returns an error if either streamElementXPath or
+// streamElementFilter, if provided, cannot be successfully parsed and compiled
+// into a valid xpath query.
+func CreateStreamParser(r io.Reader, streamElementXPath string, streamElementFilter ...string) (*StreamParser, error) {
+	elemXPath, err := getQuery(streamElementXPath)
+	if err != nil {
+		return nil, fmt.Errorf("invalid streamElementXPath '%s', err: %s", streamElementXPath, err.Error())
+	}
+	elemFilter := (*xpath.Expr)(nil)
+	if len(streamElementFilter) > 0 {
+		elemFilter, err = getQuery(streamElementFilter[0])
+		if err != nil {
+			return nil, fmt.Errorf("invalid streamElementFilter '%s', err: %s", streamElementFilter[0], err.Error())
+		}
+	}
+	sp := &StreamParser{
+		p: createParser(r),
+	}
+	sp.p.streamElementXPath = elemXPath
+	sp.p.streamElementFilter = elemFilter
+	return sp, nil
+}
+
+// Read returns a target node that satisfies the XPath specified by caller at
+// StreamParser creation time. If there is no more satisfying target nodes after
+// reading the rest of the XML document, io.EOF will be returned. At any time,
+// any XML parsing error encountered will be returned, and the stream parsing
+// stopped. Calling Read() after an error is returned (including io.EOF) results
+// undefined behavior. Also note, due to the streaming nature, calling Read()
+// will automatically remove any previous target node(s) from the document tree.
+func (sp *StreamParser) Read() (*Node, error) {
+	// Because this is a streaming read, we need to release/remove last
+	// target node from the node tree to free up memory.
+	if sp.p.streamNode != nil {
+		RemoveFromTree(sp.p.streamNode)
+		sp.p.prev = sp.p.streamNodePrev
+		sp.p.streamNode = nil
+		sp.p.streamNodePrev = nil
+	}
+	return sp.p.parse()
+}

--- a/vendor/github.com/antchfx/xmlquery/query.go
+++ b/vendor/github.com/antchfx/xmlquery/query.go
@@ -1,0 +1,309 @@
+/*
+Package xmlquery provides extract data from XML documents using XPath expression.
+*/
+package xmlquery
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/antchfx/xpath"
+)
+
+// SelectElements finds child elements with the specified name.
+func (n *Node) SelectElements(name string) []*Node {
+	return Find(n, name)
+}
+
+// SelectElement finds child elements with the specified name.
+func (n *Node) SelectElement(name string) *Node {
+	return FindOne(n, name)
+}
+
+// SelectAttr returns the attribute value with the specified name.
+func (n *Node) SelectAttr(name string) string {
+	if n.Type == AttributeNode {
+		if n.Data == name {
+			return n.InnerText()
+		}
+		return ""
+	}
+	var local, space string
+	local = name
+	if i := strings.Index(name, ":"); i > 0 {
+		space = name[:i]
+		local = name[i+1:]
+	}
+	for _, attr := range n.Attr {
+		if attr.Name.Local == local && attr.Name.Space == space {
+			return attr.Value
+		}
+	}
+	return ""
+}
+
+var _ xpath.NodeNavigator = &NodeNavigator{}
+
+// CreateXPathNavigator creates a new xpath.NodeNavigator for the specified
+// XML Node.
+func CreateXPathNavigator(top *Node) *NodeNavigator {
+	return &NodeNavigator{curr: top, root: top, attr: -1}
+}
+
+func getCurrentNode(it *xpath.NodeIterator) *Node {
+	n := it.Current().(*NodeNavigator)
+	if n.NodeType() == xpath.AttributeNode {
+		childNode := &Node{
+			Type: TextNode,
+			Data: n.Value(),
+		}
+		return &Node{
+			Parent:     n.curr,
+			Type:       AttributeNode,
+			Data:       n.LocalName(),
+			FirstChild: childNode,
+			LastChild:  childNode,
+		}
+	}
+	return n.curr
+}
+
+// Find is like QueryAll but panics if `expr` is not a valid XPath expression.
+// See `QueryAll()` function.
+func Find(top *Node, expr string) []*Node {
+	nodes, err := QueryAll(top, expr)
+	if err != nil {
+		panic(err)
+	}
+	return nodes
+}
+
+// FindOne is like Query but panics if `expr` is not a valid XPath expression.
+// See `Query()` function.
+func FindOne(top *Node, expr string) *Node {
+	node, err := Query(top, expr)
+	if err != nil {
+		panic(err)
+	}
+	return node
+}
+
+// QueryAll searches the XML Node that matches by the specified XPath expr.
+// Returns an error if the expression `expr` cannot be parsed.
+func QueryAll(top *Node, expr string) ([]*Node, error) {
+	exp, err := getQuery(expr)
+	if err != nil {
+		return nil, err
+	}
+	return QuerySelectorAll(top, exp), nil
+}
+
+// Query searches the XML Node that matches by the specified XPath expr,
+// and returns first matched element.
+func Query(top *Node, expr string) (*Node, error) {
+	exp, err := getQuery(expr)
+	if err != nil {
+		return nil, err
+	}
+	return QuerySelector(top, exp), nil
+}
+
+// QuerySelectorAll searches all of the XML Node that matches the specified
+// XPath selectors.
+func QuerySelectorAll(top *Node, selector *xpath.Expr) []*Node {
+	t := selector.Select(CreateXPathNavigator(top))
+	var elems []*Node
+	for t.MoveNext() {
+		elems = append(elems, getCurrentNode(t))
+	}
+	return elems
+}
+
+// QuerySelector returns the first matched XML Node by the specified XPath
+// selector.
+func QuerySelector(top *Node, selector *xpath.Expr) *Node {
+	t := selector.Select(CreateXPathNavigator(top))
+	if t.MoveNext() {
+		return getCurrentNode(t)
+	}
+	return nil
+}
+
+// FindEach searches the html.Node and calls functions cb.
+// Important: this method is deprecated, instead, use for .. = range Find(){}.
+func FindEach(top *Node, expr string, cb func(int, *Node)) {
+	for i, n := range Find(top, expr) {
+		cb(i, n)
+	}
+}
+
+// FindEachWithBreak functions the same as FindEach but allows to break the loop
+// by returning false from the callback function `cb`.
+// Important: this method is deprecated, instead, use .. = range Find(){}.
+func FindEachWithBreak(top *Node, expr string, cb func(int, *Node) bool) {
+	for i, n := range Find(top, expr) {
+		if !cb(i, n) {
+			break
+		}
+	}
+}
+
+type NodeNavigator struct {
+	root, curr *Node
+	attr       int
+}
+
+func (x *NodeNavigator) Current() *Node {
+	return x.curr
+}
+
+func (x *NodeNavigator) NodeType() xpath.NodeType {
+	switch x.curr.Type {
+	case CommentNode:
+		return xpath.CommentNode
+	case TextNode, CharDataNode:
+		return xpath.TextNode
+	case DeclarationNode, DocumentNode:
+		return xpath.RootNode
+	case ElementNode:
+		if x.attr != -1 {
+			return xpath.AttributeNode
+		}
+		return xpath.ElementNode
+	}
+	panic(fmt.Sprintf("unknown XML node type: %v", x.curr.Type))
+}
+
+func (x *NodeNavigator) LocalName() string {
+	if x.attr != -1 {
+		return x.curr.Attr[x.attr].Name.Local
+	}
+	return x.curr.Data
+
+}
+
+func (x *NodeNavigator) Prefix() string {
+	if x.NodeType() == xpath.AttributeNode {
+		if x.attr != -1 {
+			return x.curr.Attr[x.attr].Name.Space
+		}
+		return ""
+	}
+	return x.curr.Prefix
+}
+
+func (x *NodeNavigator) NamespaceURL() string {
+	if x.attr != -1 {
+		return x.curr.Attr[x.attr].NamespaceURI
+	}
+	return x.curr.NamespaceURI
+}
+
+func (x *NodeNavigator) Value() string {
+	switch x.curr.Type {
+	case CommentNode:
+		return x.curr.Data
+	case ElementNode:
+		if x.attr != -1 {
+			return x.curr.Attr[x.attr].Value
+		}
+		return x.curr.InnerText()
+	case TextNode:
+		return x.curr.Data
+	}
+	return ""
+}
+
+func (x *NodeNavigator) Copy() xpath.NodeNavigator {
+	n := *x
+	return &n
+}
+
+func (x *NodeNavigator) MoveToRoot() {
+	x.curr = x.root
+}
+
+func (x *NodeNavigator) MoveToParent() bool {
+	if x.attr != -1 {
+		x.attr = -1
+		return true
+	} else if node := x.curr.Parent; node != nil {
+		x.curr = node
+		return true
+	}
+	return false
+}
+
+func (x *NodeNavigator) MoveToNextAttribute() bool {
+	if x.attr >= len(x.curr.Attr)-1 {
+		return false
+	}
+	x.attr++
+	return true
+}
+
+func (x *NodeNavigator) MoveToChild() bool {
+	if x.attr != -1 {
+		return false
+	}
+	if node := x.curr.FirstChild; node != nil {
+		x.curr = node
+		return true
+	}
+	return false
+}
+
+func (x *NodeNavigator) MoveToFirst() bool {
+	if x.attr != -1 || x.curr.PrevSibling == nil {
+		return false
+	}
+	for {
+		node := x.curr.PrevSibling
+		if node == nil {
+			break
+		}
+		x.curr = node
+	}
+	return true
+}
+
+func (x *NodeNavigator) String() string {
+	return x.Value()
+}
+
+func (x *NodeNavigator) MoveToNext() bool {
+	if x.attr != -1 {
+		return false
+	}
+	for node := x.curr.NextSibling; node != nil; node = x.curr.NextSibling {
+		x.curr = node
+		if x.curr.Type != TextNode {
+			return true
+		}
+	}
+	return false
+}
+
+func (x *NodeNavigator) MoveToPrevious() bool {
+	if x.attr != -1 {
+		return false
+	}
+	for node := x.curr.PrevSibling; node != nil; node = x.curr.PrevSibling {
+		x.curr = node
+		if x.curr.Type != TextNode {
+			return true
+		}
+	}
+	return false
+}
+
+func (x *NodeNavigator) MoveTo(other xpath.NodeNavigator) bool {
+	node, ok := other.(*NodeNavigator)
+	if !ok || node.root != x.root {
+		return false
+	}
+
+	x.curr = node.curr
+	x.attr = node.attr
+	return true
+}

--- a/vendor/github.com/antchfx/xpath/.travis.yml
+++ b/vendor/github.com/antchfx/xpath/.travis.yml
@@ -2,8 +2,8 @@ language: go
 
 go:
   - 1.6
-  - 1.7
-  - 1.8
+  - 1.9
+  - '1.10'
 
 install:
   - go get github.com/mattn/goveralls

--- a/vendor/github.com/antchfx/xpath/README.md
+++ b/vendor/github.com/antchfx/xpath/README.md
@@ -1,17 +1,23 @@
-xpath
+XPath
 ====
 [![GoDoc](https://godoc.org/github.com/antchfx/xpath?status.svg)](https://godoc.org/github.com/antchfx/xpath)
 [![Coverage Status](https://coveralls.io/repos/github/antchfx/xpath/badge.svg?branch=master)](https://coveralls.io/github/antchfx/xpath?branch=master)
 [![Build Status](https://travis-ci.org/antchfx/xpath.svg?branch=master)](https://travis-ci.org/antchfx/xpath)
 [![Go Report Card](https://goreportcard.com/badge/github.com/antchfx/xpath)](https://goreportcard.com/report/github.com/antchfx/xpath)
 
-xpath is XPath package for Golang, support most of XPath features(syntax).
+XPath is Go package provides selecting nodes from XML, HTML or other documents using XPath expression.
 
-xquery
+Implementation
 ===
-[xquery](https://github.com/antchfx/xquery) package lets you extract data from HTML/XML documents using XPath, written in golang.
 
-### Features
+- [htmlquery](https://github.com/antchfx/htmlquery) - an XPath query package for HTML document
+
+- [xmlquery](https://github.com/antchfx/xmlquery) - an XPath query package for XML document.
+
+- [jsonquery](https://github.com/antchfx/jsonquery) - an XPath query package for JSON document
+
+Supported Features
+===
 
 #### The basic XPath patterns.
 
@@ -47,7 +53,10 @@ xquery
 
 - `//b` : Returns elements in the entire document matching b.
 
-- `a|b` : All nodes matching a or b.
+- `a|b` : All nodes matching a or b, union operation(not boolean or).
+
+- `(a, b, c)` : Evaluates each of its operands and concatenates the resulting sequences, in order, into a single result sequence
+
 
 #### Node Axes 
 
@@ -99,22 +108,66 @@ xquery
     * a div b	Divide
     * a mod b	Floating point mod, like Java.
 
+- `a or b` : Boolean `or` operation.
+
+- `a and b` : Boolean `and` operation.
+
 - `(expr)` : Parenthesized expressions.
 
-- `fun(arg1, ..., argn)` : Function calls.
+- `fun(arg1, ..., argn)` : Function calls:
 
-    * position()
-    * last()
-    * count(node-set)
-    * name()
-    * starts-with(string,string)
-    * normalize-space(string)
-    * substring(string,start[,length])
-    * not(expression)
-    * string-length([string])
-    * contains(string,string)
-    * come more
+| Function | Supported |
+| --- | --- |
+`boolean()`| ✓ |
+`ceiling()`| ✓ |
+`choose()`| ✗ |
+`concat()`| ✓ |
+`contains()`| ✓ |
+`count()`| ✓ |
+`current()`| ✗ |
+`document()`| ✗ |
+`element-available()`| ✗ |
+`ends-with()`| ✓ |
+`false()`| ✓ |
+`floor()`| ✓ |
+`format-number()`| ✗ |
+`function-available()`| ✗ |
+`generate-id()`| ✗ |
+`id()`| ✗ |
+`key()`| ✗ |
+`lang()`| ✗ |
+`last()`| ✓ |
+`local-name()`| ✓ |
+`matches()`| ✓ |
+`name()`| ✓ |
+`namespace-uri()`| ✓ |
+`normalize-space()`| ✓ |
+`not()`| ✓ |
+`number()`| ✓ |
+`position()`| ✓ |
+`replace()`| ✓ |
+`reverse()`| ✓ |
+`round()`| ✓ |
+`starts-with()`| ✓ |
+`string()`| ✓ |
+`string-length()`| ✓ |
+`substring()`| ✓ |
+`substring-after()`| ✓ |
+`substring-before()`| ✓ |
+`sum()`| ✓ |
+`system-property()`| ✗ |
+`translate()`| ✓ |
+`true()`| ✓ |
+`unparsed-entity-url()` | ✗ |
 
-- `a or b` : Boolean or.
+Changelogs
+===
 
-- `a and b` : Boolean and.
+2019-03-19 
+- optimize XPath `|` operation performance. [#33](https://github.com/antchfx/xpath/issues/33). Tips: suggest split into multiple subquery if you have a lot of `|` operations.
+
+2019-01-29
+-  improvement `normalize-space` function. [#32](https://github.com/antchfx/xpath/issues/32)
+
+2018-12-07
+-  supports XPath 2.0 Sequence expressions. [#30](https://github.com/antchfx/xpath/pull/30) by [@minherz](https://github.com/minherz).

--- a/vendor/github.com/antchfx/xpath/cache.go
+++ b/vendor/github.com/antchfx/xpath/cache.go
@@ -1,0 +1,80 @@
+package xpath
+
+import (
+	"regexp"
+	"sync"
+)
+
+type loadFunc func(key interface{}) (interface{}, error)
+
+const (
+	defaultCap = 65536
+)
+
+// The reason we're building a simple capacity-resetting loading cache (when capacity reached) instead of using
+// something like github.com/hashicorp/golang-lru is primarily due to (not wanting to create) external dependency.
+// Currently this library has 0 external dep (other than go sdk), and supports go 1.6, 1.9, and 1.10 (and later).
+// Creating external lib dependencies (plus their transitive dependencies) would make things hard if not impossible.
+// We expect under most circumstances, the defaultCap is big enough for any long running services that use this
+// library if their xpath regexp cardinality is low. However, in extreme cases when the capacity is reached, we
+// simply reset the cache, taking a small subsequent perf hit (next to nothing considering amortization) in trade
+// of more complex and less performant LRU type of construct.
+type loadingCache struct {
+	sync.RWMutex
+	cap   int
+	load  loadFunc
+	m     map[interface{}]interface{}
+	reset int
+}
+
+// NewLoadingCache creates a new instance of a loading cache with capacity. Capacity must be >= 0, or
+// it will panic. Capacity == 0 means the cache growth is unbounded.
+func NewLoadingCache(load loadFunc, capacity int) *loadingCache {
+	if capacity < 0 {
+		panic("capacity must be >= 0")
+	}
+	return &loadingCache{cap: capacity, load: load, m: make(map[interface{}]interface{})}
+}
+
+func (c *loadingCache) get(key interface{}) (interface{}, error) {
+	c.RLock()
+	v, found := c.m[key]
+	c.RUnlock()
+	if found {
+		return v, nil
+	}
+	v, err := c.load(key)
+	if err != nil {
+		return nil, err
+	}
+	c.Lock()
+	if c.cap > 0 && len(c.m) >= c.cap {
+		c.m = map[interface{}]interface{}{key: v}
+		c.reset++
+	} else {
+		c.m[key] = v
+	}
+	c.Unlock()
+	return v, nil
+}
+
+var (
+	// RegexpCache is a loading cache for string -> *regexp.Regexp mapping. It is exported so that in rare cases
+	// client can customize load func and/or capacity.
+	RegexpCache = defaultRegexpCache()
+)
+
+func defaultRegexpCache() *loadingCache {
+	return NewLoadingCache(
+		func(key interface{}) (interface{}, error) {
+			return regexp.Compile(key.(string))
+		}, defaultCap)
+}
+
+func getRegexp(pattern string) (*regexp.Regexp, error) {
+	exp, err := RegexpCache.get(pattern)
+	if err != nil {
+		return nil, err
+	}
+	return exp.(*regexp.Regexp), nil
+}

--- a/vendor/github.com/antchfx/xpath/func.go
+++ b/vendor/github.com/antchfx/xpath/func.go
@@ -2,8 +2,27 @@ package xpath
 
 import (
 	"errors"
+	"fmt"
+	"math"
+	"strconv"
 	"strings"
+	"sync"
+	"unicode"
 )
+
+// Defined an interface of stringBuilder that compatible with
+// strings.Builder(go 1.10) and bytes.Buffer(< go 1.10)
+type stringBuilder interface {
+	WriteRune(r rune) (n int, err error)
+	WriteString(s string) (int, error)
+	Reset()
+	Grow(n int)
+	String() string
+}
+
+var builderPool = sync.Pool{New: func() interface{} {
+	return newStringBuilder()
+}}
 
 // The XPath function list.
 
@@ -21,7 +40,7 @@ func predicate(q query) func(NodeNavigator) bool {
 func positionFunc(q query, t iterator) interface{} {
 	var (
 		count = 1
-		node  = t.Current()
+		node  = t.Current().Copy()
 	)
 	test := predicate(q)
 	for node.MoveToPrevious() {
@@ -36,7 +55,7 @@ func positionFunc(q query, t iterator) interface{} {
 func lastFunc(q query, t iterator) interface{} {
 	var (
 		count = 0
-		node  = t.Current()
+		node  = t.Current().Copy()
 	)
 	node.MoveToFirst()
 	test := predicate(q)
@@ -53,26 +72,203 @@ func lastFunc(q query, t iterator) interface{} {
 
 // countFunc is a XPath Node Set functions count(node-set).
 func countFunc(q query, t iterator) interface{} {
-	var (
-		count = 0
-		node  = t.Current()
-	)
-	node.MoveToFirst()
+	var count = 0
+	q = functionArgs(q)
 	test := predicate(q)
-	for {
-		if test(node) {
-			count++
-		}
-		if !node.MoveToNext() {
-			break
+	switch typ := q.Evaluate(t).(type) {
+	case query:
+		for node := typ.Select(t); node != nil; node = typ.Select(t) {
+			if test(node) {
+				count++
+			}
 		}
 	}
 	return float64(count)
 }
 
+// sumFunc is a XPath Node Set functions sum(node-set).
+func sumFunc(q query, t iterator) interface{} {
+	var sum float64
+	switch typ := functionArgs(q).Evaluate(t).(type) {
+	case query:
+		for node := typ.Select(t); node != nil; node = typ.Select(t) {
+			if v, err := strconv.ParseFloat(node.Value(), 64); err == nil {
+				sum += v
+			}
+		}
+	case float64:
+		sum = typ
+	case string:
+		v, err := strconv.ParseFloat(typ, 64)
+		if err != nil {
+			panic(errors.New("sum() function argument type must be a node-set or number"))
+		}
+		sum = v
+	}
+	return sum
+}
+
+func asNumber(t iterator, o interface{}) float64 {
+	switch typ := o.(type) {
+	case query:
+		node := typ.Select(t)
+		if node == nil {
+			return float64(0)
+		}
+		if v, err := strconv.ParseFloat(node.Value(), 64); err == nil {
+			return v
+		}
+	case float64:
+		return typ
+	case string:
+		v, err := strconv.ParseFloat(typ, 64)
+		if err != nil {
+			panic(errors.New("ceiling() function argument type must be a node-set or number"))
+		}
+		return v
+	}
+	return 0
+}
+
+// ceilingFunc is a XPath Node Set functions ceiling(node-set).
+func ceilingFunc(q query, t iterator) interface{} {
+	val := asNumber(t, functionArgs(q).Evaluate(t))
+	return math.Ceil(val)
+}
+
+// floorFunc is a XPath Node Set functions floor(node-set).
+func floorFunc(q query, t iterator) interface{} {
+	val := asNumber(t, functionArgs(q).Evaluate(t))
+	return math.Floor(val)
+}
+
+// roundFunc is a XPath Node Set functions round(node-set).
+func roundFunc(q query, t iterator) interface{} {
+	val := asNumber(t, functionArgs(q).Evaluate(t))
+	//return math.Round(val)
+	return round(val)
+}
+
 // nameFunc is a XPath functions name([node-set]).
-func nameFunc(q query, t iterator) interface{} {
-	return t.Current().LocalName()
+func nameFunc(arg query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		var v NodeNavigator
+		if arg == nil {
+			v = t.Current()
+		} else {
+			v = arg.Clone().Select(t)
+			if v == nil {
+				return ""
+			}
+		}
+		ns := v.Prefix()
+		if ns == "" {
+			return v.LocalName()
+		}
+		return ns + ":" + v.LocalName()
+	}
+}
+
+// localNameFunc is a XPath functions local-name([node-set]).
+func localNameFunc(arg query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		var v NodeNavigator
+		if arg == nil {
+			v = t.Current()
+		} else {
+			v = arg.Clone().Select(t)
+			if v == nil {
+				return ""
+			}
+		}
+		return v.LocalName()
+	}
+}
+
+// namespaceFunc is a XPath functions namespace-uri([node-set]).
+func namespaceFunc(arg query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		var v NodeNavigator
+		if arg == nil {
+			v = t.Current()
+		} else {
+			// Get the first node in the node-set if specified.
+			v = arg.Clone().Select(t)
+			if v == nil {
+				return ""
+			}
+		}
+		// fix about namespace-uri() bug: https://github.com/antchfx/xmlquery/issues/22
+		// TODO: In the next version, add NamespaceURL() to the NodeNavigator interface.
+		type namespaceURL interface {
+			NamespaceURL() string
+		}
+		if f, ok := v.(namespaceURL); ok {
+			return f.NamespaceURL()
+		}
+		return v.Prefix()
+	}
+}
+
+func asBool(t iterator, v interface{}) bool {
+	switch v := v.(type) {
+	case nil:
+		return false
+	case *NodeIterator:
+		return v.MoveNext()
+	case bool:
+		return v
+	case float64:
+		return v != 0
+	case string:
+		return v != ""
+	case query:
+		return v.Select(t) != nil
+	default:
+		panic(fmt.Errorf("unexpected type: %T", v))
+	}
+}
+
+func asString(t iterator, v interface{}) string {
+	switch v := v.(type) {
+	case nil:
+		return ""
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case float64:
+		return strconv.FormatFloat(v, 'g', -1, 64)
+	case string:
+		return v
+	case query:
+		node := v.Select(t)
+		if node == nil {
+			return ""
+		}
+		return node.Value()
+	default:
+		panic(fmt.Errorf("unexpected type: %T", v))
+	}
+}
+
+// booleanFunc is a XPath functions boolean([node-set]).
+func booleanFunc(q query, t iterator) interface{} {
+	v := functionArgs(q).Evaluate(t)
+	return asBool(t, v)
+}
+
+// numberFunc is a XPath functions number([node-set]).
+func numberFunc(q query, t iterator) interface{} {
+	v := functionArgs(q).Evaluate(t)
+	return asNumber(t, v)
+}
+
+// stringFunc is a XPath functions string([node-set]).
+func stringFunc(q query, t iterator) interface{} {
+	v := functionArgs(q).Evaluate(t)
+	return asString(t, v)
 }
 
 // startwithFunc is a XPath functions starts-with(string, string).
@@ -82,7 +278,7 @@ func startwithFunc(arg1, arg2 query) func(query, iterator) interface{} {
 			m, n string
 			ok   bool
 		)
-		switch typ := arg1.Evaluate(t).(type) {
+		switch typ := functionArgs(arg1).Evaluate(t).(type) {
 		case string:
 			m = typ
 		case query:
@@ -94,11 +290,38 @@ func startwithFunc(arg1, arg2 query) func(query, iterator) interface{} {
 		default:
 			panic(errors.New("starts-with() function argument type must be string"))
 		}
-		n, ok = arg2.Evaluate(t).(string)
+		n, ok = functionArgs(arg2).Evaluate(t).(string)
 		if !ok {
 			panic(errors.New("starts-with() function argument type must be string"))
 		}
 		return strings.HasPrefix(m, n)
+	}
+}
+
+// endwithFunc is a XPath functions ends-with(string, string).
+func endwithFunc(arg1, arg2 query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		var (
+			m, n string
+			ok   bool
+		)
+		switch typ := functionArgs(arg1).Evaluate(t).(type) {
+		case string:
+			m = typ
+		case query:
+			node := typ.Select(t)
+			if node == nil {
+				return false
+			}
+			m = node.Value()
+		default:
+			panic(errors.New("ends-with() function argument type must be string"))
+		}
+		n, ok = functionArgs(arg2).Evaluate(t).(string)
+		if !ok {
+			panic(errors.New("ends-with() function argument type must be string"))
+		}
+		return strings.HasSuffix(m, n)
 	}
 }
 
@@ -109,8 +332,7 @@ func containsFunc(arg1, arg2 query) func(query, iterator) interface{} {
 			m, n string
 			ok   bool
 		)
-
-		switch typ := arg1.Evaluate(t).(type) {
+		switch typ := functionArgs(arg1).Evaluate(t).(type) {
 		case string:
 			m = typ
 		case query:
@@ -123,7 +345,7 @@ func containsFunc(arg1, arg2 query) func(query, iterator) interface{} {
 			panic(errors.New("contains() function argument type must be string"))
 		}
 
-		n, ok = arg2.Evaluate(t).(string)
+		n, ok = functionArgs(arg2).Evaluate(t).(string)
 		if !ok {
 			panic(errors.New("contains() function argument type must be string"))
 		}
@@ -132,33 +354,81 @@ func containsFunc(arg1, arg2 query) func(query, iterator) interface{} {
 	}
 }
 
+// matchesFunc is an XPath function that tests a given string against a regexp pattern.
+// Note: does not support https://www.w3.org/TR/xpath-functions-31/#func-matches 3rd optional `flags` argument; if
+// needed, directly put flags in the regexp pattern, such as `(?i)^pattern$` for `i` flag.
+func matchesFunc(arg1, arg2 query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		var s string
+		switch typ := functionArgs(arg1).Evaluate(t).(type) {
+		case string:
+			s = typ
+		case query:
+			node := typ.Select(t)
+			if node == nil {
+				return ""
+			}
+			s = node.Value()
+		}
+		var pattern string
+		var ok bool
+		if pattern, ok = functionArgs(arg2).Evaluate(t).(string); !ok {
+			panic(errors.New("matches() function second argument type must be string"))
+		}
+		re, err := getRegexp(pattern)
+		if err != nil {
+			panic(fmt.Errorf("matches() function second argument is not a valid regexp pattern, err: %s", err.Error()))
+		}
+		return re.MatchString(s)
+	}
+}
+
 // normalizespaceFunc is XPath functions normalize-space(string?)
 func normalizespaceFunc(q query, t iterator) interface{} {
 	var m string
-	switch typ := q.Evaluate(t).(type) {
+	switch typ := functionArgs(q).Evaluate(t).(type) {
 	case string:
 		m = typ
 	case query:
 		node := typ.Select(t)
 		if node == nil {
-			return false
+			return ""
 		}
 		m = node.Value()
 	}
-	return strings.TrimSpace(m)
+	var b = builderPool.Get().(stringBuilder)
+	b.Grow(len(m))
+
+	runeStr := []rune(strings.TrimSpace(m))
+	l := len(runeStr)
+	for i := range runeStr {
+		r := runeStr[i]
+		isSpace := unicode.IsSpace(r)
+		if !(isSpace && (i+1 < l && unicode.IsSpace(runeStr[i+1]))) {
+			if isSpace {
+				r = ' '
+			}
+			b.WriteRune(r)
+		}
+	}
+	result := b.String()
+	b.Reset()
+	builderPool.Put(b)
+
+	return result
 }
 
 // substringFunc is XPath functions substring function returns a part of a given string.
 func substringFunc(arg1, arg2, arg3 query) func(query, iterator) interface{} {
 	return func(q query, t iterator) interface{} {
 		var m string
-		switch typ := arg1.Evaluate(t).(type) {
+		switch typ := functionArgs(arg1).Evaluate(t).(type) {
 		case string:
 			m = typ
 		case query:
 			node := typ.Select(t)
 			if node == nil {
-				return false
+				return ""
 			}
 			m = node.Value()
 		}
@@ -166,11 +436,14 @@ func substringFunc(arg1, arg2, arg3 query) func(query, iterator) interface{} {
 		var start, length float64
 		var ok bool
 
-		if start, ok = arg2.Evaluate(t).(float64); !ok {
+		if start, ok = functionArgs(arg2).Evaluate(t).(float64); !ok {
 			panic(errors.New("substring() function first argument type must be int"))
+		} else if start < 1 {
+			panic(errors.New("substring() function first argument type must be >= 1"))
 		}
+		start--
 		if arg3 != nil {
-			if length, ok = arg3.Evaluate(t).(float64); !ok {
+			if length, ok = functionArgs(arg3).Evaluate(t).(float64); !ok {
 				panic(errors.New("substring() function second argument type must be int"))
 			}
 		}
@@ -184,11 +457,51 @@ func substringFunc(arg1, arg2, arg3 query) func(query, iterator) interface{} {
 	}
 }
 
+// substringIndFunc is XPath functions substring-before/substring-after function returns a part of a given string.
+func substringIndFunc(arg1, arg2 query, after bool) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		var str string
+		switch v := functionArgs(arg1).Evaluate(t).(type) {
+		case string:
+			str = v
+		case query:
+			node := v.Select(t)
+			if node == nil {
+				return ""
+			}
+			str = node.Value()
+		}
+		var word string
+		switch v := functionArgs(arg2).Evaluate(t).(type) {
+		case string:
+			word = v
+		case query:
+			node := v.Select(t)
+			if node == nil {
+				return ""
+			}
+			word = node.Value()
+		}
+		if word == "" {
+			return ""
+		}
+
+		i := strings.Index(str, word)
+		if i < 0 {
+			return ""
+		}
+		if after {
+			return str[i+len(word):]
+		}
+		return str[:i]
+	}
+}
+
 // stringLengthFunc is XPATH string-length( [string] ) function that returns a number
 // equal to the number of characters in a given string.
 func stringLengthFunc(arg1 query) func(query, iterator) interface{} {
 	return func(q query, t iterator) interface{} {
-		switch v := arg1.Evaluate(t).(type) {
+		switch v := functionArgs(arg1).Evaluate(t).(type) {
 		case string:
 			return float64(len(v))
 		case query:
@@ -202,9 +515,39 @@ func stringLengthFunc(arg1 query) func(query, iterator) interface{} {
 	}
 }
 
+// translateFunc is XPath functions translate() function returns a replaced string.
+func translateFunc(arg1, arg2, arg3 query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		str := asString(t, functionArgs(arg1).Evaluate(t))
+		src := asString(t, functionArgs(arg2).Evaluate(t))
+		dst := asString(t, functionArgs(arg3).Evaluate(t))
+
+		replace := make([]string, 0, len(src))
+		for i, s := range src {
+			d := ""
+			if i < len(dst) {
+				d = string(dst[i])
+			}
+			replace = append(replace, string(s), d)
+		}
+		return strings.NewReplacer(replace...).Replace(str)
+	}
+}
+
+// replaceFunc is XPath functions replace() function returns a replaced string.
+func replaceFunc(arg1, arg2, arg3 query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		str := asString(t, functionArgs(arg1).Evaluate(t))
+		src := asString(t, functionArgs(arg2).Evaluate(t))
+		dst := asString(t, functionArgs(arg3).Evaluate(t))
+
+		return strings.Replace(str, src, dst, -1)
+	}
+}
+
 // notFunc is XPATH functions not(expression) function operation.
 func notFunc(q query, t iterator) interface{} {
-	switch v := q.Evaluate(t).(type) {
+	switch v := functionArgs(q).Evaluate(t).(type) {
 	case bool:
 		return !v
 	case query:
@@ -212,5 +555,60 @@ func notFunc(q query, t iterator) interface{} {
 		return node == nil
 	default:
 		return false
+	}
+}
+
+// concatFunc is the concat function concatenates two or more
+// strings and returns the resulting string.
+// concat( string1 , string2 [, stringn]* )
+func concatFunc(args ...query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		b := builderPool.Get().(stringBuilder)
+		for _, v := range args {
+			v = functionArgs(v)
+
+			switch v := v.Evaluate(t).(type) {
+			case string:
+				b.WriteString(v)
+			case query:
+				node := v.Select(t)
+				if node != nil {
+					b.WriteString(node.Value())
+				}
+			}
+		}
+		result := b.String()
+		b.Reset()
+		builderPool.Put(b)
+
+		return result
+	}
+}
+
+// https://github.com/antchfx/xpath/issues/43
+func functionArgs(q query) query {
+	if _, ok := q.(*functionQuery); ok {
+		return q
+	}
+	return q.Clone()
+}
+
+func reverseFunc(q query, t iterator) func() NodeNavigator {
+	var list []NodeNavigator
+	for {
+		node := q.Select(t)
+		if node == nil {
+			break
+		}
+		list = append(list, node.Copy())
+	}
+	i := len(list)
+	return func() NodeNavigator {
+		if i <= 0 {
+			return nil
+		}
+		i--
+		node := list[i]
+		return node
 	}
 }

--- a/vendor/github.com/antchfx/xpath/func_go110.go
+++ b/vendor/github.com/antchfx/xpath/func_go110.go
@@ -1,0 +1,16 @@
+// +build go1.10
+
+package xpath
+
+import (
+	"math"
+	"strings"
+)
+
+func round(f float64) int {
+	return int(math.Round(f))
+}
+
+func newStringBuilder() stringBuilder{ 
+	return &strings.Builder{}
+}

--- a/vendor/github.com/antchfx/xpath/func_pre_go110.go
+++ b/vendor/github.com/antchfx/xpath/func_pre_go110.go
@@ -1,0 +1,22 @@
+// +build !go1.10
+
+package xpath
+
+import (
+	"bytes"
+	"math"
+)
+
+// math.Round() is supported by Go 1.10+,
+// This method just compatible for version <1.10.
+// https://github.com/golang/go/issues/20100
+func round(f float64) int {
+	if math.Abs(f) < 0.5 {
+		return 0
+	}
+	return int(f + math.Copysign(0.5, f))
+}
+
+func newStringBuilder() stringBuilder {
+	return &bytes.Buffer{}
+}

--- a/vendor/github.com/antchfx/xpath/go.mod
+++ b/vendor/github.com/antchfx/xpath/go.mod
@@ -1,0 +1,3 @@
+module github.com/antchfx/xpath
+
+go 1.14

--- a/vendor/github.com/antchfx/xpath/operator.go
+++ b/vendor/github.com/antchfx/xpath/operator.go
@@ -163,7 +163,17 @@ func cmpNodeSetString(t iterator, op string, m, n interface{}) bool {
 }
 
 func cmpNodeSetNodeSet(t iterator, op string, m, n interface{}) bool {
-	return false
+	a := m.(query)
+	b := n.(query)
+	x := a.Select(t)
+	if x == nil {
+		return false
+	}
+	y := b.Select(t)
+	if y == nil {
+		return false
+	}
+	return cmpStringStringF(op, x.Value(), y.Value())
 }
 
 func cmpStringNumeric(t iterator, op string, m, n interface{}) bool {

--- a/vendor/github.com/antchfx/xpath/parse.go
+++ b/vendor/github.com/antchfx/xpath/parse.go
@@ -42,7 +42,7 @@ const (
 	itemString                     // Quoted string constant
 	itemNumber                     // Number constant
 	itemAxe                        // Axe (like child::)
-	itemEof                        // END
+	itemEOF                        // END
 )
 
 // A node is an XPath node in the parse tree.
@@ -389,7 +389,7 @@ Loop:
 }
 
 // Step	::= AxisSpecifier NodeTest Predicate* | AbbreviatedStep
-func (p *parser) parseStep(n node) node {
+func (p *parser) parseStep(n node) (opnd node) {
 	axeTyp := "child" // default axes value.
 	if p.r.typ == itemDot || p.r.typ == itemDotDot {
 		if p.r.typ == itemDot {
@@ -398,20 +398,42 @@ func (p *parser) parseStep(n node) node {
 			axeTyp = "parent"
 		}
 		p.next()
-		return newAxisNode(axeTyp, "", "", "", n)
+		opnd = newAxisNode(axeTyp, "", "", "", n)
+		if p.r.typ != itemLBracket {
+			return opnd
+		}
+	} else {
+		switch p.r.typ {
+		case itemAt:
+			p.next()
+			axeTyp = "attribute"
+		case itemAxe:
+			axeTyp = p.r.name
+			p.next()
+		case itemLParens:
+			return p.parseSequence(n)
+		}
+		opnd = p.parseNodeTest(n, axeTyp)
 	}
-	switch p.r.typ {
-	case itemAt:
-		p.next()
-		axeTyp = "attribute"
-	case itemAxe:
-		axeTyp = p.r.name
-		p.next()
-	}
-	opnd := p.parseNodeTest(n, axeTyp)
-	if p.r.typ == itemLBracket {
+	for p.r.typ == itemLBracket {
 		opnd = newFilterNode(opnd, p.parsePredicate(opnd))
 	}
+	return opnd
+}
+
+// Expr ::= '(' Step ("," Step)* ')'
+func (p *parser) parseSequence(n node) (opnd node) {
+	p.skipItem(itemLParens)
+	opnd = p.parseStep(n)
+	for {
+		if p.r.typ != itemComma {
+			break
+		}
+		p.next()
+		opnd2 := p.parseStep(n)
+		opnd = newOperatorNode("|", opnd, opnd2)
+	}
+	p.skipItem(itemRParens)
 	return opnd
 }
 
@@ -628,7 +650,7 @@ func (s *scanner) nextChar() bool {
 		return false
 	}
 	s.curr = rune(s.text[s.pos])
-	s.pos += 1
+	s.pos++
 	return true
 }
 
@@ -636,7 +658,7 @@ func (s *scanner) nextItem() bool {
 	s.skipSpace()
 	switch s.curr {
 	case 0:
-		s.typ = itemEof
+		s.typ = itemEOF
 		return false
 	case ',', '@', '(', ')', '|', '*', '[', ']', '+', '-', '=', '#', '$':
 		s.typ = asItemType(s.curr)

--- a/vendor/github.com/antchfx/xpath/query.go
+++ b/vendor/github.com/antchfx/xpath/query.go
@@ -1,6 +1,9 @@
 package xpath
 
 import (
+	"bytes"
+	"fmt"
+	"hash/fnv"
 	"reflect"
 )
 
@@ -15,7 +18,20 @@ type query interface {
 
 	// Evaluate evaluates query and returns values of the current query.
 	Evaluate(iterator) interface{}
+
+	Clone() query
 }
+
+// nopQuery is an empty query that always return nil for any query.
+type nopQuery struct {
+	query
+}
+
+func (nopQuery) Select(iterator) NodeNavigator { return nil }
+
+func (nopQuery) Evaluate(iterator) interface{} { return nil }
+
+func (nopQuery) Clone() query { return nopQuery{} }
 
 // contextQuery is returns current node on the iterator object query.
 type contextQuery struct {
@@ -39,6 +55,10 @@ func (c *contextQuery) Evaluate(iterator) interface{} {
 	return c
 }
 
+func (c *contextQuery) Clone() query {
+	return &contextQuery{count: 0, Root: c.Root}
+}
+
 // ancestorQuery is an XPath ancestor node query.(ancestor::*|ancestor-self::*)
 type ancestorQuery struct {
 	iterator func() NodeNavigator
@@ -56,6 +76,7 @@ func (a *ancestorQuery) Select(t iterator) NodeNavigator {
 				return nil
 			}
 			first := true
+			node = node.Copy()
 			a.iterator = func() NodeNavigator {
 				if first && a.Self {
 					first = false
@@ -65,7 +86,7 @@ func (a *ancestorQuery) Select(t iterator) NodeNavigator {
 				}
 				for node.MoveToParent() {
 					if !a.Predicate(node) {
-						break
+						continue
 					}
 					return node
 				}
@@ -82,11 +103,16 @@ func (a *ancestorQuery) Select(t iterator) NodeNavigator {
 
 func (a *ancestorQuery) Evaluate(t iterator) interface{} {
 	a.Input.Evaluate(t)
+	a.iterator = nil
 	return a
 }
 
 func (a *ancestorQuery) Test(n NodeNavigator) bool {
 	return a.Predicate(n)
+}
+
+func (a *ancestorQuery) Clone() query {
+	return &ancestorQuery{Self: a.Self, Input: a.Input.Clone(), Predicate: a.Predicate}
 }
 
 // attributeQuery is an XPath attribute node query.(@*)
@@ -133,6 +159,10 @@ func (a *attributeQuery) Evaluate(t iterator) interface{} {
 
 func (a *attributeQuery) Test(n NodeNavigator) bool {
 	return a.Predicate(n)
+}
+
+func (a *attributeQuery) Clone() query {
+	return &attributeQuery{Input: a.Input.Clone(), Predicate: a.Predicate}
 }
 
 // childQuery is an XPath child node query.(child::*)
@@ -185,6 +215,10 @@ func (c *childQuery) Test(n NodeNavigator) bool {
 	return c.Predicate(n)
 }
 
+func (c *childQuery) Clone() query {
+	return &childQuery{Input: c.Input.Clone(), Predicate: c.Predicate}
+}
+
 // position returns a position of current NodeNavigator.
 func (c *childQuery) position() int {
 	return c.posit
@@ -194,6 +228,7 @@ func (c *childQuery) position() int {
 type descendantQuery struct {
 	iterator func() NodeNavigator
 	posit    int
+	level    int
 
 	Self      bool
 	Input     query
@@ -209,32 +244,38 @@ func (d *descendantQuery) Select(t iterator) NodeNavigator {
 				return nil
 			}
 			node = node.Copy()
-			level := 0
+			d.level = 0
+			positmap := make(map[int]int)
 			first := true
 			d.iterator = func() NodeNavigator {
 				if first && d.Self {
 					first = false
 					if d.Predicate(node) {
+						d.posit = 1
+						positmap[d.level] = 1
 						return node
 					}
 				}
 
 				for {
 					if node.MoveToChild() {
-						level++
+						d.level = d.level + 1
+						positmap[d.level] = 0
 					} else {
 						for {
-							if level == 0 {
+							if d.level == 0 {
 								return nil
 							}
 							if node.MoveToNext() {
 								break
 							}
 							node.MoveToParent()
-							level--
+							d.level = d.level - 1
 						}
 					}
 					if d.Predicate(node) {
+						positmap[d.level]++
+						d.posit = positmap[d.level]
 						return node
 					}
 				}
@@ -242,7 +283,6 @@ func (d *descendantQuery) Select(t iterator) NodeNavigator {
 		}
 
 		if node := d.iterator(); node != nil {
-			d.posit++
 			return node
 		}
 		d.iterator = nil
@@ -264,8 +304,17 @@ func (d *descendantQuery) position() int {
 	return d.posit
 }
 
+func (d *descendantQuery) depth() int {
+	return d.level
+}
+
+func (d *descendantQuery) Clone() query {
+	return &descendantQuery{Self: d.Self, Input: d.Input.Clone(), Predicate: d.Predicate}
+}
+
 // followingQuery is an XPath following node query.(following::*|following-sibling::*)
 type followingQuery struct {
+	posit    int
 	iterator func() NodeNavigator
 
 	Input     query
@@ -276,6 +325,7 @@ type followingQuery struct {
 func (f *followingQuery) Select(t iterator) NodeNavigator {
 	for {
 		if f.iterator == nil {
+			f.posit = 0
 			node := f.Input.Select(t)
 			if node == nil {
 				return nil
@@ -288,12 +338,13 @@ func (f *followingQuery) Select(t iterator) NodeNavigator {
 							return nil
 						}
 						if f.Predicate(node) {
+							f.posit++
 							return node
 						}
 					}
 				}
 			} else {
-				var q query // descendant query
+				var q *descendantQuery // descendant query
 				f.iterator = func() NodeNavigator {
 					for {
 						if q == nil {
@@ -310,6 +361,7 @@ func (f *followingQuery) Select(t iterator) NodeNavigator {
 							t.Current().MoveTo(node)
 						}
 						if node := q.Select(t); node != nil {
+							f.posit = q.posit
 							return node
 						}
 						q = nil
@@ -334,9 +386,18 @@ func (f *followingQuery) Test(n NodeNavigator) bool {
 	return f.Predicate(n)
 }
 
+func (f *followingQuery) Clone() query {
+	return &followingQuery{Input: f.Input.Clone(), Sibling: f.Sibling, Predicate: f.Predicate}
+}
+
+func (f *followingQuery) position() int {
+	return f.posit
+}
+
 // precedingQuery is an XPath preceding node query.(preceding::*)
 type precedingQuery struct {
 	iterator  func() NodeNavigator
+	posit     int
 	Input     query
 	Sibling   bool // The matching sibling node of current node.
 	Predicate func(NodeNavigator) bool
@@ -345,6 +406,7 @@ type precedingQuery struct {
 func (p *precedingQuery) Select(t iterator) NodeNavigator {
 	for {
 		if p.iterator == nil {
+			p.posit = 0
 			node := p.Input.Select(t)
 			if node == nil {
 				return nil
@@ -357,6 +419,7 @@ func (p *precedingQuery) Select(t iterator) NodeNavigator {
 							return nil
 						}
 						if p.Predicate(node) {
+							p.posit++
 							return node
 						}
 					}
@@ -370,6 +433,7 @@ func (p *precedingQuery) Select(t iterator) NodeNavigator {
 								if !node.MoveToParent() {
 									return nil
 								}
+								p.posit = 0
 							}
 							q = &descendantQuery{
 								Self:      true,
@@ -379,6 +443,7 @@ func (p *precedingQuery) Select(t iterator) NodeNavigator {
 							t.Current().MoveTo(node)
 						}
 						if node := q.Select(t); node != nil {
+							p.posit++
 							return node
 						}
 						q = nil
@@ -400,6 +465,14 @@ func (p *precedingQuery) Evaluate(t iterator) interface{} {
 
 func (p *precedingQuery) Test(n NodeNavigator) bool {
 	return p.Predicate(n)
+}
+
+func (p *precedingQuery) Clone() query {
+	return &precedingQuery{Input: p.Input.Clone(), Sibling: p.Sibling, Predicate: p.Predicate}
+}
+
+func (p *precedingQuery) position() int {
+	return p.posit
 }
 
 // parentQuery is an XPath parent node query.(parent::*)
@@ -424,6 +497,10 @@ func (p *parentQuery) Select(t iterator) NodeNavigator {
 func (p *parentQuery) Evaluate(t iterator) interface{} {
 	p.Input.Evaluate(t)
 	return p
+}
+
+func (p *parentQuery) Clone() query {
+	return &parentQuery{Input: p.Input.Clone(), Predicate: p.Predicate}
 }
 
 func (p *parentQuery) Test(n NodeNavigator) bool {
@@ -458,10 +535,16 @@ func (s *selfQuery) Test(n NodeNavigator) bool {
 	return s.Predicate(n)
 }
 
+func (s *selfQuery) Clone() query {
+	return &selfQuery{Input: s.Input.Clone(), Predicate: s.Predicate}
+}
+
 // filterQuery is an XPath query for predicate filter.
 type filterQuery struct {
 	Input     query
 	Predicate query
+	posit     int
+	positmap  map[int]int
 }
 
 func (f *filterQuery) do(t iterator) bool {
@@ -472,8 +555,8 @@ func (f *filterQuery) do(t iterator) bool {
 	case reflect.String:
 		return len(val.String()) > 0
 	case reflect.Float64:
-		pt := float64(getNodePosition(f.Input))
-		return int(val.Float()) == int(pt)
+		pt := getNodePosition(f.Input)
+		return int(val.Float()) == pt
 	default:
 		if q, ok := f.Predicate.(query); ok {
 			return q.Select(t) != nil
@@ -482,17 +565,29 @@ func (f *filterQuery) do(t iterator) bool {
 	return false
 }
 
+func (f *filterQuery) position() int {
+	return f.posit
+}
+
 func (f *filterQuery) Select(t iterator) NodeNavigator {
+	if f.positmap == nil {
+		f.positmap = make(map[int]int)
+	}
 	for {
+
 		node := f.Input.Select(t)
 		if node == nil {
 			return node
 		}
 		node = node.Copy()
-		//fmt.Println(node.LocalName())
 
 		t.Current().MoveTo(node)
 		if f.do(t) {
+			// fix https://github.com/antchfx/htmlquery/issues/26
+			// Calculate and keep the each of matching node's position in the same depth.
+			level := getNodeDepth(f.Input)
+			f.positmap[level]++
+			f.posit = f.positmap[level]
 			return node
 		}
 	}
@@ -503,8 +598,13 @@ func (f *filterQuery) Evaluate(t iterator) interface{} {
 	return f
 }
 
-// functionQuery is an XPath function that call a function to returns
-// value of current NodeNavigator node.
+func (f *filterQuery) Clone() query {
+	return &filterQuery{Input: f.Input.Clone(), Predicate: f.Predicate.Clone()}
+}
+
+// functionQuery is an XPath function that returns a computed value for
+// the Evaluate call of the current NodeNavigator node. Select call isn't
+// applicable for functionQuery.
 type functionQuery struct {
 	Input query                             // Node Set
 	Func  func(query, iterator) interface{} // The xpath function.
@@ -520,6 +620,38 @@ func (f *functionQuery) Evaluate(t iterator) interface{} {
 	return f.Func(f.Input, t)
 }
 
+func (f *functionQuery) Clone() query {
+	return &functionQuery{Input: f.Input.Clone(), Func: f.Func}
+}
+
+// transformFunctionQuery diffs from functionQuery where the latter computes a scalar
+// value (number,string,boolean) for the current NodeNavigator node while the former
+// (transformFunctionQuery) performs a mapping or transform of the current NodeNavigator
+// and returns a new NodeNavigator. It is used for non-scalar XPath functions such as
+// reverse(), remove(), subsequence(), unordered(), etc.
+type transformFunctionQuery struct {
+	Input    query
+	Func     func(query, iterator) func() NodeNavigator
+	iterator func() NodeNavigator
+}
+
+func (f *transformFunctionQuery) Select(t iterator) NodeNavigator {
+	if f.iterator == nil {
+		f.iterator = f.Func(f.Input, t)
+	}
+	return f.iterator()
+}
+
+func (f *transformFunctionQuery) Evaluate(t iterator) interface{} {
+	f.Input.Evaluate(t)
+	f.iterator = nil
+	return f
+}
+
+func (f *transformFunctionQuery) Clone() query {
+	return &transformFunctionQuery{Input: f.Input.Clone(), Func: f.Func}
+}
+
 // constantQuery is an XPath constant operand.
 type constantQuery struct {
 	Val interface{}
@@ -531,6 +663,10 @@ func (c *constantQuery) Select(t iterator) NodeNavigator {
 
 func (c *constantQuery) Evaluate(t iterator) interface{} {
 	return c.Val
+}
+
+func (c *constantQuery) Clone() query {
+	return c
 }
 
 // logicalQuery is an XPath logical expression.
@@ -559,6 +695,10 @@ func (l *logicalQuery) Evaluate(t iterator) interface{} {
 	return l.Do(t, m, n)
 }
 
+func (l *logicalQuery) Clone() query {
+	return &logicalQuery{Left: l.Left.Clone(), Right: l.Right.Clone(), Do: l.Do}
+}
+
 // numericQuery is an XPath numeric operator expression.
 type numericQuery struct {
 	Left, Right query
@@ -574,6 +714,10 @@ func (n *numericQuery) Evaluate(t iterator) interface{} {
 	m := n.Left.Evaluate(t)
 	k := n.Right.Evaluate(t)
 	return n.Do(m, k)
+}
+
+func (n *numericQuery) Clone() query {
+	return &numericQuery{Left: n.Left.Clone(), Right: n.Right.Clone(), Do: n.Do}
 }
 
 type booleanQuery struct {
@@ -648,10 +792,114 @@ func (b *booleanQuery) Select(t iterator) NodeNavigator {
 
 func (b *booleanQuery) Evaluate(t iterator) interface{} {
 	m := b.Left.Evaluate(t)
-	if m.(bool) == b.IsOr {
-		return m
+	left := asBool(t, m)
+	if b.IsOr && left {
+		return true
+	} else if !b.IsOr && !left {
+		return false
 	}
-	return b.Right.Evaluate(t)
+	m = b.Right.Evaluate(t)
+	return asBool(t, m)
+}
+
+func (b *booleanQuery) Clone() query {
+	return &booleanQuery{IsOr: b.IsOr, Left: b.Left.Clone(), Right: b.Right.Clone()}
+}
+
+type unionQuery struct {
+	Left, Right query
+	iterator    func() NodeNavigator
+}
+
+func (u *unionQuery) Select(t iterator) NodeNavigator {
+	if u.iterator == nil {
+		var list []NodeNavigator
+		var m = make(map[uint64]bool)
+		root := t.Current().Copy()
+		for {
+			node := u.Left.Select(t)
+			if node == nil {
+				break
+			}
+			code := getHashCode(node.Copy())
+			if _, ok := m[code]; !ok {
+				m[code] = true
+				list = append(list, node.Copy())
+			}
+		}
+		t.Current().MoveTo(root)
+		for {
+			node := u.Right.Select(t)
+			if node == nil {
+				break
+			}
+			code := getHashCode(node.Copy())
+			if _, ok := m[code]; !ok {
+				m[code] = true
+				list = append(list, node.Copy())
+			}
+		}
+		var i int
+		u.iterator = func() NodeNavigator {
+			if i >= len(list) {
+				return nil
+			}
+			node := list[i]
+			i++
+			return node
+		}
+	}
+	return u.iterator()
+}
+
+func (u *unionQuery) Evaluate(t iterator) interface{} {
+	u.iterator = nil
+	u.Left.Evaluate(t)
+	u.Right.Evaluate(t)
+	return u
+}
+
+func (u *unionQuery) Clone() query {
+	return &unionQuery{Left: u.Left.Clone(), Right: u.Right.Clone()}
+}
+
+func getHashCode(n NodeNavigator) uint64 {
+	var sb bytes.Buffer
+	switch n.NodeType() {
+	case AttributeNode, TextNode, CommentNode:
+		sb.WriteString(fmt.Sprintf("%s=%s", n.LocalName(), n.Value()))
+		// https://github.com/antchfx/htmlquery/issues/25
+		d := 1
+		for n.MoveToPrevious() {
+			d++
+		}
+		sb.WriteString(fmt.Sprintf("-%d", d))
+		for n.MoveToParent() {
+			d = 1
+			for n.MoveToPrevious() {
+				d++
+			}
+			sb.WriteString(fmt.Sprintf("-%d", d))
+		}
+	case ElementNode:
+		sb.WriteString(n.Prefix() + n.LocalName())
+		d := 1
+		for n.MoveToPrevious() {
+			d++
+		}
+		sb.WriteString(fmt.Sprintf("-%d", d))
+
+		for n.MoveToParent() {
+			d = 1
+			for n.MoveToPrevious() {
+				d++
+			}
+			sb.WriteString(fmt.Sprintf("-%d", d))
+		}
+	}
+	h := fnv.New64a()
+	h.Write([]byte(sb.String()))
+	return h.Sum64()
 }
 
 func getNodePosition(q query) int {
@@ -662,4 +910,14 @@ func getNodePosition(q query) int {
 		return count.position()
 	}
 	return 1
+}
+
+func getNodeDepth(q query) int {
+	type Depth interface {
+		depth() int
+	}
+	if count, ok := q.(Depth); ok {
+		return count.depth()
+	}
+	return 0
 }

--- a/vendor/github.com/antchfx/xpath/xpath.go
+++ b/vendor/github.com/antchfx/xpath/xpath.go
@@ -1,5 +1,10 @@
 package xpath
 
+import (
+	"errors"
+	"fmt"
+)
+
 // NodeType represents a type of XPath node.
 type NodeType int
 
@@ -18,6 +23,9 @@ const (
 
 	// CommentNode is a comment node, such as <!-- my comment -->
 	CommentNode
+
+	// allNode is any types of node, used by xpath package only to predicate match.
+	allNode
 )
 
 // NodeNavigator provides cursor model for navigating XML data.
@@ -86,11 +94,68 @@ func (t *NodeIterator) MoveNext() bool {
 }
 
 // Select selects a node set using the specified XPath expression.
+// This method is deprecated, recommend using Expr.Select() method instead.
 func Select(root NodeNavigator, expr string) *NodeIterator {
-	qy, err := build(expr)
+	exp, err := Compile(expr)
 	if err != nil {
 		panic(err)
 	}
-	t := &NodeIterator{query: qy, node: root}
-	return t
+	return exp.Select(root)
+}
+
+// Expr is an XPath expression for query.
+type Expr struct {
+	s string
+	q query
+}
+
+type iteratorFunc func() NodeNavigator
+
+func (f iteratorFunc) Current() NodeNavigator {
+	return f()
+}
+
+// Evaluate returns the result of the expression.
+// The result type of the expression is one of the follow: bool,float64,string,NodeIterator).
+func (expr *Expr) Evaluate(root NodeNavigator) interface{} {
+	val := expr.q.Evaluate(iteratorFunc(func() NodeNavigator { return root }))
+	switch val.(type) {
+	case query:
+		return &NodeIterator{query: expr.q.Clone(), node: root}
+	}
+	return val
+}
+
+// Select selects a node set using the specified XPath expression.
+func (expr *Expr) Select(root NodeNavigator) *NodeIterator {
+	return &NodeIterator{query: expr.q.Clone(), node: root}
+}
+
+// String returns XPath expression string.
+func (expr *Expr) String() string {
+	return expr.s
+}
+
+// Compile compiles an XPath expression string.
+func Compile(expr string) (*Expr, error) {
+	if expr == "" {
+		return nil, errors.New("expr expression is nil")
+	}
+	qy, err := build(expr)
+	if err != nil {
+		return nil, err
+	}
+	if qy == nil {
+		return nil, fmt.Errorf(fmt.Sprintf("undeclared variable in XPath expression: %s", expr))
+	}
+	return &Expr{s: expr, q: qy}, nil
+}
+
+// MustCompile compiles an XPath expression string and ignored error.
+func MustCompile(expr string) *Expr {
+	exp, err := Compile(expr)
+	if err != nil {
+		return &Expr{s: expr, q: nopQuery{}}
+	}
+	return exp
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,7 +14,11 @@ github.com/Azure/go-autorest/tracing
 # github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559
 ## explicit
 github.com/ajeddeloh/go-json
-# github.com/antchfx/xpath v0.0.0-20170515025933-1f3266e77307
+# github.com/antchfx/xmlquery v1.3.5
+## explicit
+github.com/antchfx/xmlquery
+# github.com/antchfx/xpath v1.1.11
+## explicit
 github.com/antchfx/xpath
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile


### PR DESCRIPTION
xmldom seems to be a stale project, and its current issues present some
usability limitations for us:

* Excessive resource usage
* Inability to get full xml content from sub-nodes.

The second point results in us getting malformed descriptions in some
rules.

This aims to address that by replacing the XML parsing [for another
library that's more active](https://github.com/antchfx/xmlquery).

This is only used when generated profiles, rules and variables.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>