### PR TITLE
Remove unused const definitions

### DIFF
--- a/pkg/utils/parse_arf_result.go
+++ b/pkg/utils/parse_arf_result.go
@@ -27,9 +27,7 @@ const (
 
 // Constants useful for parsing warnings
 const (
-	endPointTag    = "ocp-api-endpoint"
-	endPointTagEnd = endPointTag + "\">"
-	codeTag        = "</code>"
+	endPointTag = "ocp-api-endpoint"
 )
 
 type ParseResult struct {


### PR DESCRIPTION
There are a couple of unused const definitions that were left overs from
the migration off the xmldom library. This removes them.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>