### PR TITLE
Switch to using openscap 1.3.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ else ifeq ($(RUNTIME), docker)
 endif
 
 # Temporary
-RELATED_IMAGE_OPENSCAP_TAG?=latest
+RELATED_IMAGE_OPENSCAP_TAG?=1.3.5
 
 # Image path to use. Set this if you want to use a specific path for building
 # or your e2e tests. This is overwritten if we bulid the image and push it to

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -45,7 +45,7 @@ spec:
               value: "compliance-operator"
             - name: RELATED_IMAGE_OPENSCAP
               # Hardcoding this temporarily until its propagated to CI
-              value: "quay.io/compliance-operator/openscap-ocp:latest"
+              value: "quay.io/compliance-operator/openscap-ocp:1.3.5"
             - name: RELATED_IMAGE_OPERATOR
               value: "quay.io/compliance-operator/compliance-operator:latest"
             - name: RELATED_IMAGE_PROFILE

--- a/images/openscap/Dockerfile
+++ b/images/openscap/Dockerfile
@@ -8,6 +8,18 @@ LABEL \
     io.openshift.tags="compliance openscap scan" \
     io.openshift.wants="scap-content"
 
+RUN echo $'[openscap-1-3-5-copr]\n\
+name=Copr repo for openscap-1-3-5 owned by jhrozek\n\
+baseurl=https://download.copr.fedorainfracloud.org/results/jhrozek/openscap-1-3-5/epel-8-$basearch/\n\
+type=rpm-md\n\
+skip_if_unavailable=True\n\
+gpgcheck=1\n\
+gpgkey=https://download.copr.fedorainfracloud.org/results/jhrozek/openscap-1-3-5/pubkey.gpg\n\
+repo_gpgcheck=0\n\
+enabled=1\n\
+enabled_metadata=1\n '\
+>> /etc/yum.repos.d/openscap.repo
+
 RUN true \
     && microdnf install -y openscap-scanner \
     && microdnf clean all \

--- a/images/openscap/Dockerfile.ci
+++ b/images/openscap/Dockerfile.ci
@@ -8,6 +8,18 @@ LABEL \
     io.openshift.tags="compliance openscap scan" \
     io.openshift.wants="scap-content"
 
+RUN echo $'[openscap-1-3-5-copr]\n\
+name=Copr repo for openscap-1-3-5 owned by jhrozek\n\
+baseurl=https://download.copr.fedorainfracloud.org/results/jhrozek/openscap-1-3-5/epel-8-$basearch/\n\
+type=rpm-md\n\
+skip_if_unavailable=True\n\
+gpgcheck=1\n\
+gpgkey=https://download.copr.fedorainfracloud.org/results/jhrozek/openscap-1-3-5/pubkey.gpg\n\
+repo_gpgcheck=0\n\
+enabled=1\n\
+enabled_metadata=1\n '\
+>> /etc/yum.repos.d/openscap.repo
+
 RUN true \
     && microdnf install -y openscap-scanner \
     && microdnf clean all \


### PR DESCRIPTION
RHEL-8.5 is going to use openscap 1.3.5 that fixes several crashes. In
the meantime, we can use that release from a personal COPR repository.