### PR TITLE
Release v0.1.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.40] - 2021-09-09
+### Changes
+- Remove tailorprofile variable selection check
+- Disallow empty titles and descriptions for tailored profiles
+- Restart profileparser on failures
+- Skip e2e TestNodeSchedulingErrorFailsTheScan for now
+- Make default scanTolerations more tolerant
+- e2e: Migrate TestScanProducesRemediations to use ScanSettingBinding
+- Associate variable with compliance check result
+- Enable Creation of TailoredProfiles without extending existing ones
+- Don't shadow an import with a variable name
+- compliancescan: Fill the <target> element and the urn:xccdf:fact:identifier for node checks
+- Remove dead code
+- Add supoort for remediation templating for operator
+
 ## [0.1.39] - 2021-08-23
 ### Changes
 - Allow profileparser to parse PCI-DSS references

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.39'
+    olm.skipRange: '>=0.1.17 <0.1.40'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.39
+  name: compliance-operator.v0.1.40
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1141,10 +1141,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.4
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.39
+                  value: quay.io/compliance-operator/compliance-operator:0.1.40
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.39
+                image: quay.io/compliance-operator/compliance-operator:0.1.40
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources:
@@ -1481,4 +1481,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.39
+  version: 0.1.40

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancecheckresults_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancecheckresults_crd.yaml
@@ -58,6 +58,11 @@ spec:
           status:
             description: The result of a check
             type: string
+          valuesUsed:
+            description: It stores a list of values used by the check
+            items:
+              type: string
+            type: array
           warnings:
             description: Any warnings that the user should be aware about.
             items:

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancescans_crd.yaml
@@ -131,13 +131,11 @@ spec:
                 type: string
               scanTolerations:
                 default:
-                - effect: NoSchedule
-                  key: node-role.kubernetes.io/master
-                  operator: Exists
+                - operator: Exists
                 description: Specifies tolerations needed for the scan to run on the
                   nodes. This is useful in case the target set of nodes have custom
                   taints that don't allow certain workloads to run. Defaults to allowing
-                  scheduling on the master nodes.
+                  scheduling on all nodes.
                 items:
                   description: The pod this Toleration is attached to tolerates any
                     taint that matches the triple <key,value,effect> using the matching

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancesuites_crd.yaml
@@ -155,13 +155,11 @@ spec:
                       type: string
                     scanTolerations:
                       default:
-                      - effect: NoSchedule
-                        key: node-role.kubernetes.io/master
-                        operator: Exists
+                      - operator: Exists
                       description: Specifies tolerations needed for the scan to run
                         on the nodes. This is useful in case the target set of nodes
                         have custom taints that don't allow certain workloads to run.
-                        Defaults to allowing scheduling on the master nodes.
+                        Defaults to allowing scheduling on all nodes.
                       items:
                         description: The pod this Toleration is attached to tolerates
                           any taint that matches the triple <key,value,effect> using

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_scansettings_crd.yaml
@@ -105,13 +105,11 @@ spec:
             type: array
           scanTolerations:
             default:
-            - effect: NoSchedule
-              key: node-role.kubernetes.io/master
-              operator: Exists
+            - operator: Exists
             description: Specifies tolerations needed for the scan to run on the nodes.
               This is useful in case the target set of nodes have custom taints that
               don't allow certain workloads to run. Defaults to allowing scheduling
-              on the master nodes.
+              on all nodes.
             items:
               description: The pod this Toleration is attached to tolerates any taint
                 that matches the triple <key,value,effect> using the matching operator

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_tailoredprofiles_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_tailoredprofiles_crd.yaml
@@ -41,7 +41,8 @@ spec:
             description: TailoredProfileSpec defines the desired state of TailoredProfile
             properties:
               description:
-                description: Overwrites the description of the extended profile
+                description: Description of tailored profile. It can't be empty.
+                pattern: ^.+$
                 type: string
               disableRules:
                 description: Disables the referenced rules
@@ -105,10 +106,12 @@ spec:
                 nullable: true
                 type: array
               title:
-                description: Overwrites the title of the extended profile
+                description: Title for the tailored profile. It can't be empty.
+                pattern: ^.+$
                 type: string
             required:
-            - extends
+            - description
+            - title
             type: object
           status:
             description: TailoredProfileStatus defines the observed state of TailoredProfile

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.39"
+	Version = "0.1.40"
 )


### PR DESCRIPTION
## [0.1.40] - 2021-09-09
### Changes
- Remove tailorprofile variable selection check
- Disallow empty titles and descriptions for tailored profiles
- Restart profileparser on failures
- Skip e2e TestNodeSchedulingErrorFailsTheScan for now
- Make default scanTolerations more tolerant
- e2e: Migrate TestScanProducesRemediations to use ScanSettingBinding
- Associate variable with compliance check result
- Enable Creation of TailoredProfiles without extending existing ones
- Don't shadow an import with a variable name
- compliancescan: Fill the <target> element and the urn:xccdf:fact:identifier for node checks
- Remove dead code
- Add supoort for remediation templating for operator