### PR TITLE
hardening: Confine most workloads with the default Seccomp profile

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -13,6 +13,7 @@ spec:
         name: compliance-operator
       annotations:
         workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
     spec:
       serviceAccountName: compliance-operator
       containers:

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -39,6 +39,7 @@ func newAggregatorPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Log
 			Labels:    podLabels,
 			Annotations: map[string]string{
 				"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+				corev1.SeccompPodAnnotationKey:     corev1.SeccompProfileRuntimeDefault,
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/pkg/controller/compliancescan/config.go
+++ b/pkg/controller/compliancescan/config.go
@@ -40,8 +40,7 @@ const (
 	// Tailoring constants
 	OpenScapTailoringDir = "/tailoring"
 
-	PlatformScanName                  = "api-checks"
-	PlatformScanResourceCollectorName = "api-resource-collector"
+	PlatformScanName = "api-checks"
 	// This coincides with the default ocp_data_root var in CaC.
 	PlatformScanDataRoot = "/kubernetes-api-resources"
 )

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -129,6 +129,7 @@ func resultServer(scanInstance *compv1alpha1.ComplianceScan, labels map[string]s
 					Labels: labels,
 					Annotations: map[string]string{
 						"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+						corev1.SeccompPodAnnotationKey:     corev1.SeccompProfileRuntimeDefault,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/controller/compliancesuite/suitererunner.go
+++ b/pkg/controller/compliancesuite/suitererunner.go
@@ -119,6 +119,7 @@ func getRerunner(suite *compv1alpha1.ComplianceSuite) *batchv1beta1.CronJob {
 							},
 							Annotations: map[string]string{
 								"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+								corev1.SeccompPodAnnotationKey:     corev1.SeccompProfileRuntimeDefault,
 							},
 						},
 						Spec: corev1.PodSpec{

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -410,6 +410,7 @@ func newWorkloadForBundle(pb *compliancev1alpha1.ProfileBundle, image string) *a
 					Labels: labels,
 					Annotations: map[string]string{
 						"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+						corev1.SeccompPodAnnotationKey:     corev1.SeccompProfileRuntimeDefault,
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
This confines most workloads using the runtime/default seccomp profile.
This should greatly reduce the attack vector in our containers.

The only resource that hasn't been confined is the scanner container for
node type scans.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>