### PR TITLE
Add management workload annotations

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         name: compliance-operator
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       serviceAccountName: compliance-operator
       containers:

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -37,6 +37,9 @@ func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Log
 			Name:      podName,
 			Namespace: common.GetComplianceOperatorNamespace(),
 			Labels:    podLabels,
+			Annotations: map[string]string{
+				"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+			},
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: aggregatorSA,

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -127,6 +127,9 @@ func resultServer(scanInstance *compv1alpha1.ComplianceScan, labels map[string]s
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
+					Annotations: map[string]string{
+						"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+					},
 				},
 				Spec: corev1.PodSpec{
 					// TODO(jaosorior): Should we schedule this in the master nodes only?

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -272,6 +272,9 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 			Name:      podName,
 			Namespace: common.GetComplianceOperatorNamespace(),
 			Labels:    podLabels,
+			Annotations: map[string]string{
+				"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+			},
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: apiResourceCollectorSA,

--- a/pkg/controller/compliancesuite/suitererunner.go
+++ b/pkg/controller/compliancesuite/suitererunner.go
@@ -117,6 +117,9 @@ func getRerunner(suite *compv1alpha1.ComplianceSuite) *batchv1beta1.CronJob {
 								compv1alpha1.SuiteScriptLabel: "",
 								"workload":                    "suitererunner",
 							},
+							Annotations: map[string]string{
+								"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+							},
 						},
 						Spec: corev1.PodSpec{
 							ServiceAccountName: rerunnerServiceAccount,

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -408,6 +408,9 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *a
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
+					Annotations: map[string]string{
+						"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+					},
 				},
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{


### PR DESCRIPTION
In support of the workload partitioning feature (openshift/enhancements#703),
we need to add annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

The proposed workloads to only run in the management-designated
resources are the following:

* Compliance Opertor Deployment: Runs reconcile loops and schedules
  everyting. Only meant for management and shouldn't run on
  non-management resources.

* Result Server: Gets the full ARF raw results and positions them into the
  Persistent Volume.

* Aggregator: Gets a subset of the results and builds ComplianceCheckResult
  and ComplianceRemediation objects.

* Platform scan: This type of scan queries the kube API before running
  OpenSCAP to evaluate them. There's no need for this to run on the
  non-management resources.

* Suite-rerunner: is a one-off job that ensures that the ComplianceSuite
  is re-run at the configured time.

* ProfileBundle's profileparser: parses the data stream and builds
  profiles, rules and variable kubernetes objects out of it.

Node type of scans was purposefully left out of this as there may be the possibility
of nodes not being configured with these management resources, and thus the
Kubelet wouldn't schedule them appropriately as it should.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>