### PR TITLE
Allow the api-resource collector to read ComplianceSuite objects

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1096,3 +1096,12 @@ rules:
   - get
   - list
   - watch
+# Necessary for the reading resources for moderate benchmark
+- apiGroups:
+  - compliance.openshift.io
+  resources:
+  - compliancesuites
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
This is needed for the moderate benchmark.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>