### PR TITLE
Release v0.1.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.41] - 2021-09-20
+### Changes
+- Specify fsgroup, user and non-root user usage in resultserver
+- Gather /version when doing Platform scans
+- Add flag to skip the metrics deployment
+- fetch openscap version during build time
+- Add instructions and check type to Rule object
+- e2e: Mark logging functions as helper functions
+- Makefile: Rename IMAGE_FORMAT var
+- add support for multi line remediation
+- Fix value-required handling.
+- Use ClusterRole/ClusterRoleBinding for monitoring permissions
+
 ## [0.1.40] - 2021-09-09
 ### Changes
 - Remove tailorprofile variable selection check

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.40'
+    olm.skipRange: '>=0.1.17 <0.1.41'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.40
+  name: compliance-operator.v0.1.41
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -233,7 +233,31 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - pods
+          - services
+          - endpoints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+        - nonResourceURLs:
+          - /metrics
+          - /metrics-co
+          verbs:
+          - get
+        serviceAccountName: compliance-operator-metrics
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
           - nodes
+          - namespaces
           verbs:
           - list
           - watch
@@ -1141,10 +1165,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.4
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.40
+                  value: quay.io/compliance-operator/compliance-operator:0.1.41
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.40
+                image: quay.io/compliance-operator/compliance-operator:0.1.41
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources:
@@ -1442,18 +1466,6 @@ spec:
           - update
           - delete
         serviceAccountName: profileparser
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
-          - services
-          - endpoints
-          - pods
-          verbs:
-          - get
-          - list
-          - watch
-        serviceAccountName: prometheus-k8s
     strategy: deployment
   installModes:
   - supported: true
@@ -1481,4 +1493,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.40
+  version: 0.1.41

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_rules_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_rules_crd.yaml
@@ -44,11 +44,18 @@ spec:
             nullable: true
             type: array
             x-kubernetes-list-type: atomic
+          checkType:
+            description: 'What type of check will this rule execute: Platform, Node
+              or none (represented by an empty string)'
+            type: string
           description:
             description: The description of the Rule
             type: string
           id:
             description: The XCCDF ID
+            type: string
+          instructions:
+            description: Instructions for auditing this specific rule
             type: string
           kind:
             description: 'Kind is a string value representing the REST resource this

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.40"
+	Version = "0.1.41"
 )


### PR DESCRIPTION
## [0.1.41] - 2021-09-20
### Changes
- Specify fsgroup, user and non-root user usage in resultserver
- Gather /version when doing Platform scans
- Add flag to skip the metrics deployment
- fetch openscap version during build time
- Add instructions and check type to Rule object
- e2e: Mark logging functions as helper functions
- Makefile: Rename IMAGE_FORMAT var
- add support for multi line remediation
- Fix value-required handling.
- Use ClusterRole/ClusterRoleBinding for monitoring permissions
