### PR TITLE
Issue warning if filter issues more than one object

### DIFF
--- a/cmd/manager/scap_test.go
+++ b/cmd/manager/scap_test.go
@@ -117,5 +117,20 @@ var _ = Describe("Testing filtering", func() {
 				`.items[`)
 			Expect(filterErr).ToNot(BeNil())
 		})
+		Context("Filtering namespaces", func() {
+			var rawns []byte
+			BeforeEach(func() {
+				nsFile, err := os.Open("../../tests/data/namespaces.json")
+				Expect(err).To(BeNil())
+				var readErr error
+				rawns, readErr = ioutil.ReadAll(nsFile)
+				Expect(readErr).To(BeNil())
+			})
+
+			It("skips extra results", func() {
+				_, filterErr := filter(context.TODO(), rawns, `.items[]`)
+				Expect(filterErr).Should(MatchError(MoreThanOneObjErr))
+			})
+		})
 	})
 })


### PR DESCRIPTION
We only really take one object into account when filtering results. This
can be tricky for content writes and we should ideally tell them
something is wrong. Thus, we issue a warning for such cases.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>