### PR TITLE
Release v0.1.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.37] - 2021-08-04
+### Changes
+- Bug 1946512: Use latest for CSV documentation link
+- doc: note that rolling back images in ProfileBundle is not well supported
+- Controller metrics e2e testing
+- Add initial controller metrics support
+- vendor deps
+- Bump the suitererunner resource limits
+- Fix instructions on building VMs
+- Add NERC-CIP reference support
+- The remediation templating design doc Squashed
+- Add implementation of enforcement remediations
+- tailoring: Update the tailoring CM on changes
+- Move Compliance Operator to use ubi-micro
+
 ## [0.1.36] - 2021-06-28
 ### Changes
 - Issue warning if filter issues more than one object

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.36'
+    olm.skipRange: '>=0.1.17 <0.1.37'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.36
+  name: compliance-operator.v0.1.37
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -270,6 +270,42 @@ spec:
           - watch
           - update
           - patch
+        - apiGroups:
+          - templates.gatekeeper.sh
+          resources:
+          - constrainttemplates
+          verbs:
+          - list
+          - get
+          - patch
+          - create
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - config.gatekeeper.sh
+          resources:
+          - configs
+          verbs:
+          - list
+          - get
+          - patch
+          - create
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - constraints.gatekeeper.sh
+          resources:
+          - '*'
+          verbs:
+          - list
+          - get
+          - patch
+          - create
+          - watch
+          - update
+          - delete
         serviceAccountName: compliance-operator
       - rules:
         - apiGroups:
@@ -1094,10 +1130,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.4
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.36
+                  value: quay.io/compliance-operator/compliance-operator:0.1.37
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.36
+                image: quay.io/compliance-operator/compliance-operator:0.1.37
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources:
@@ -1110,6 +1146,10 @@ spec:
                 securityContext:
                   allowPrivilegeEscalation: false
                   readOnlyRootFilesystem: true
+                volumeMounts:
+                - mountPath: /var/run/secrets/serving-cert
+                  name: serving-cert
+                  readOnly: true
               nodeSelector:
                 node-role.kubernetes.io/master: ""
               serviceAccountName: compliance-operator
@@ -1125,6 +1165,10 @@ spec:
                 key: node.kubernetes.io/not-ready
                 operator: Exists
                 tolerationSeconds: 120
+              volumes:
+              - name: serving-cert
+                secret:
+                  secretName: compliance-operator-serving-cert
       permissions:
       - rules:
         - apiGroups:
@@ -1217,6 +1261,7 @@ spec:
           verbs:
           - get
           - create
+          - update
         - apiGroups:
           - apps
           resourceNames:
@@ -1385,6 +1430,18 @@ spec:
           - update
           - delete
         serviceAccountName: profileparser
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - endpoints
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: prometheus-k8s
     strategy: deployment
   installModes:
   - supported: true
@@ -1412,4 +1469,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.36
+  version: 0.1.37

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_complianceremediations_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_complianceremediations_crd.yaml
@@ -72,6 +72,17 @@ spec:
                     x-kubernetes-embedded-resource: true
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
+              type:
+                default: Configuration
+                description: 'The type of remediation that this object applies. The
+                  available types are: Configuration and Enforcement. Where the Configuration
+                  type fixes a configuration to match a compliance expectation. The
+                  Enforcement type, on the other hand, ensures that the cluster stays
+                  in compliance via means of authorization.'
+                enum:
+                - Configuration
+                - Enforcement
+                type: string
             required:
             - apply
             type: object

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancescans_crd.yaml
@@ -57,9 +57,9 @@ spec:
                 description: Enable debug logging of workloads and OpenSCAP
                 type: boolean
               httpsProxy:
-                description: Defines a proxy for the scan to get external resources
-                  from. This is useful for disconnected installations with access
-                  to a proxy.
+                description: It is recommended to set the proxy via the config.openshift.io/Proxy
+                  object Defines a proxy for the scan to get external resources from.
+                  This is useful for disconnected installations with access to a proxy.
                 type: string
               noExternalResources:
                 description: Defines that no external resources in the Data Stream
