### PR TITLE
Release v0.1.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.35] - 2021-06-09
+### Changes
+- Collect all ocp-api-endpoint elements
+- RBAC: Add permissions to update oauths config
+
 ## [0.1.34] - 2021-06-02
 ### Changes
 - Switch to using go 1.16

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.34'
+    olm.skipRange: '>=0.1.17 <0.1.35'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.34
+  name: compliance-operator.v0.1.35
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -263,6 +263,7 @@ spec:
           - cluster
           resources:
           - apiservers
+          - oauths
           verbs:
           - get
           - list
@@ -1093,10 +1094,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.4
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.34
+                  value: quay.io/compliance-operator/compliance-operator:0.1.35
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.34
+                image: quay.io/compliance-operator/compliance-operator:0.1.35
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources:
@@ -1411,4 +1412,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.34
+  version: 0.1.35

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.0.1"
+	Version = "0.1.35"
 )


### PR DESCRIPTION
## [0.1.35] - 2021-06-09
### Changes
- Collect all ocp-api-endpoint elements
- RBAC: Add permissions to update oauths config
