### PR TITLE
Validate that rules in tailored profile are of appropriate type

### DIFF
--- a/deploy/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
@@ -115,7 +115,7 @@ spec:
           status:
             description: TailoredProfileStatus defines the observed state of TailoredProfile
             properties:
-              errorMessagae:
+              errorMessage:
                 type: string
               id:
                 description: The XCCDF ID of the tailored profile

--- a/pkg/apis/compliance/v1alpha1/tailoredprofile_types.go
+++ b/pkg/apis/compliance/v1alpha1/tailoredprofile_types.go
@@ -69,7 +69,7 @@ type TailoredProfileStatus struct {
 	OutputRef OutputRef `json:"outputRef,omitempty"`
 	// The current state of the tailored profile
 	State        TailoredProfileState `json:"state,omitempty"`
-	ErrorMessage string               `json:"errorMessagae,omitempty"`
+	ErrorMessage string               `json:"errorMessage,omitempty"`
 }
 
 // OutputRef is a reference to the object created from the tailored profile

--- a/pkg/controller/tailoredprofile/tailoredprofile_controller.go
+++ b/pkg/controller/tailoredprofile/tailoredprofile_controller.go
@@ -171,6 +171,12 @@ func (r *ReconcileTailoredProfile) Reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, ruleErr
 	}
 
+	if ruleValidErr := assertValidRuleTypes(rules); ruleValidErr != nil {
+		// Surface the error.
+		suerr := r.updateTailoredProfileStatusError(instance, ruleValidErr)
+		return reconcile.Result{}, suerr
+	}
+
 	variables, varErr := r.getVariablesFromSelections(instance, pb)
 	if varErr != nil && !common.IsRetriable(varErr) {
 		// Surface the error.
@@ -460,4 +466,29 @@ func isOwnedBy(obj, owner metav1.Object) bool {
 		}
 	}
 	return false
+}
+
+func assertValidRuleTypes(rules map[string]*cmpv1alpha1.Rule) error {
+	// Figure out
+	var expectedCheckType string
+	for _, rule := range rules {
+		// cmpv1alpha1.CheckTypeNone fits every type since it's
+		// merely informational
+		if rule.CheckType == cmpv1alpha1.CheckTypeNone {
+			continue
+		}
+		// Initialize expected check type
+		if expectedCheckType == "" {
+			expectedCheckType = rule.CheckType
+			// No need to compare if we're just initializing the
+			// expectation
+			continue
+		}
+
+		if expectedCheckType != rule.CheckType {
+			return common.NewNonRetriableCtrlError("Rule '%s' with type '%s' didn't match expected type: %s",
+				rule.GetName(), rule.CheckType, expectedCheckType)
+		}
+	}
+	return nil
 }

--- a/pkg/controller/tailoredprofile/tailoredprofile_controller.go
+++ b/pkg/controller/tailoredprofile/tailoredprofile_controller.go
@@ -268,7 +268,7 @@ func (r *ReconcileTailoredProfile) getProfileBundleFromRulesOrVars(tp *cmpv1alph
 }
 
 func (r *ReconcileTailoredProfile) getRulesFromSelections(tp *cmpv1alpha1.TailoredProfile, pb *cmpv1alpha1.ProfileBundle) (map[string]*cmpv1alpha1.Rule, error) {
-	rules := make(map[string]*cmpv1alpha1.Rule)
+	rules := make(map[string]*cmpv1alpha1.Rule, len(tp.Spec.EnableRules)+len(tp.Spec.DisableRules))
 	for _, selection := range append(tp.Spec.EnableRules, tp.Spec.DisableRules...) {
 		_, ok := rules[selection.Name]
 		if ok {


### PR DESCRIPTION
This PR now validates that the rules added to a tailored profile belong
to a relevant type.

As we know, we have the following types:

* **Platform**: Runs on the platform, do k8s checks.
* **Node**: Runs on the node itself.
* **None**: Informational.

When building a tailored profile, we want there only to be rules that
are gonna be relevant and run as the user expects. Here, you can mix and
match the following:

* Platform rules and None rules
* Node rules and None rules

but nothing in between. Platform and Node rules shouldn't mix.

With this validation, users will now see an error in the tailored
profile and will not build tailored profiles that don't do what they
want.