@@ -114,6 +114,16 @@ spec:
                     nullable: true
                     type: string
                 type: object
+              remediationEnforcement:
+                description: 'Specifies what to do with remediations of Enforcement
+                  type. If left empty, this defaults to "off" which doesn''t create
+                  nor apply any enforcement remediations. If set to "all" this creates
+                  any enforcement remediations it encounters. Subsequently, this can
+                  also be set to a specific type. e.g. setting it to "gatekeeper"
+                  will apply any enforcement remediations relevant to the Gatekeeper
+                  OPA system. These objects will annotated in the content itself with:     complianceascode.io/enforcement-type:
+                  <type>'
+                type: string
               rule:
                 description: A Rule can be specified if the scan should check only
                   for a specific rule. Note that when leaving this empty, the scan

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancesuites_crd.yaml
@@ -72,7 +72,8 @@ spec:
                       description: Enable debug logging of workloads and OpenSCAP
                       type: boolean
                     httpsProxy:
-                      description: Defines a proxy for the scan to get external resources
+                      description: It is recommended to set the proxy via the config.openshift.io/Proxy
+                        object Defines a proxy for the scan to get external resources
                         from. This is useful for disconnected installations with access
                         to a proxy.
                       type: string
@@ -136,6 +137,17 @@ spec:
                           nullable: true
                           type: string
                       type: object
+                    remediationEnforcement:
+                      description: 'Specifies what to do with remediations of Enforcement
+                        type. If left empty, this defaults to "off" which doesn''t
+                        create nor apply any enforcement remediations. If set to "all"
+                        this creates any enforcement remediations it encounters. Subsequently,
+                        this can also be set to a specific type. e.g. setting it to
+                        "gatekeeper" will apply any enforcement remediations relevant
+                        to the Gatekeeper OPA system. These objects will annotated
+                        in the content itself with:     complianceascode.io/enforcement-type:
+                        <type>'
+                      type: string
                     rule:
                       description: A Rule can be specified if the scan should check
                         only for a specific rule. Note that when leaving this empty,

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_scansettings_crd.yaml
@@ -37,7 +37,8 @@ spec:
             description: Enable debug logging of workloads and OpenSCAP
             type: boolean
           httpsProxy:
-            description: Defines a proxy for the scan to get external resources from.
+            description: It is recommended to set the proxy via the config.openshift.io/Proxy
+              object Defines a proxy for the scan to get external resources from.
               This is useful for disconnected installations with access to a proxy.
             type: string
           kind:
@@ -87,6 +88,16 @@ spec:
                 nullable: true
                 type: string
             type: object
+          remediationEnforcement:
+            description: 'Specifies what to do with remediations of Enforcement type.
+              If left empty, this defaults to "off" which doesn''t create nor apply
+              any enforcement remediations. If set to "all" this creates any enforcement
+              remediations it encounters. Subsequently, this can also be set to a
+              specific type. e.g. setting it to "gatekeeper" will apply any enforcement
+              remediations relevant to the Gatekeeper OPA system. These objects will
+              annotated in the content itself with:     complianceascode.io/enforcement-type:
+              <type>'
+            type: string
           roles:
             description: The list of roles to apply node-specific checks to
             items:

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.36"
+	Version = "0.1.37"
 )


### PR DESCRIPTION
## [0.1.37] - 2021-08-04
### Changes
- Bug 1946512: Use latest for CSV documentation link
- doc: note that rolling back images in ProfileBundle is not well supported
- Controller metrics e2e testing
- Add initial controller metrics support
- vendor deps
- Bump the suitererunner resource limits
- Fix instructions on building VMs
- Add NERC-CIP reference support
- The remediation templating design doc Squashed
- Add implementation of enforcement remediations
- tailoring: Update the tailoring CM on changes
- Move Compliance Operator to use ubi-micro
