### PR TITLE
docs: fix typo

### DIFF
--- a/doc/crds.md
+++ b/doc/crds.md
@@ -282,7 +282,7 @@ You can get all the check results from a suite by using the label
 For instance:
 
 ```
-oc get compliancesuites -l compliance.openshift.io/suite=example-compliancesuite
+oc get compliancecheckresults -l compliance.openshift.io/suite=example-compliancesuite
 ```
 
 ### The `ComplianceRemediation` object


### PR DESCRIPTION
I was about to send this with my earlier docs commits but for some reason forgot.