### PR TITLE
Add warnings to ComplianceCheckResult

### DIFF
--- a/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
@@ -57,6 +57,12 @@ spec:
           status:
             description: The result of a check
             type: string
+          warnings:
+            description: Any warnings that the user should be aware about.
+            items:
+              type: string
+            nullable: true
+            type: array
         required:
         - id
         - severity

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -235,6 +235,9 @@ Where:
   the data-stream/content.
 * **severity**: Describes the severity of the check. The possible values are:
   `unknown`, `info`, `low`, `medium`, `high`
+* **warnings**: A list of warnings that the user might want to look out for.
+  Often, if the result is marked at NOT-APPLICABLE, a relevant warning will
+  explain why.
 * **status**: Describes the result of the check. The possible values are:
 	* **PASS**: Which indicates that check ran to completion and passed.
 	* **FAIL**: Which indicates that the check ran to completion and failed.

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -89,6 +89,9 @@ type ComplianceCheckResult struct {
 	// How to evaluate if the rule status manually. If no automatic test is present, the rule status will be MANUAL
 	// and the administrator should follow these instructions.
 	Instructions string `json:"instructions,omitempty"`
+	// Any warnings that the user should be aware about.
+	// +nullable
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // IDToDNSFriendlyName gets the ID from the scan and returns a DNS

--- a/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
@@ -15,6 +15,11 @@ func (in *ComplianceCheckResult) DeepCopyInto(out *ComplianceCheckResult) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.Warnings != nil {
+		in, out := &in.Warnings, &out.Warnings
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Lately, we've gotten reports of folks getting confused by some results
being NOT-APPLICABLE for some benchmarks.

Even if for us this is normal and expected, users find it confusing and
will think something is wrong.

In a recent PR we also are handling rules differently depending on the
OpenShift version [1]. So, this makes it very relevant for us not to
confuse users and try to give as much relevant information as possible.

To address this, the version dependency notice has been added as a
warning in the rule itself. To reflect this in the operator, this
commit adds a `warnings` section to the ComplianceCheckResult Custom
Resource. This goes through the warnings and exposes them to users,
hence explaning possible things people want to watch out for.

Note that we are using the warnings for persisting the API path
information. This is not very relevant to users, so this is skipped when
adding it to the result.

I also noticed at we were only taking one warning into account when
parsing the aforementioned API path; this fixes that. Only waking one
warning into account could have been problematic in cases where the API
path is not present in the first warning of a rule.

[1] https://github.com/ComplianceAsCode/content/pull/6813

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>