### PR TITLE
Enable Creation of TailoredProfiles without extending existing ones

### DIFF
--- a/deploy/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
@@ -106,8 +106,6 @@ spec:
               title:
                 description: Overwrites the title of the extended profile
                 type: string
-            required:
-            - extends
             type: object
           status:
             description: TailoredProfileStatus defines the observed state of TailoredProfile

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -598,7 +598,7 @@ spec:
 
 Notable attributes:
 
-* **spec.extends**: Name of the `Profile` object that this `TailoredProfile` builds upon
+* **spec.extends**: (Optional) Name of the `Profile` object that this `TailoredProfile` builds upon
 * **spec.title**: Human-readable title of the `TailoredProfile`
 * **spec.disableRules**: A list of `name` and `rationale` pairs. Each name refers to a name
   of a `Rule` object that is supposed to be disabled. `Rationale` is a human-readable text
@@ -613,6 +613,29 @@ Notable attributes:
   `tailoringConfigMap.name` attribute of a `ComplianceScan`.
 * **status.state**: Either of `PENDING`, `READY` or `ERROR`. If the state is `ERROR`, the
   attribute `status.errorMessage` contains the reason for the failure.
+
+While it's possible to extend a profile and build it based on another one, it's also
+possible to write a profile from scratch using the `TailoredProfile` construct.
+To do this, remember to set an appropriate title and description. It's very important
+to leave the `extends` field empty for this case. Subsequently, you'll also need
+to indicate to the Compliance Operator what type of scan will this custom profile
+generate:
+
+* Node scan: Scans the Operating System.
+* Platform scan: Scans the OpenShift configuration.
+
+To do this, set the following annotation on the TailoredProfile object:
+
+```
+  compliance.openshift.io/product-type: <Type>
+```
+
+Where the `Platform` type will build a Platform scan, and `Node` will
+build an OS scan. Note that if no `product-type` annotation is given, the
+operator will default to `Platform`. Adding the `-node` suffix to the
+name of the `TailoredProfile` object will have a similar effect as
+adding the `Node` product type annotation, and will generate an Operating
+System scan.
 
 ### The `ScanSetting` and `ScanSettingBinding` objects
 Defining the `ComplianceSuite` objects manually including all the details

--- a/pkg/apis/compliance/v1alpha1/tailoredprofile_types.go
+++ b/pkg/apis/compliance/v1alpha1/tailoredprofile_types.go
@@ -20,14 +20,15 @@ type VariableValueSpec struct {
 	Name string `json:"name"`
 	// Rationale of why this value is being tailored
 	Rationale string `json:"rationale"`
-	// Rationale of why this value is being tailored
+	// Value of the variable being set
 	Value string `json:"value"`
 }
 
 // TailoredProfileSpec defines the desired state of TailoredProfile
 type TailoredProfileSpec struct {
+	// +optional
 	// Points to the name of the profile to extend
-	Extends string `json:"extends"`
+	Extends string `json:"extends,omitempty"`
 	// Overwrites the title of the extended profile
 	Title string `json:"title,omitempty"`
 	// Overwrites the description of the extended profile

--- a/pkg/xccdf/tailoring.go
+++ b/pkg/xccdf/tailoring.go
@@ -50,7 +50,7 @@ type VersionElement struct {
 type ProfileElement struct {
 	XMLName     xml.Name                   `xml:"xccdf-1.2:Profile"`
 	ID          string                     `xml:"id,attr"`
-	Extends     string                     `xml:"extends,attr"`
+	Extends     string                     `xml:"extends,attr,omitempty"`
 	Title       *TitleOrDescriptionElement `xml:"xccdf-1.2:title,omitempty"`
 	Description *TitleOrDescriptionElement `xml:"xccdf-1.2:description,omitempty"`
 	Selections  []SelectElement
@@ -151,10 +151,12 @@ func TailoredProfileToXML(tp *cmpv1alpha1.TailoredProfile, p *cmpv1alpha1.Profil
 		},
 		Profile: ProfileElement{
 			ID:         GetXCCDFProfileID(tp),
-			Extends:    p.ID,
 			Selections: getSelections(tp, rules),
 			Values:     getValuesFromVariables(variables),
 		},
+	}
+	if p != nil {
+		tailoring.Profile.Extends = p.ID
 	}
 	if tp.Spec.Title != "" {
 		tailoring.Profile.Title = &TitleOrDescriptionElement{


### PR DESCRIPTION
This removes the requirement of having to extend a Profile in order to
create a TailoredProfile. So, the `extends` field from the
TailoredProfile CRD is no longer mandatory.

This requires for users to only select rules from the same
ProfileBundle, as the ProfileBundle will become "owner" of the
TailoredProfile object (for garbage collection reasons).

Also, TailoredProfiles now require the following annotation (which is
currently used by Profiles):

    compliance.openshift.io/product-type: <Type>

If left unset, the default will be `Platform`.

If the TailoredProfile's name ends with the suffix `-node`, the
annotation will have the value `Node`, and will schedule a `Node` scan
type instead.

If the annotation is set, it's left untouched.

This is a little manual right now, but can be extended in the future.

The ScanSettigBinding controller will also now wait for a
TailoredProfile object to be parsed and ready before trying to create a
ComplianceSuite.

Closes https://github.com/openshift/compliance-operator/issues/628