### PR TITLE
Add description to TailoredProfile yaml

### DIFF
--- a/doc/tutorials/workshop/content/exercises/05-tailoring-profiles.md
+++ b/doc/tutorials/workshop/content/exercises/05-tailoring-profiles.md
@@ -28,6 +28,7 @@ metadata:
   name: rhcos4-no-kptr-restrict
   namespace: openshift-compliance
 spec:
+  description: test tailored profile
   extends: rhcos4-e8
   title: RHCOS4 E8 profile disables the kptr-restrict rule
   disableRules:


### PR DESCRIPTION
In tutorial exercises/05-tailored-profile.md when trying to deploy the current yaml, oc create errors with `The TailoredProfile "rhcos4-no-kptr-restrict" is invalid: spec.description: Required value`

This fix adds a description allowing the TailoredProfile to deploy