### PR TITLE
Allow profileparser to parse PCI-DSS references

### DIFF
--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -720,6 +720,10 @@ func newStandardParser() *referenceParser {
 	if nciperr != nil {
 		log.Error(nciperr, "Could not register NERC-CIP reference parser") // not much we can do here..
 	}
+	pcidssperr := p.registerStandard("PCI-DSS", `^https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf$`)
+	if pcidssperr != nil {
+		log.Error(nciperr, "Could not register PCI-DSS reference parser") // not much we can do here..
+	}
 
 	p.registerFormatter(profileOperatorFormatter)
 	p.registerFormatter(rhacmFormatter)


### PR DESCRIPTION
This adds PCI-DSS to the list of profiles we support.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>