### PR TITLE
docs: Document the default-auto-apply ScanSetting

### DIFF
--- a/doc/crds.md
+++ b/doc/crds.md
@@ -751,6 +751,13 @@ The following attributes can be set in the `ScanSetting:
   should be scheduled on. Internally, each `Profile` or `TailoredProfile` in a
    `ScanSettingBinding` creates a `ComplianceScan` for each role specified in this attribute.
 
+The Compliance Operator creates two `ScanSetting` objects on startup:
+ * **default**: a ScanSetting that would run a scan every day at 1AM on both masters and workers,
+   using a 1GBi PV and keeping the last three results. Remediations are neither applied nor updated
+   automatically.
+ * **default-auto-apply**: As above, except both autoApplyRemediations and autoUpdateRemediations
+   are set to true.
+
  When the above objects are created, the result are a suite and three scans:
 ```
 $ oc get compliancesuites

--- a/doc/remediation-flow.md
+++ b/doc/remediation-flow.md
@@ -133,7 +133,8 @@ Coming from the administrator side, the admin would define the
 that itself unrolls into one or more `ComplianceScan` objects.
 After the scans finish, `ComplianceCheckResult` objects are generated for
 each test in the scan and a `ComplianceRemediation` object for every gap
-that can be remediated automatically.
+that can be remediated automatically. Note that two `ScanSettings` objects are
+provided by default by the operator.
 
 The `ComplianceRemediation` objects would link back to the `suite` with
 labels that identify the suite and the scan respectively. This way, the
@@ -268,7 +269,9 @@ It's possible to tell the Compliance Operator that, if a remediation is created 
 it should attempt to apply it. This is done through the `autoApplyRemediations` flag which is
 available in both the `ScanSettings` and the `ComplianceSuite` itself. If this is enabled,
 the operator will apply the remediations belonging to a scan once the ComplianceSuite reaches
-the `Done` phase. To avoid multiple reboots, the Compliance Operator would pause the 
+the `Done` phase. To avoid multiple reboots, the Compliance Operator would pause the
+MachineConfigPools until the remediations are applied. There also exists a `ScanSettingBinding`
+named "default-auto-apply" that can be used to generate scans that auto-apply remediations.
 
 #### Remediations with dependencies
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -97,6 +97,10 @@ settingsRef:
   kind: ScanSetting
   apiGroup: compliance.openshift.io/v1alpha1
 ```
+
+Note that the operator creates two `ScanSetting` objects by default for
+convenience.
+
 Both `ScanSetting` and `ScanSettingBinding` objects are handled by the
 same controller tagged with `logger=scansettingbindingctrl`.  These objects
 have no status, any issues are communicated in form of events. On success,


### PR DESCRIPTION
Improves our upstream docs by mentioning the default and default-auto-apply ScanSetting objects.