### PR TITLE
Release v0.1.31 for 4.6

### DIFF
--- a/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
@@ -57,6 +57,12 @@ spec:
           status:
             description: The result of a check
             type: string
+          warnings:
+            description: Any warnings that the user should be aware about.
+            items:
+              type: string
+            nullable: true
+            type: array
         required:
         - id
         - severity

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.30'
+    olm.skipRange: '>=0.1.17 <0.1.31'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
-    operators.openshift.io/infrastructure-features: '["Disconnected"]'
+    operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.30
+  name: compliance-operator.v0.1.31
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1058,10 +1058,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.4
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.30
+                  value: quay.io/compliance-operator/compliance-operator:0.1.31
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.30
+                image: quay.io/compliance-operator/compliance-operator:0.1.31
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources:
@@ -1376,4 +1376,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.30
+  version: 0.1.31

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1365,8 +1365,10 @@ spec:
   - openscap
   - audit
   links:
-  - name: Compliance Operator
-    url: https://compliance-operator.domain
+  - name: Compliance Operator upstream repo
+    url: https://github.com/openshift/compliance-operator
+  - name: Compliance Operator documentation
+    url: https://docs.openshift.com/container-platform/4.7/security/compliance_operator/compliance-operator-understanding.html
   maintainers:
   - email: support@redhat.com
     name: Red Hat Support

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancecheckresults_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancecheckresults_crd.yaml
@@ -58,6 +58,12 @@ spec:
           status:
             description: The result of a check
             type: string
+          warnings:
+            description: Any warnings that the user should be aware about.
+            items:
+              type: string
+            nullable: true
+            type: array
         required:
         - id
         - severity

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -235,6 +235,9 @@ Where:
   the data-stream/content.
 * **severity**: Describes the severity of the check. The possible values are:
   `unknown`, `info`, `low`, `medium`, `high`
+* **warnings**: A list of warnings that the user might want to look out for.
+  Often, if the result is marked at NOT-APPLICABLE, a relevant warning will
+  explain why.
 * **status**: Describes the result of the check. The possible values are:
 	* **PASS**: Which indicates that check ran to completion and passed.
 	* **FAIL**: Which indicates that the check ran to completion and failed.

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -89,6 +89,9 @@ type ComplianceCheckResult struct {
 	// How to evaluate if the rule status manually. If no automatic test is present, the rule status will be MANUAL
 	// and the administrator should follow these instructions.
 	Instructions string `json:"instructions,omitempty"`
+	// Any warnings that the user should be aware about.
+	// +nullable
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // IDToDNSFriendlyName gets the ID from the scan and returns a DNS

--- a/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
@@ -15,6 +15,11 @@ func (in *ComplianceCheckResult) DeepCopyInto(out *ComplianceCheckResult) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.Warnings != nil {
+		in, out := &in.Warnings, &out.Warnings
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
* Adds warnings to ComplianceCheckResult: Useful to expose deprecations, node dependencies or service dependencies.
* Adds fips feature flag for OLM.
* CSV links are fixed.