### PR TITLE
Add permission for checking the kubeadmin user

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1183,3 +1183,12 @@ rules:
   - get
   - watch
   - list
+# Necessary for checking that the kubeadmin secret has been removed
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - kubeadmin
+  verbs:
+  - get

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -387,6 +387,8 @@ rules:
 # because the OLM doesn't support adding labels to roles nor specifying
 # roleRefs
 # See: https://github.com/operator-framework/operator-lifecycle-manager/issues/732
+# As an addition, this role is also able to read the kubeadmin secret
+# with the main intent to check that it's been removed.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
This adds the necessary RBAC permission for checking if the kubeadmin
secret exists. The intent is to verify that it has been removed, as done
in the accompanying CaC PR [1]. This is possible thanks to the recent
addition that enables us to persist if kube returned NotFound for a
specific object [2].

[1] https://github.com/ComplianceAsCode/content/pull/7723
[2] Commit f200ae00f32ea29670cfa67ee802109b0a0709e2

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>