### PR TITLE
Release v0.1.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.42] - 2021-10-04
+### Changes
+- add error to the result object as comment (#721)
+- docs: Document the default-auto-apply ScanSetting
+- Makefile: Add push-openscap-image target
+- Proposal for Kubelet Config Remediation
+- fix needs-review unpause pool
+- add openscap image build
+- Update 06-troubleshooting.md
+- Remove Benchmark unit tests
+- Validate that rules in tailored profile are of appropriate type
+- TailoredProfiles: Allocate rules map with expected number of items
+- Fix error message json representation in CRD
+- aggregator: Remove MachineConfig validation
+- Add description to TailoredProfile yaml
+
 ## [0.1.41] - 2021-09-20
 ### Changes
 - Specify fsgroup, user and non-root user usage in resultserver

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.41'
+    olm.skipRange: '>=0.1.17 <0.1.42'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.41
+  name: compliance-operator.v0.1.42
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1163,12 +1163,12 @@ spec:
                 - name: OPERATOR_NAME
                   value: compliance-operator
                 - name: RELATED_IMAGE_OPENSCAP
-                  value: quay.io/compliance-operator/openscap-ocp:1.3.4
+                  value: quay.io/compliance-operator/openscap-ocp:latest
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.41
+                  value: quay.io/compliance-operator/compliance-operator:0.1.42
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.41
+                image: quay.io/compliance-operator/compliance-operator:0.1.42
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources:
@@ -1493,4 +1493,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.41
+  version: 0.1.42

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_tailoredprofiles_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_tailoredprofiles_crd.yaml
@@ -116,7 +116,7 @@ spec:
           status:
             description: TailoredProfileStatus defines the observed state of TailoredProfile
             properties:
-              errorMessagae:
+              errorMessage:
                 type: string
               id:
                 description: The XCCDF ID of the tailored profile

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.41"
+	Version = "0.1.42"
 )


### PR DESCRIPTION
## [0.1.42] - 2021-10-04
### Changes
- add error to the result object as comment (#721)
- docs: Document the default-auto-apply ScanSetting
- Makefile: Add push-openscap-image target
- Proposal for Kubelet Config Remediation
- fix needs-review unpause pool
- add openscap image build
- Update 06-troubleshooting.md
- Remove Benchmark unit tests
- Validate that rules in tailored profile are of appropriate type
- TailoredProfiles: Allocate rules map with expected number of items
- Fix error message json representation in CRD
- aggregator: Remove MachineConfig validation
- Add description to TailoredProfile yaml