### PR TITLE
Restart profileparser on failures

### DIFF
--- a/cmd/manager/profileparser.go
+++ b/cmd/manager/profileparser.go
@@ -151,6 +151,11 @@ func runProfileParser(cmd *cobra.Command, args []string) {
 	// to valid
 	updateProfileBundleStatus(pcfg, pb, err)
 
+	if err != nil {
+		log.Error(err, "Parsing the bundle failed, will restart the container")
+		os.Exit(1)
+	}
+
 	if closeErr := contentFile.Close(); closeErr != nil {
 		log.Error(err, "Couldn't close the content file")
 	}

--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -480,8 +480,8 @@ func ParseVariablesAndDo(contentDom *xmlquery.Node, pb *cmpv1alpha1.ProfileBundl
 			err = action(&v)
 			if err != nil {
 				log.Error(err, "couldn't execute action for variable")
-				// We continue even if there's an error.
-				continue
+				errs <- err
+				break
 			}
 		}
 		wg.Done()
@@ -635,7 +635,8 @@ func ParseRulesAndDo(contentDom *xmlquery.Node, stdParser *referenceParser, pb *
 			err = action(&p)
 			if err != nil {
 				log.Error(err, "couldn't execute action for rule")
-				// We continue even if there's an error.
+				errs <- err
+				break
 			}
 		}
 


### PR DESCRIPTION
We used to be too permisive about failures in the profileparser, which
worked fine in the beginning, but doesn't work so well since we started
annotating the objects with the bundle SHA digest during an update and delete
any objects that were not annotated with that digest value - in case
an update operation failed because of a transient error, we would have
skipped annotating that object and ultimately treat it as removed and
delete it. This was happening especially during upgrades where the API
server might be unreachable at some point.

This patch exits the profileparser with a non-zero code on failures as
well as propagates the errors from the client operations to the error
channels so that they are eventually returned to the binary and used for
the error code. This ensures that the profileparser restarts and
hopefully goes through after the restart.

Jira: [OCPBUGSM-32701](https://issues.redhat.com/browse/OCPBUGSM-32701)