### PR TITLE
Release v0.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.36] - 2021-06-28
+### Changes
+- Issue warning if filter issues more than one object
+- This checks for the empty remediation yaml file before creating a remediation
+- Enable filtering using `jq` syntax
+- Wrap warning fetching with struct
+- Persist resources as JSON and not YAML
+- Bug 1975358: Refresh pool reference before trying to unpause it
+- TailoredProfiles: When transitioning to Ready, remove previous error message
+- docs: Add an example of setting a variable in a tailoredProfile
+
 ## [0.1.35] - 2021-06-09
 ### Changes
 - Collect all ocp-api-endpoint elements

--- a/Makefile
+++ b/Makefile
@@ -401,6 +401,8 @@ undo-deploy-tag-image: package-version-to-tag
 .PHONY: git-release
 git-release: package-version-to-tag changelog
 	git checkout -b "release-v$(TAG)"
+	sed -i "s/\(.*Version = \"\).*/\1$(TAG)\"/" version/version.go
+	git add "version/version.go"
 	git add "deploy/olm-catalog/compliance-operator/"
 	git add "CHANGELOG.md"
 	git commit -m "Release v$(TAG)"

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.35'
+    olm.skipRange: '>=0.1.17 <0.1.36'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.35
+  name: compliance-operator.v0.1.36
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1094,10 +1094,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.4
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.35
+                  value: quay.io/compliance-operator/compliance-operator:0.1.36
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.35
+                image: quay.io/compliance-operator/compliance-operator:0.1.36
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources:
@@ -1412,4 +1412,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.35
+  version: 0.1.36

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.35"
+	Version = "0.1.36"
 )


### PR DESCRIPTION
## [0.1.36] - 2021-06-28
### Changes
- Issue warning if filter issues more than one object
- This checks for the empty remediation yaml file before creating a remediation
- Enable filtering using `jq` syntax
- Wrap warning fetching with struct
- Persist resources as JSON and not YAML
- Bug 1975358: Refresh pool reference before trying to unpause it
- TailoredProfiles: When transitioning to Ready, remove previous error message
- docs: Add an example of setting a variable in a tailoredProfile
