### PR TITLE
This fixes the issue where a empty remediation yaml file is present

### DIFF
--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -378,7 +378,7 @@ func createResults(crClient *complianceCrClient, scan *compv1alpha1.ComplianceSc
 		if canCreate, why := canCreateRemediation(scan, remTargetObj); !canCreate {
 			// Only issue event once.
 			if !remediationNotPossibleEventIssued {
-				log.Info(why + " Remediation:" + crkey.Name)
+				log.Info(why, "Remediation", crkey.Name)
 				crClient.recorder.Event(scan, v1.EventTypeWarning, "CannotRemediate", why+" Remediation:"+crkey.Name)
 				remediationNotPossibleEventIssued = true
 			}

--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -34,6 +34,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -277,8 +278,12 @@ func createOrUpdateOneResult(crClient *complianceCrClient, owner metav1.Object, 
 	return nil
 }
 
-func canCreateRemediation(scan *compv1alpha1.ComplianceScan, obj runtime.Object) (bool, string) {
+func canCreateRemediation(scan *compv1alpha1.ComplianceScan, obj *unstructured.Unstructured) (bool, string) {
 	// FIXME(jaosorior): Figure out a more pluggable way of adding these sorts of special cases
+	if obj == nil || len(obj.Object) == 0 {
+		return false, "The remediaiton yaml file is empty"
+	}
+
 	if obj.GetObjectKind().GroupVersionKind().Kind != "MachineConfig" {
 		return true, ""
 	}
@@ -373,8 +378,8 @@ func createResults(crClient *complianceCrClient, scan *compv1alpha1.ComplianceSc
 		if canCreate, why := canCreateRemediation(scan, remTargetObj); !canCreate {
 			// Only issue event once.
 			if !remediationNotPossibleEventIssued {
-				log.Info(why)
-				crClient.recorder.Event(scan, v1.EventTypeWarning, "CannotRemediate", why)
+				log.Info(why + " Remediation:" + crkey.Name)
+				crClient.recorder.Event(scan, v1.EventTypeWarning, "CannotRemediate", why+" Remediation:"+crkey.Name)
 				remediationNotPossibleEventIssued = true
 			}
 			continue

--- a/cmd/manager/aggregator_test.go
+++ b/cmd/manager/aggregator_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("Aggregator Empty Remediation Test", func() {
+
+	var (
+		namespace          = "test-ns"
+		remediationName    = "testRem"
+		targetNodeSelector = map[string]string{
+			"hops": "malt",
+		}
+	)
+	nodeScanSettings := compv1alpha1.ComplianceScanSpec{
+		ScanType:     compv1alpha1.ScanTypeNode,
+		NodeSelector: targetNodeSelector,
+	}
+
+	nodeScan := &compv1alpha1.ComplianceScan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testScanNode",
+			Namespace: namespace,
+		},
+		Spec: nodeScanSettings,
+	}
+	emptyRem := &compv1alpha1.ComplianceRemediation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      remediationName,
+			Namespace: namespace,
+		},
+		Spec: compv1alpha1.ComplianceRemediationSpec{
+			ComplianceRemediationSpecMeta: compv1alpha1.ComplianceRemediationSpecMeta{
+				Apply: true,
+			},
+			Current: compv1alpha1.ComplianceRemediationPayload{
+				Object: &unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				},
+			},
+		},
+	}
+	canCreate, _ := canCreateRemediation(nodeScan, emptyRem.Spec.Current.Object)
+	Expect(canCreate).To(BeFalse())
+})


### PR DESCRIPTION
Prevent creating ComplianceRemediations with empty remediation objects. 