### PR TITLE
Release v0.1.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.34] - 2021-06-02
+### Changes
+- Switch to using go 1.16
+- Remove unused const definitions
+- Update dependencies
+- RBAC: Allow api-resource-collector to list FIO objects
+
 ## [0.1.33] - 2021-05-24
 ### Changes
 - Allow api-resource-collector to read PrometheusRules

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.33'
+    olm.skipRange: '>=0.1.17 <0.1.34'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.33
+  name: compliance-operator.v0.1.34
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1050,6 +1050,7 @@ spec:
           verbs:
           - get
           - watch
+          - list
         - apiGroups:
           - monitoring.coreos.com
           resources:
@@ -1092,10 +1093,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.4
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.33
+                  value: quay.io/compliance-operator/compliance-operator:0.1.34
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.33
+                image: quay.io/compliance-operator/compliance-operator:0.1.34
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources:
@@ -1410,4 +1411,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.33
+  version: 0.1.34


### PR DESCRIPTION
## [0.1.34] - 2021-06-02
### Changes
- Switch to using go 1.16
- Remove unused const definitions
- Update dependencies
- RBAC: Allow api-resource-collector to list FIO objects