### PR TITLE
RBAC: Allow api-resource-collector to list FIO objects

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1115,12 +1115,13 @@ rules:
   - list
   - watch
 - apiGroups:
-  - "fileintegrity.openshift.io"
+  - fileintegrity.openshift.io
   resources:
   - fileintegrities
   verbs:
   - get
   - watch
+  - list
 - apiGroups:
   - monitoring.coreos.com
   resources:


### PR DESCRIPTION
The CaC check that ensures that some FIO objects exist in the cluster
needs to also list the FIO objects (it would get something like
"/apis/fileintegrity.openshift.io/v1alpha1/fileintegrities?limit=5")
therefore the RBAC rules must also grant the list verb.