### PR TITLE
Remove Benchmark unit tests

### DIFF
--- a/pkg/profileparser/profileparser_test.go
+++ b/pkg/profileparser/profileparser_test.go
@@ -654,21 +654,3 @@ var _ = Describe("Testing CPE string parsing in isolation", func() {
 		})
 	})
 })
-
-var _ = Describe("Performance", func() {
-	BeforeEach(func() {
-		Expect(pInput.contentDom).NotTo(BeNil())
-	})
-
-	Context("Testing parsing profiles", func() {
-		Measure("it should parse profiles efficiently", func(b Benchmarker) {
-			rtime := b.Time("runtime", func() {
-				err := ParseBundle(pInput.contentDom, pInput.pb, pInput.pcfg)
-				Expect(err).To(BeNil())
-			})
-
-			Ω(rtime.Seconds()).Should(BeNumerically("<", 1.2), "ParseProfilesAndDo() shouldn't take too long.")
-		}, 1000)
-
-	})
-})

--- a/pkg/utils/parse_arf_result_test.go
+++ b/pkg/utils/parse_arf_result_test.go
@@ -403,38 +403,4 @@ Server 3.fedora.pool.ntp.org`
 			})
 		})
 	})
-
-	Describe("Benchmark loading the XCCFD and the DS", func() {
-		BeforeEach(func() {
-			mcInstance := &mcfgv1.MachineConfig{}
-			schema = scheme.Scheme
-			schema.AddKnownTypes(mcfgv1.SchemeGroupVersion, mcInstance)
-			resultsFilename = "../../tests/data/xccdf-result.xml"
-			dsFilename = "../../tests/data/ds-input.xml"
-		})
-
-		JustBeforeEach(func() {
-			xccdf, err = os.Open(resultsFilename)
-			Expect(err).NotTo(HaveOccurred())
-
-			ds, err = os.Open(dsFilename)
-			Expect(err).NotTo(HaveOccurred())
-
-		})
-
-		Context("Valid XCCDF and DS with remediations", func() {
-			Measure("Should parse the XCCDF and DS without errors", func(b Benchmarker) {
-				runtime := b.Time("runtime", func() {
-					dsDom, err := ParseContent(ds)
-					Expect(err).NotTo(HaveOccurred())
-					resultList, err = ParseResultsFromContentAndXccdf(schema, "testScan", "testNamespace", dsDom, xccdf)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(nRems).To(Equal(totalRemediations))
-					Expect(nChecks).To(Equal(totalChecks))
-				})
-
-				Ω(runtime.Seconds()).Should(BeNumerically("<", 3.0), "ParseRemediationsFromArf() shouldn't take too long.")
-			}, 100)
-		})
-	})
 })


### PR DESCRIPTION
the `Measure` directive will be removed from Ginkgo v2.

Instead of migrating to something else, this removes the Benchmark tests
entirely. The coverage we were getting out of them is questionable and
we also didn't see much benefit from them from a resource measurement
perspective.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>