### PR TITLE
Fix needs-review unpause pool

### DIFF
--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -495,6 +495,10 @@ func (r *ReconcileComplianceSuite) reconcileRemediations(suite *compv1alpha1.Com
 	// Check that all remediations have been applied yet. If not, requeue.
 	for _, rem := range postProcessRemList.Items {
 		if !rem.IsApplied() {
+			if rem.Status.ApplicationState == compv1alpha1.RemediationNeedsReview {
+				r.recorder.Event(suite, corev1.EventTypeWarning, "CannotRemediate", "Remediation needs-review. Values not set"+" Remediation:"+rem.Name)
+				continue
+			}
 			logger.Info("Remediation not applied yet. Skipping post-processing", "ComplianceRemediation.Name", rem.Name)
 			return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
 		}


### PR DESCRIPTION
This PR fixes the bug that the MachineConfig Pool will not be unpaused when there is a remediation that has value not set caused by either missing a required value or a parsed xccdf value can not be found from ResultCM.