### PR TITLE
Bug 1990836: Move metrics service creation back into operator startup

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -58,6 +58,7 @@ spec:
         - name: serving-cert
           secret:
             secretName: compliance-operator-serving-cert
+            optional: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -32,30 +32,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: resultserver
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    name: compliance-operator
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: compliance-operator-serving-cert
-  name: metrics
-  namespace: openshift-compliance
-spec:
-  ports:
-    - name: http-metrics
-      port: 8383
-      protocol: TCP
-      targetPort: 8383
-    - name: cr-metrics
-      port: 8686
-      protocol: TCP
-      targetPort: 8686
-    - name: metrics-co
-      port: 8585
-      protocol: TCP
-      targetPort: 8585
-  selector:
-    name: compliance-operator
-  type: ClusterIP


### PR DESCRIPTION
The metrics service (and corresponding service-cert) can't be handled by the
CSV, so this takes the following approach:

- Mark the serving-cert as optional: true for the operator deployment.
- On operator startup, create the metrics service if needed, and check for the
  service-cert availability. If the service-cert is not available (i.e.,
  initial run), restart the operator. On the subsequent restart the service-cert
  should be available and the operator runs as normal.