### PR TITLE
Release v0.1.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.38] - 2021-08-11
+### Changes
+- e2e: aggregating/NA metric value
+- Bug 1990836: Move metrics service creation back into operator startup
+- Add fetch-git-tags make target
+- Add a must-gather plugin
+
 ## [0.1.37] - 2021-08-04
 ### Changes
 - Bug 1946512: Use latest for CSV documentation link

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.37'
+    olm.skipRange: '>=0.1.17 <0.1.38'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.37
+  name: compliance-operator.v0.1.38
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1130,10 +1130,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.4
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.37
+                  value: quay.io/compliance-operator/compliance-operator:0.1.38
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.37
+                image: quay.io/compliance-operator/compliance-operator:0.1.38
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources:
@@ -1168,6 +1168,7 @@ spec:
               volumes:
               - name: serving-cert
                 secret:
+                  optional: true
                   secretName: compliance-operator-serving-cert
       permissions:
       - rules:
@@ -1469,4 +1470,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.37
+  version: 0.1.38

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.37"
+	Version = "0.1.38"
 )


### PR DESCRIPTION
## [0.1.38] - 2021-08-11
### Changes
- e2e: aggregating/NA metric value
- Bug 1990836: Move metrics service creation back into operator startup
- Add fetch-git-tags make target
- Add a must-gather plugin
