### PR TITLE
WIP: Converge rules that present multiple results

### DIFF
--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -133,7 +133,7 @@ func readCompressedData(compressed string) (*bzip2.Reader, error) {
 // Returns a triple of (array-of-ParseResults, source, error) where source identifies the entity whose
 // scan produced this configMap -- typically a nodeName for node scans. For platform scans, the source
 // is empty. The source is used later when reconciling inconsistent results
-func parseResultRemediations(scheme *runtime.Scheme, scanName, namespace string, content *utils.XMLDocument, cm *v1.ConfigMap) ([]*utils.ParseResult, string, error) {
+func parseResultRemediations(scheme *runtime.Scheme, scanName, namespace string, content *utils.XMLDocument, cm *v1.ConfigMap) (map[string]*utils.ParseResult, string, error) {
 	var scanReader io.Reader
 
 	_, ok := cm.Annotations[configMapRemediationsProcessed]
@@ -186,7 +186,7 @@ func getScanResult(cm *v1.ConfigMap) (compv1alpha1.ComplianceScanStatusResult, s
 	return compv1alpha1.ResultError, fmt.Sprintf("The ConfigMap '%s' was missing 'exit-code'", cm.Name)
 }
 
-func annotateCMWithScanResult(cm *v1.ConfigMap, cmParsedResults []*utils.ParseResult) *v1.ConfigMap {
+func annotateCMWithScanResult(cm *v1.ConfigMap, cmParsedResults map[string]*utils.ParseResult) *v1.ConfigMap {
 	scanResult, errMsg := getScanResult(cm)
 	if scanResult == compv1alpha1.ResultCompliant {
 		// Special case: If the OS didn't match at all and SCAP skipped all the tests,
@@ -325,7 +325,7 @@ func getCheckResultAnnotations(cr *compv1alpha1.ComplianceCheckResult, resultAnn
 	return annotations
 }
 
-func createResults(crClient *complianceCrClient, scan *compv1alpha1.ComplianceScan, consistentResults []*utils.ParseResultContextItem) error {
+func createResults(crClient *complianceCrClient, scan *compv1alpha1.ComplianceScan, consistentResults map[string]*utils.ParseResultContextItem) error {
 	log.Info("Will create result objects", "objects", len(consistentResults))
 	if len(consistentResults) == 0 {
 		log.Info("Nothing to create")

--- a/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
@@ -36,6 +36,13 @@ spec:
           description:
             description: A human-readable check description, what and why it does
             type: string
+          failureInfo:
+            description: Collects failure information that can serve as evidence that's
+              helpful to understand what failed.
+            items:
+              type: string
+            nullable: true
+            type: array
           id:
             description: A unique identifier of a check
             type: string

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -94,6 +94,24 @@ type ComplianceCheckResult struct {
 	Warnings []string `json:"warnings,omitempty"`
 }
 
+// CompareCheckResults returns the most relevant result out of two
+func CompareCheckResults(a ComplianceCheckStatus, b ComplianceCheckStatus) ComplianceCheckStatus {
+	orderedResults := make(map[ComplianceCheckStatus]int)
+	orderedResults[CheckResultError] = 0
+	orderedResults[CheckResultInconsistent] = 1
+	orderedResults[CheckResultFail] = 2
+	orderedResults[CheckResultPass] = 3
+	orderedResults[CheckResultInfo] = 4
+	orderedResults[CheckResultManual] = 5
+	orderedResults[CheckResultNotApplicable] = 6
+	orderedResults[CheckResultNoResult] = 7
+
+	if orderedResults[a] > orderedResults[b] {
+		return b
+	}
+	return a
+}
+
 // IDToDNSFriendlyName gets the ID from the scan and returns a DNS
 // friendly name
 func (ccr *ComplianceCheckResult) IDToDNSFriendlyName() string {

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -92,6 +92,10 @@ type ComplianceCheckResult struct {
 	// Any warnings that the user should be aware about.
 	// +nullable
 	Warnings []string `json:"warnings,omitempty"`
+	// Collects failure information that can serve as evidence that's
+	// helpful to understand what failed.
+	// +nullable
+	FailureInfo []string `json:"failureInfo,omitempty"`
 }
 
 // CompareCheckResults returns the most relevant result out of two

--- a/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
@@ -20,6 +20,11 @@ func (in *ComplianceCheckResult) DeepCopyInto(out *ComplianceCheckResult) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.FailureInfo != nil {
+		in, out := &in.FailureInfo, &out.FailureInfo
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/utils/parse_arf_result_test.go
+++ b/pkg/utils/parse_arf_result_test.go
@@ -10,13 +10,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	ign2types "github.com/coreos/ignition/config/v2_2/types"
 	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	mcfgcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 )
 
-func countResultItems(resultList []*ParseResult) (int, int) {
+func countResultItems(resultList map[string]*ParseResult) (int, int) {
 	if resultList == nil {
 		return 0, 0
 	}
@@ -52,7 +51,7 @@ var _ = Describe("XCCDF parser", func() {
 		schema          *runtime.Scheme
 		resultsFilename string
 		dsFilename      string
-		resultList      []*ParseResult
+		resultList      map[string]*ParseResult
 		nChecks         int
 		nRems           int
 		err             error
@@ -136,14 +135,14 @@ var _ = Describe("XCCDF parser", func() {
 			)
 
 			BeforeEach(func() {
+				expName = "testScan-no-direct-root-logins"
 				for i := range resultList {
-					if resultList[i].Remediation != nil {
+					if resultList[i].Remediation != nil && resultList[i].Remediation.Name == expName {
 						rem = resultList[i].Remediation
 						break
 					}
 				}
 				Expect(rem).ToNot(BeNil())
-				expName = "testScan-no-direct-root-logins"
 			})
 
 			It("Should have the expected name", func() {
@@ -161,7 +160,7 @@ var _ = Describe("XCCDF parser", func() {
 				BeforeEach(func() {
 					mcfg, _ := ParseMachineConfig(rem, rem.Spec.Current.Object)
 					ignRaw, _ := mcfgcommon.IgnParseWrapper(mcfg.Spec.Config.Raw)
-					parsedIgn := ignRaw.(ign2types.Config)
+					parsedIgn := ignRaw.(igntypes.Config)
 					mcFiles = parsedIgn.Storage.Files
 				})
 


### PR DESCRIPTION
This enables the Compliance Operator to handle rules that output
multiple results.

This is the case for rules like `security_patches_up_to_date` which will
present a result per-package.

For this kind of results, we get one final result. So logic to get the
most relevant result was added. Being `ERROR` the most relevant result,
followed by `FAIL`.

To facilitate this, the results are now stored in memory in a hash, as
opposed to the previous list. This allowed for us to remove the Id from
the structure of ParsedResults and leverage the id that's stored in the
hash already.

## Refactor aggregator to get relevant logging info while parsing

Our parsing of ARF results skipped all errors quietly. This might get
tricky when trying to debug issues, so this commit refactors the
aggregator to use a common interface that contains appropriate client
and logging functions.

The logging interface is passed down when parsing the ARF.

## Add `failureInfo` to handle extra information for rules

This new parameter in the ComplianceCheck result will be used to gather
failure information that could be useful to asses the results given by
the operator.

Right now, its only usage is for verifying the
`security_patches_up_to_date` rule, which is a `multi-check` of OVAL
class "patch".

As we get requests, we'll add handling for different class types.