### PR TITLE
e2e: Mark logging functions as helper functions

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -100,18 +100,22 @@ type mcTestCtx struct {
 }
 
 func E2ELogf(t *testing.T, format string, args ...interface{}) {
+	t.Helper()
 	t.Logf(fmt.Sprintf("%s: %s", time.Now().Format(time.RFC3339), format), args...)
 }
 
 func E2ELog(t *testing.T, args ...interface{}) {
+	t.Helper()
 	t.Log(fmt.Sprintf("%s: %s", time.Now().Format(time.RFC3339), fmt.Sprint(args...)))
 }
 
 func E2EErrorf(t *testing.T, format string, args ...interface{}) {
+	t.Helper()
 	t.Errorf(fmt.Sprintf("E2E-FAILURE: %s: %s", time.Now().Format(time.RFC3339), format), args...)
 }
 
 func E2EFatalf(t *testing.T, format string, args ...interface{}) {
+	t.Helper()
 	t.Fatalf(fmt.Sprintf("E2E-FAILURE: %s: %s", time.Now().Format(time.RFC3339), format), args...)
 }
 


### PR DESCRIPTION
This ensures that we get the relevant log lines in our test output when
using the logging functions

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>