### PR TITLE
Move relevant workloads to be scheduled on the master nodes only

### DIFF
--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -42,6 +42,16 @@ func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Log
 			},
 		},
 		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{
+				"node-role.kubernetes.io/master": "",
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
 			ServiceAccountName: aggregatorSA,
 			InitContainers: []corev1.Container{
 				{

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -132,7 +132,16 @@ func resultServer(scanInstance *compv1alpha1.ComplianceScan, labels map[string]s
 					},
 				},
 				Spec: corev1.PodSpec{
-					// TODO(jaosorior): Should we schedule this in the master nodes only?
+					NodeSelector: map[string]string{
+						"node-role.kubernetes.io/master": "",
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
 					ServiceAccountName: resultserverSA,
 					Containers: []corev1.Container{
 						{

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -408,7 +408,13 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 			NodeSelector: map[string]string{
 				"node-role.kubernetes.io/master": "",
 			},
-			Tolerations:   scanInstance.Spec.ScanTolerations,
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
 			RestartPolicy: corev1.RestartPolicyOnFailure,
 			Volumes: []corev1.Volume{
 				{

--- a/pkg/controller/compliancesuite/suitererunner.go
+++ b/pkg/controller/compliancesuite/suitererunner.go
@@ -122,6 +122,16 @@ func getRerunner(suite *compv1alpha1.ComplianceSuite) *batchv1beta1.CronJob {
 							},
 						},
 						Spec: corev1.PodSpec{
+							NodeSelector: map[string]string{
+								"node-role.kubernetes.io/master": "",
+							},
+							Tolerations: []corev1.Toleration{
+								{
+									Key:      "node-role.kubernetes.io/master",
+									Operator: corev1.TolerationOpExists,
+									Effect:   corev1.TaintEffectNoSchedule,
+								},
+							},
 							ServiceAccountName: rerunnerServiceAccount,
 							RestartPolicy:      corev1.RestartPolicyOnFailure,
 							Containers: []corev1.Container{

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -413,6 +413,16 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *a
 					},
 				},
 				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"node-role.kubernetes.io/master": "",
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
 					InitContainers: []corev1.Container{
 						{
 							Name:  "content-container",


### PR DESCRIPTION
This ensures that the worker nodes are free for customer workloads only
and thus we only use master resources.

The main use-cases for this are:

* Hypershift, where the master nodes are in different infrastructure (maybe even a different cloud) than the worker nodes.
* Remote worker nodes (results should only reside on the master).