### PR TITLE
Add permission for operator to remediate prometheusrule objects

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -174,6 +174,17 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+  - patch
 # Enforcement types
 - apiGroups:
   - templates.gatekeeper.sh


### PR DESCRIPTION
This is needed for the AU-5 control which requires an alert that looks
for audit log errors.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>