### PR TITLE
aggregator: Remove MachineConfig validation

### DIFF
--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -297,14 +297,6 @@ func canCreateRemediationObject(scan *compv1alpha1.ComplianceScan, obj *unstruct
 		return false, "The remediaiton yaml file is empty"
 	}
 
-	if obj.GetObjectKind().GroupVersionKind().Kind != "MachineConfig" {
-		return true, ""
-	}
-
-	role := utils.GetFirstNodeRole(scan.Spec.NodeSelector)
-	if role == "" {
-		return false, "ComplianceScan's nodeSelector doesn't have any role. Ideally this needs to match a MachineConfigPool"
-	}
 	return true, ""
 }
 


### PR DESCRIPTION
we don't need to do this in the aggregator, the validation is ran anyway
on the remediation controller. This way we can actually show to the user
why a MachineConfig remediation wasn't able to be created.

With this, the aggregator is just a "simple" program that aggregated and
creates remediations, no extra magic.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>