### PR TITLE
Associate variable with compliance check result

### DIFF
--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -322,6 +322,10 @@ func getCheckResultLabels(pr *utils.ParseResult, resultLabels map[string]string,
 	labels[compv1alpha1.SuiteLabel] = scan.Labels[compv1alpha1.SuiteLabel]
 	labels[compv1alpha1.ComplianceCheckResultStatusLabel] = string(pr.CheckResult.Status)
 	labels[compv1alpha1.ComplianceCheckResultSeverityLabel] = string(pr.CheckResult.Severity)
+	if len(pr.CheckResult.ValuesUsed) > 0 {
+		labels[compv1alpha1.ComplianceCheckResultValueLabel] = ""
+	}
+
 	if pr.Remediations != nil {
 		labels[compv1alpha1.ComplianceCheckResultHasRemediation] = ""
 	}
@@ -336,7 +340,6 @@ func getCheckResultLabels(pr *utils.ParseResult, resultLabels map[string]string,
 func getCheckResultAnnotations(cr *compv1alpha1.ComplianceCheckResult, resultAnnotations map[string]string) map[string]string {
 	annotations := make(map[string]string)
 	annotations[compv1alpha1.ComplianceCheckResultRuleAnnotation] = cr.IDToDNSFriendlyName()
-
 	for k, v := range resultAnnotations {
 		annotations[k] = v
 	}

--- a/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancecheckresults_crd.yaml
@@ -57,6 +57,11 @@ spec:
           status:
             description: The result of a check
             type: string
+          valuesUsed:
+            description: It stores a list of values used by the check
+            items:
+              type: string
+            type: array
           warnings:
             description: Any warnings that the user should be aware about.
             items:

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -251,6 +251,8 @@ Where:
       properly.
 	* **NOTAPPLICABLE**: Which indicates that the check didn't run because it is not
       applicable or not selected.
+ * **valuesUsed**: a list of settable variables associated with the rule scan result,
+  a user can set these variables in a tailored profile.
 
 This object is owned by the scan that created it, as seen in the
 `ownerReferences` field.

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -13,6 +13,7 @@ type ComplianceCheckStatus string
 // way.
 const ComplianceCheckResultStatusLabel = "compliance.openshift.io/check-status"
 const ComplianceCheckResultSeverityLabel = "compliance.openshift.io/check-severity"
+const ComplianceCheckResultValueLabel = "compliance.openshift.io/check-has-value"
 
 // ComplianceCheckResultLabel defines a label that will be included in the
 // ComplianceCheckResult objects. It indicates whether the result has an automated
@@ -92,6 +93,8 @@ type ComplianceCheckResult struct {
 	// Any warnings that the user should be aware about.
 	// +nullable
 	Warnings []string `json:"warnings,omitempty"`
+	// It stores a list of values used by the check
+	ValuesUsed []string `json:"valuesUsed,omitempty"`
 }
 
 // IDToDNSFriendlyName gets the ID from the scan and returns a DNS

--- a/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
@@ -20,6 +20,11 @@ func (in *ComplianceCheckResult) DeepCopyInto(out *ComplianceCheckResult) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ValuesUsed != nil {
+		in, out := &in.ValuesUsed, &out.ValuesUsed
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Added a new attribute `ValuesUsed` into `ComplianceCheckResult` that contains a string slice with all the associate settable variables for a rule