### PR TITLE
Allow api-resource-collector to read PrometheusRules and oauthclients

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -594,6 +594,7 @@ rules:
   - oauth.openshift.io
   resources:
   - oauthclientauthorizations
+  - oauthclients
   verbs:
   - get
   - list

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1121,3 +1121,11 @@ rules:
   verbs:
   - get
   - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  verbs:
+  - get
+  - watch
+  - list


### PR DESCRIPTION
This is needed to cover several FedRAMP rules.