### PR TITLE
Add permission to api-resource-collector to read MCs

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1105,3 +1105,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - machineconfigs
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
This is needed to verify if FIPS mode needs to be enabled.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>