### PR TITLE
Makefile: Add push-openscap-image target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,6 +441,11 @@ push-index: index-image
 	# index image
 	$(RUNTIME) push $(INDEX_IMAGE_PATH):latest
 
+.PHONY: push-openscap-image
+push-openscap-image: openscap-image
+	# openscap image
+	$(RUNTIME) push $(RELATED_IMAGE_OPENSCAP_PATH):$(RELATED_IMAGE_OPENSCAP_TAG)
+
 .PHONY: check-operator-version
 check-operator-version:
 ifndef OPERATOR_VERSION


### PR DESCRIPTION
I just ran this target so `quay.io/compliance-operator/openscap-ocp:latest` now has the addition of the version file.
@JAORMX @jhrozek 