### PR TITLE
Disallow empty titles and descriptions for tailored profiles

### DIFF
--- a/deploy/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
@@ -40,7 +40,8 @@ spec:
             description: TailoredProfileSpec defines the desired state of TailoredProfile
             properties:
               description:
-                description: Overwrites the description of the extended profile
+                description: Description of tailored profile. It can't be empty.
+                pattern: ^.+$
                 type: string
               disableRules:
                 description: Disables the referenced rules
@@ -104,8 +105,12 @@ spec:
                 nullable: true
                 type: array
               title:
-                description: Overwrites the title of the extended profile
+                description: Title for the tailored profile. It can't be empty.
+                pattern: ^.+$
                 type: string
+            required:
+            - description
+            - title
             type: object
           status:
             description: TailoredProfileStatus defines the observed state of TailoredProfile

--- a/pkg/apis/compliance/v1alpha1/tailoredprofile_types.go
+++ b/pkg/apis/compliance/v1alpha1/tailoredprofile_types.go
@@ -29,10 +29,12 @@ type TailoredProfileSpec struct {
 	// +optional
 	// Points to the name of the profile to extend
 	Extends string `json:"extends,omitempty"`
-	// Overwrites the title of the extended profile
-	Title string `json:"title,omitempty"`
-	// Overwrites the description of the extended profile
-	Description string `json:"description,omitempty"`
+	// Title for the tailored profile. It can't be empty.
+	// +kubebuilder:validation:Pattern=^.+$
+	Title string `json:"title"`
+	// Description of tailored profile. It can't be empty.
+	// +kubebuilder:validation:Pattern=^.+$
+	Description string `json:"description"`
 	// Enables the referenced rules
 	// +optional
 	// +nullable

--- a/pkg/xccdf/tailoring.go
+++ b/pkg/xccdf/tailoring.go
@@ -51,8 +51,8 @@ type ProfileElement struct {
 	XMLName     xml.Name                   `xml:"xccdf-1.2:Profile"`
 	ID          string                     `xml:"id,attr"`
 	Extends     string                     `xml:"extends,attr,omitempty"`
-	Title       *TitleOrDescriptionElement `xml:"xccdf-1.2:title,omitempty"`
-	Description *TitleOrDescriptionElement `xml:"xccdf-1.2:description,omitempty"`
+	Title       *TitleOrDescriptionElement `xml:"xccdf-1.2:title"`
+	Description *TitleOrDescriptionElement `xml:"xccdf-1.2:description"`
 	Selections  []SelectElement
 	Values      []SetValueElement
 }


### PR DESCRIPTION
These settings are actually required by the tailored profile, so let's
instead validate them appropriately instead of silently failing.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>