### PR TITLE
Limit resource usage for all workloads

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -28,10 +28,10 @@ spec:
           resources:
             requests:
               memory: "20Mi"
-              cpu: "250m"
+              cpu: "10m"
             limits:
               memory: "200Mi"
-              cpu: "500m"
+              cpu: "100m"
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -90,6 +91,16 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 						AllowPrivilegeEscalation: &falseP,
 						ReadOnlyRootFilesystem:   &trueP,
 					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("10Mi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+						},
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "content-dir",
@@ -122,6 +133,16 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 						AllowPrivilegeEscalation: &falseP,
 						ReadOnlyRootFilesystem:   &trueP,
 					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("20Mi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+						},
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "report-dir",
@@ -144,6 +165,16 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 						ReadOnlyRootFilesystem: &trueP,
 						// TODO(jaosorior): Figure out if the default
 						// seccomp profile is sufficient here.
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("500Mi"),
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -292,6 +323,16 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 						AllowPrivilegeEscalation: &falseP,
 						ReadOnlyRootFilesystem:   &trueP,
 					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("10Mi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+						},
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "content-dir",
@@ -307,6 +348,16 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &falseP,
 						ReadOnlyRootFilesystem:   &trueP,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("20Mi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -349,6 +400,16 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 						AllowPrivilegeEscalation: &falseP,
 						ReadOnlyRootFilesystem:   &trueP,
 					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("20Mi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+						},
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "report-dir",
@@ -369,6 +430,16 @@ func newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.L
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &falseP,
 						ReadOnlyRootFilesystem:   &trueP,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("500Mi"),
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/pkg/controller/compliancesuite/suitererunner.go
+++ b/pkg/controller/compliancesuite/suitererunner.go
@@ -150,11 +150,11 @@ func getRerunner(suite *compv1alpha1.ComplianceSuite) *batchv1beta1.CronJob {
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
 											corev1.ResourceMemory: resource.MustParse("10Mi"),
-											corev1.ResourceCPU:    resource.MustParse("100m"),
+											corev1.ResourceCPU:    resource.MustParse("10m"),
 										},
 										Limits: corev1.ResourceList{
 											corev1.ResourceMemory: resource.MustParse("50Mi"),
-											corev1.ResourceCPU:    resource.MustParse("250m"),
+											corev1.ResourceCPU:    resource.MustParse("50m"),
 										},
 									},
 								},

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -440,11 +440,11 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *a
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("10Mi"),
-									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceCPU:    resource.MustParse("10m"),
 								},
 								Limits: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
-									corev1.ResourceCPU:    resource.MustParse("250m"),
+									corev1.ResourceCPU:    resource.MustParse("50m"),
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -464,11 +464,11 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *a
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("20Mi"),
-									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceCPU:    resource.MustParse("10m"),
 								},
 								Limits: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("200Mi"),
-									corev1.ResourceCPU:    resource.MustParse("1000m"),
+									corev1.ResourceCPU:    resource.MustParse("100m"),
 								},
 							},
 							Command: []string{
@@ -508,11 +508,11 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *a
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("1Mi"),
-									corev1.ResourceCPU:    resource.MustParse("20m"),
+									corev1.ResourceCPU:    resource.MustParse("10m"),
 								},
 								Limits: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("15Mi"),
-									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceCPU:    resource.MustParse("10m"),
 								},
 							},
 						},


### PR DESCRIPTION
now that our profiles aren't using as many resources as they used to,
let's add appropriate requests and limits for all resources.

The max CPU usage that a workload is allowed to have for the compliance
operator is 100m, this is with the intent of leaving resources for other
workloads so this would work in single-node deployments.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>