### PR TITLE
TP: When transitioning to Ready, remove previous error message

### DIFF
--- a/pkg/controller/tailoredprofile/tailoredprofile_controller.go
+++ b/pkg/controller/tailoredprofile/tailoredprofile_controller.go
@@ -249,6 +249,7 @@ func (r *ReconcileTailoredProfile) updateTailoredProfileStatusReady(tp *cmpv1alp
 	// Never update the original (update the copy)
 	tpCopy := tp.DeepCopy()
 	tpCopy.Status.State = cmpv1alpha1.TailoredProfileStateReady
+	tpCopy.Status.ErrorMessage = ""
 	tpCopy.Status.OutputRef = cmpv1alpha1.OutputRef{
 		Name:      out.GetName(),
 		Namespace: out.GetNamespace(),


### PR DESCRIPTION
When a TP was marked as an error, the error message would always be
there regardless of the actual state