### PR TITLE
tailoring: Update the tailoring CM on changes

### DIFF
--- a/pkg/controller/tailoredprofile/tailoredprofile_controller.go
+++ b/pkg/controller/tailoredprofile/tailoredprofile_controller.go
@@ -309,8 +309,16 @@ func (r *ReconcileTailoredProfile) ensureOutputObject(tp *cmpv1alpha1.TailoredPr
 		return reconcile.Result{}, err
 	}
 
-	// ConfigMap already exists - don't requeue
-	logger.Info("Skip reconcile: ConfigMap already exists", "ConfigMap.Namespace", found.Namespace, "ConfigMap.Name", found.Name)
+	// ConfigMap already exists - update
+	update := found.DeepCopy()
+	update.Data = tpcm.Data
+	err = r.client.Update(context.TODO(), update)
+	if err != nil {
+		fmt.Printf("Couldn't update TailoredProfile configMap: %v\n", err)
+		return reconcile.Result{}, err
+	}
+
+	logger.Info("Skip reconcile: ConfigMap already exists and is up-to-date", "ConfigMap.Namespace", found.Namespace, "ConfigMap.Name", found.Name)
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
We used to only create the tailoring CM, not update it. This makes a
tight test loop harder as you'd need to remove the tailoredProfile every
time.

JIRA: [CMP-1008](https://issues.redhat.com/browse/CMP-1008)