### PR TITLE
Release v0.1.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.33] - 2021-05-24
+### Changes
+- Allow api-resource-collector to read PrometheusRules
+- Allow api-resource-collector to read oauthclients
+- Add CHANGELOG.md and make release update target
+- Add permission to get fileintegrity objects
+- Update go.uber.org/zap dependency
+- Add permission to api-resource-collector to read MCs
+- Convert XML from CaC content to markdown in the k8s objects
+- Allow the api-resource collector to read ComplianceSuite objects
+- Die xmldom! Die!
+- Set the operators.openshift.io/infrastructure-features:proxy-aware annotation
+- Make use of the HTTPS_PROXY environment variable
+
 ## [0.1.32] - 2021-04-26
 ### Changes
 - Add Workload management annotations

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.32'
+    olm.skipRange: '>=0.1.17 <0.1.33'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.32
+  name: compliance-operator.v0.1.33
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -525,6 +525,7 @@ spec:
           - oauth.openshift.io
           resources:
           - oauthclientauthorizations
+          - oauthclients
           verbs:
           - get
           - list
@@ -1026,6 +1027,37 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - compliance.openshift.io
+          resources:
+          - compliancesuites
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - machineconfiguration.openshift.io
+          resources:
+          - machineconfigs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - fileintegrity.openshift.io
+          resources:
+          - fileintegrities
+          verbs:
+          - get
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - get
+          - watch
+          - list
         serviceAccountName: api-resource-collector
       deployments:
       - name: compliance-operator
@@ -1060,10 +1092,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.4
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.32
+                  value: quay.io/compliance-operator/compliance-operator:0.1.33
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.32
+                image: quay.io/compliance-operator/compliance-operator:0.1.33
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources:
@@ -1378,4 +1410,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.32
+  version: 0.1.33


### PR DESCRIPTION
- Allow api-resource-collector to read PrometheusRules
- Allow api-resource-collector to read oauthclients
- Add CHANGELOG.md and make release update target
- Add permission to get fileintegrity objects
- Update go.uber.org/zap dependency
- Add permission to api-resource-collector to read MCs
- Convert XML from CaC content to markdown in the k8s objects
- Allow the api-resource collector to read ComplianceSuite objects
-  Remove problematic xmldom dependency
- Set the operators.openshift.io/infrastructure-features:proxy-aware annotation
- Make use of the HTTPS_PROXY environment variable
