### PR TITLE
Add permission to get fileintegrity objects

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1113,3 +1113,10 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - "fileintegrity.openshift.io"
+  resources:
+  - fileintegrities
+  verbs:
+  - get
+  - watch


### PR DESCRIPTION
This will be used by the moderate profile.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>