### PR TITLE
Add instructions and check type to Rule object

### DIFF
--- a/deploy/crds/compliance.openshift.io_rules_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_rules_crd.yaml
@@ -43,11 +43,18 @@ spec:
             nullable: true
             type: array
             x-kubernetes-list-type: atomic
+          checkType:
+            description: 'What type of check will this rule execute: Platform, Node
+              or none (represented by an empty string)'
+            type: string
           description:
             description: The description of the Rule
             type: string
           id:
             description: The XCCDF ID
+            type: string
+          instructions:
+            description: Instructions for auditing this specific rule
             type: string
           kind:
             description: 'Kind is a string value representing the REST resource this

--- a/pkg/apis/compliance/v1alpha1/rule_types.go
+++ b/pkg/apis/compliance/v1alpha1/rule_types.go
@@ -11,6 +11,12 @@ import (
 // here or in the compliance-operator?
 const RuleIDAnnotationKey = "compliance.openshift.io/rule"
 
+const (
+	CheckTypePlatform = "Platform"
+	CheckTypeNode     = "Node"
+	CheckTypeNone     = ""
+)
+
 type RulePayload struct {
 	// The XCCDF ID
 	ID string `json:"id"`
@@ -24,6 +30,11 @@ type RulePayload struct {
 	Warning string `json:"warning,omitempty"`
 	// The severity level
 	Severity string `json:"severity,omitempty"`
+	// Instructions for auditing this specific rule
+	Instructions string `json:"instructions,omitempty"`
+	// What type of check will this rule execute:
+	// Platform, Node or none (represented by an empty string)
+	CheckType string `json:"checkType,omitempty"`
 	// The Available fixes
 	// +nullable
 	// +optional

--- a/pkg/profileparser/profileparser_test.go
+++ b/pkg/profileparser/profileparser_test.go
@@ -318,13 +318,25 @@ var _ = Describe("Testing ParseBundle", func() {
 			Expect(moderateProfilePre.Rules).To(HaveLen(len(moderateProfilePost.Rules) + 2))
 		})
 
-		It("Detects that a rule has changed severity", func() {
-			ruleChangedSeverityPost := &cmpv1alpha1.Rule{}
-			key := types.NamespacedName{Namespace: testNamespace, Name: chronydMaxpollRuleName}
-			err := client.Get(context.TODO(), key, ruleChangedSeverityPost)
-			Expect(err).To(BeNil())
+		When("Fetching the rule", func() {
+			var fetchedRule *cmpv1alpha1.Rule
+			JustBeforeEach(func() {
+				fetchedRule = &cmpv1alpha1.Rule{}
+				key := types.NamespacedName{Namespace: testNamespace, Name: chronydMaxpollRuleName}
+				err := client.Get(context.TODO(), key, fetchedRule)
+				Expect(err).To(BeNil())
+			})
+			It("Detects that a rule has changed severity", func() {
+				Expect(fetchedRule.Severity).ToNot(BeEquivalentTo(ruleChangedSeverityPre.Severity))
+			})
 
-			Expect(ruleChangedSeverityPost.Severity).ToNot(BeEquivalentTo(ruleChangedSeverityPre.Severity))
+			It("Detect that a rule is of type Node", func() {
+				Expect(fetchedRule.CheckType).To(BeEquivalentTo(cmpv1alpha1.CheckTypeNode))
+			})
+
+			It("Detect that a rule has instructions", func() {
+				Expect(fetchedRule.Instructions).ToNot(BeEmpty())
+			})
 		})
 	})
 


### PR DESCRIPTION
This enables folks browsing the rules to know what type of check will a
specific rule do and how to manually audit it without having to run a
scan.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>