### PR TITLE
RBAC: Add permissions to update oauths config

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -159,11 +159,12 @@ rules:
   verbs:
   - get
   - list
-# These are needed for remediating objects for the CIS benchmark
+# These are needed for remediating objects
 - apiGroups:
   - config.openshift.io
   resources:
   - apiservers
+  - oauths
   resourceNames:
   - cluster
   verbs:


### PR DESCRIPTION
This is needed to remediate token inactivity settings.