### PR TITLE
Bug 1969620: compliancescan: Fill the <target> element and the urn:xccdf:fact:identifier for node checks

### DIFF
--- a/pkg/controller/compliancescan/config.go
+++ b/pkg/controller/compliancescan/config.go
@@ -77,8 +77,9 @@ if [ -z $HOSTROOT ]; then
 		oscap xccdf eval \
 	)
 else
+	export OSCAP_PROBE_ROOT="$HOSTROOT"
 	cmd=(
-		oscap-chroot $HOSTROOT xccdf eval \
+		oscap xccdf eval \
 	)
 fi
 
@@ -134,8 +135,21 @@ echo "The rds-split operation returned $split_rv"
 
 # Put both the XCCDF result and the full ARF result into the report
 # directory.
-test -f $XCCDF_PATH && mv $XCCDF_PATH $REPORT_DIR
-test -f $ARF_REPORT && mv $ARF_REPORT $REPORT_DIR
+if [ -f "$XCCDF_PATH" ]; then
+	if [ ! -z "$OVERRIDE_TARGET" ]; then
+		sed -i "s/\(<target>\)[^<>]*\(<\/target\)/\1$OVERRIDE_TARGET\2/" "$XCCDF_PATH"
+	fi
+
+	mv $XCCDF_PATH $REPORT_DIR
+fi
+
+if [ -f "$ARF_REPORT" ]; then
+	if [ ! -z "$OVERRIDE_TARGET" ]; then
+		sed -i "s/\(<target>\)[^<>]*\(<\/target\)/\1$OVERRIDE_TARGET\2/" "$ARF_REPORT"
+	fi
+
+	mv $ARF_REPORT $REPORT_DIR
+fi
 echo "$rv" > $REPORT_DIR/exit_code
 
 # Return success

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -201,6 +201,16 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 							ReadOnly:  true,
 						},
 					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "OVERRIDE_TARGET",
+							Value: node.Labels[corev1.LabelHostname],
+						},
+						{
+							Name:  "OSCAP_EVALUATION_TARGET",
+							Value: node.Name,
+						},
+					},
 					EnvFrom: []corev1.EnvFromSource{
 						{
 							ConfigMapRef: &corev1.ConfigMapEnvSource{


### PR DESCRIPTION
The <target> element ought to contain the hostname of the system being 
scanned, but for the node scan results produced by oscap-chroot, it was
just saying unknown. This is because openscap normally reads /etc/hostname, 
which is not present on RHCOS.

While there is a bug filed against openscap
(https://bugzilla.redhat.com/show_bug.cgi?id=1977668) to read alternative
sources, let's work around that issue in the meantime by overriding the
<target> element ourselves during scan results post-processing.

Also, because the node host name is not that useful outside baremetal 
on-prem deployments, let's also put the node name into the <fact> with
"id=urn:xccdf:fact:identifier". This is done by setting the 
OSCAP_EVALUATION_TARGET environment variable. But in order to do so, we 
need to stop using oscap-chroot and start using oscap directly with the 
OSCAP_PROBE_ROOT variable set to "chroot://" ourselves because the 
oscap-chroot wrapper script also sets OSCAP_EVALUATION_TARGET to a value on
its own.

Platform check results are not changed in any way, because it is not 
possible to find the cluster name internally, without having the client 
context (see e.g. https://github.com/kubernetes/kubernetes/issues/44954)

Related: [OCPBUGSM-30237](https://issues.redhat.com/browse/OCPBUGSM-30237)