### PR TITLE
Collect all ocp-api-endpoint elements

### DIFF
--- a/cmd/manager/scap.go
+++ b/cmd/manager/scap.go
@@ -164,7 +164,7 @@ func (c *scapContentDataStream) FigureResources(profile string) error {
 //
 //  <warning category="general" lang="en-US"><code class="ocp-api-endpoint">/apis/config.openshift.io/v1/oauths/cluster
 //  </code></warning>
-func getPathFromWarningXML(in *xmlquery.Node) string {
+func getPathFromWarningXML(in *xmlquery.Node) []string {
 	DBG("Parsing warning %s", in.OutputXML(false))
 	return utils.GetPathFromWarningXML(in)
 }
@@ -228,12 +228,12 @@ func getResourcePaths(profileDefs *xmlquery.Node, ruleDefs *xmlquery.Node, profi
 			if warn == nil {
 				continue
 			}
-			apiPath := getPathFromWarningXML(warn)
-			if len(apiPath) == 0 {
+			apiPaths := getPathFromWarningXML(warn)
+			if len(apiPaths) == 0 {
 				continue
 			}
 			// We only care for the first occurrence that works
-			out = append(out, apiPath)
+			out = append(out, apiPaths...)
 			warningFound = true
 			break
 		}

--- a/cmd/manager/scap_test.go
+++ b/cmd/manager/scap_test.go
@@ -32,7 +32,10 @@ var _ = Describe("Testing SCAP parsing and storage", func() {
 			Expect(err).To(BeNil())
 
 			By("parsing content for warnings")
-			expected := []string{"/apis/config.openshift.io/v1/oauths/cluster"}
+			expected := []string{
+				"/apis/config.openshift.io/v1/oauths/cluster",
+				"/api/v1/namespaces/openshift-kube-apiserver/configmaps/config",
+			}
 			got := getResourcePaths(contentDS, contentDS, "xccdf_org.ssgproject.content_profile_platform-moderate")
 			Expect(got).To(Equal(expected))
 		})


### PR DESCRIPTION
Some rules need to collect several resources and correlate them or run a
check on several results. For example OAuth token inactivity can be set
either in the OAuth server object or any of the OAuth clients.

This patch extends gathering the API resource URLs to all of those that
are included in the warnings elemement instead of the first one to
support cases like above.

Jira: [CMP-775](https://issues.redhat.com/browse/CMP-775)