### PR TITLE
Gather /version when doing Platform scans

### DIFF
--- a/cmd/manager/scap.go
+++ b/cmd/manager/scap.go
@@ -139,6 +139,10 @@ func (c *scapContentDataStream) FigureResources(profile string) error {
 	// Always stage the clusteroperators/openshift-apiserver object for version detection.
 	found := []utils.ResourcePath{
 		{
+			ObjPath:  "/version",
+			DumpPath: "/version",
+		},
+		{
 			ObjPath:  "/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver",
 			DumpPath: "/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver",
 		},


### PR DESCRIPTION
For other kubernetes distros, we rely on the version given by the kube
api server in order to determine the CPE in SCAP. Let's gather this
endpoint always as it's harmless and helps us scan other kube distros.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>