### PR TITLE
Remove Variable Selection check for tailor profile 

### DIFF
--- a/pkg/apis/compliance/v1alpha1/variable_test.go
+++ b/pkg/apis/compliance/v1alpha1/variable_test.go
@@ -75,10 +75,10 @@ var _ = Describe("Testing variables API", func() {
 			Expect(v.Value).To(BeEquivalentTo("ringo"))
 		})
 
-		It("denied values are not used", func() {
+		It("custom values are used", func() {
 			err := v.SetValue("ringo_deathstarr")
-			Expect(err).ToNot(BeNil())
-			Expect(v.Value).To(BeEquivalentTo("john"))
+			Expect(err).To(BeNil())
+			Expect(v.Value).To(BeEquivalentTo("ringo_deathstarr"))
 		})
 	})
 
@@ -141,10 +141,10 @@ var _ = Describe("Testing variables API", func() {
 			Expect(v.Value).To(BeEquivalentTo("84"))
 		})
 
-		It("disallowed values are not used", func() {
+		It("custom allowed values are used", func() {
 			err := v.SetValue("123")
-			Expect(err).ToNot(BeNil())
-			Expect(v.Value).To(BeEquivalentTo("42"))
+			Expect(err).To(BeNil())
+			Expect(v.Value).To(BeEquivalentTo("123"))
 		})
 	})
 })

--- a/pkg/apis/compliance/v1alpha1/variable_types.go
+++ b/pkg/apis/compliance/v1alpha1/variable_types.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,11 +60,6 @@ func (v *Variable) SetValue(val string) error {
 	if err := v.validateType(val); err != nil {
 		return err
 	}
-
-	if err := v.validateValue(val); err != nil {
-		return err
-	}
-
 	v.Value = val
 	return nil
 }
@@ -87,20 +81,6 @@ func (v *Variable) validateType(val string) error {
 	}
 
 	return err
-}
-
-func (v *Variable) validateValue(val string) error {
-	if len(v.Selections) == 0 {
-		return nil
-	}
-
-	for _, av := range v.Selections {
-		if av.Value == val {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("value %s is not allowed, use one of %v", val, v.Selections)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
To enable the use of custom variable for remediation templating, we need to remove the Variable Selection check so that user can use any values for variables doing both scan and remediation 