### PR TITLE
Bug 1975358: Refresh pool reference before trying to unpause it

### DIFF
--- a/pkg/controller/compliancesuite/compliancesuite_controller_test.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller_test.go
@@ -89,7 +89,7 @@ var _ = Describe("ComplianceSuiteController", func() {
 		Expect(err).To(BeNil())
 
 		client := fake.NewFakeClientWithScheme(cscheme, nodeScan.DeepCopy(), suite.DeepCopy())
-		reconciler = &ReconcileComplianceSuite{client: client, scheme: cscheme}
+		reconciler = &ReconcileComplianceSuite{reader: client, client: client, scheme: cscheme}
 		zaplog, _ := zap.NewDevelopment()
 		logger = zapr.NewLogger(zaplog)
 	})


### PR DESCRIPTION
This reduces the conflicts as we'll be dealing with a fresh object for
the pool. Thus we'll be able to update it.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>