### PR TITLE
Make pauser pod limit be 15Mi

### DIFF
--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -498,7 +498,7 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *a
 									corev1.ResourceCPU:    resource.MustParse("20m"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("2Mi"),
+									corev1.ResourceMemory: resource.MustParse("15Mi"),
 									corev1.ResourceCPU:    resource.MustParse("50m"),
 								},
 							},


### PR DESCRIPTION
In some cases, the kubelet was complaining that it was too little for
the limit, this fixes that.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>