### PR TITLE
Make use of the HTTPS_PROXY environment variable

### DIFF
--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -155,6 +155,7 @@ type ComplianceScanSettings struct {
 	// resources could be, for instance, CVE feeds. This is useful for disconnected
 	// installations without access to a proxy.
 	NoExternalResources bool `json:"noExternalResources,omitempty"`
+	// It is recommended to set the proxy via the config.openshift.io/Proxy object
 	// Defines a proxy for the scan to get external resources from. This is useful for
 	// disconnected installations with access to a proxy.
 	HTTPSProxy string `json:"httpsProxy,omitempty"`

--- a/pkg/controller/compliancescan/config.go
+++ b/pkg/controller/compliancescan/config.go
@@ -2,6 +2,7 @@ package compliancescan
 
 import (
 	"context"
+	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -247,8 +248,9 @@ func commonOpenScapEnvCm(name string, scan *compv1alpha1.ComplianceScan) *corev1
 		cm.Data[OpenScapTailoringDirEnvName] = OpenScapTailoringDir
 	}
 
-	if scan.Spec.HTTPSProxy != "" {
-		cm.Data[HTTPSProxyEnvName] = scan.Spec.HTTPSProxy
+	proxy := getHttpsProxy(scan)
+	if proxy != "" {
+		cm.Data[HTTPSProxyEnvName] = proxy
 	}
 
 	if scan.Spec.NoExternalResources {
@@ -256,6 +258,14 @@ func commonOpenScapEnvCm(name string, scan *compv1alpha1.ComplianceScan) *corev1
 	}
 
 	return cm
+}
+
+func getHttpsProxy(scan *compv1alpha1.ComplianceScan) string {
+	if scan.Spec.HTTPSProxy != "" {
+		return scan.Spec.HTTPSProxy
+	}
+
+	return os.Getenv("HTTPS_PROXY")
 }
 
 func defaultOpenScapEnvCm(name string, scan *compv1alpha1.ComplianceScan) *corev1.ConfigMap {


### PR DESCRIPTION
OpenShift allows the administrator to set a global proxy by editing the
proxy/cluster object:
    https://github.com/openshift/api/blob/master/config/v1/types_proxy.go
The OLM can in turn watch for the proxy objects and set the HTTPS_PROXY
environment variable in the CO deployment.

This patch sets the proxy environment variable for the openscap pods
based on the value of the HTTPS_PROXY environment variable passed for
the operator, thus taking advantage of the global proxy settings.

The HTTPSProxy member of the ComplianceScanSettings structure is
retained, just an attribute is added that the OCP proxy is preferred.

Jira: [CMP-846](https://issues.redhat.com/browse/CMP-846)