### PR TITLE
Specify fsgroup, user and non-root user usage in resultserver

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -137,6 +137,7 @@ rules:
   - ""
   resources:
   - nodes  # We need to list the nodes to be able to selectively scan
+  - namespaces # We need this to get the range
   verbs:
   - list
   - watch

--- a/pkg/controller/compliancescan/compliancescan_controller_test.go
+++ b/pkg/controller/compliancescan/compliancescan_controller_test.go
@@ -3,6 +3,7 @@ package compliancescan
 import (
 	"context"
 	"fmt"
+
 	"github.com/openshift/compliance-operator/pkg/controller/metrics"
 	"github.com/openshift/compliance-operator/pkg/controller/metrics/metricsfakes"
 
@@ -73,7 +74,13 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 		serverSecret, _ := serverCertSecret(compliancescaninstance, caSecret.Data[corev1.TLSCertKey], caSecret.Data[corev1.TLSPrivateKeyKey], common.GetComplianceOperatorNamespace())
 		clientSecret, _ := clientCertSecret(compliancescaninstance, caSecret.Data[corev1.TLSCertKey], caSecret.Data[corev1.TLSPrivateKeyKey], common.GetComplianceOperatorNamespace())
 
-		objs = append(objs, nodeinstance1, nodeinstance2, caSecret, serverSecret, clientSecret)
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: common.GetComplianceOperatorNamespace(),
+			},
+		}
+
+		objs = append(objs, nodeinstance1, nodeinstance2, caSecret, serverSecret, clientSecret, ns)
 		scheme := scheme.Scheme
 		scheme.AddKnownTypes(compv1alpha1.SchemeGroupVersion, compliancescaninstance)
 


### PR DESCRIPTION
This helps us run the result server in other distros that aren't
openshift.

For OpenShift, we need to select the FSGroup and UID from the approved
range which is available in the namespace's annotations; if it's not
available, we'll just choose a default.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>