### PR TITLE
Result Server: Make nodeSelector and tolerations configurable

### DIFF
--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -81,6 +81,16 @@ spec:
               rawResultStorage:
                 description: Specifies settings that pertain to raw result storage.
                 properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    default:
+                      node-role.kubernetes.io/master: ""
+                    description: By setting this, it's possible to configure where
+                      the result server instances are run. These instances will mount
+                      a Persistent Volume to store the raw results, so special care
+                      should be taken to schedule these in trusted nodes.
+                    type: object
                   pvAccessModes:
                     default:
                     - ReadWriteOnce
@@ -112,6 +122,54 @@ spec:
                       specified then this needs to be set.
                     nullable: true
                     type: string
+                  tolerations:
+                    default:
+                    - effect: NoSchedule
+                      key: node-role.kubernetes.io/master
+                      operator: Exists
+                    description: Specifies tolerations needed for the result server
+                      to run on the nodes. This is useful in case the target set of
+                      nodes have custom taints that don't allow certain workloads
+                      to run. Defaults to allowing scheduling on master nodes.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
                 type: object
               remediationEnforcement:
                 description: 'Specifies what to do with remediations of Enforcement

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -102,6 +102,17 @@ spec:
                     rawResultStorage:
                       description: Specifies settings that pertain to raw result storage.
                       properties:
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          default:
+                            node-role.kubernetes.io/master: ""
+                          description: By setting this, it's possible to configure
+                            where the result server instances are run. These instances
+                            will mount a Persistent Volume to store the raw results,
+                            so special care should be taken to schedule these in trusted
+                            nodes.
+                          type: object
                         pvAccessModes:
                           default:
                           - ReadWriteOnce
@@ -135,6 +146,57 @@ spec:
                             is no default class specified then this needs to be set.
                           nullable: true
                           type: string
+                        tolerations:
+                          default:
+                          - effect: NoSchedule
+                            key: node-role.kubernetes.io/master
+                            operator: Exists
+                          description: Specifies tolerations needed for the result
+                            server to run on the nodes. This is useful in case the
+                            target set of nodes have custom taints that don't allow
+                            certain workloads to run. Defaults to allowing scheduling
+                            on master nodes.
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     remediationEnforcement:
                       description: 'Specifies what to do with remediations of Enforcement

--- a/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
@@ -55,6 +55,16 @@ spec:
           rawResultStorage:
             description: Specifies settings that pertain to raw result storage.
             properties:
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                default:
+                  node-role.kubernetes.io/master: ""
+                description: By setting this, it's possible to configure where the
+                  result server instances are run. These instances will mount a Persistent
+                  Volume to store the raw results, so special care should be taken
+                  to schedule these in trusted nodes.
+                type: object
               pvAccessModes:
                 default:
                 - ReadWriteOnce
@@ -86,6 +96,53 @@ spec:
                   needs to be set.
                 nullable: true
                 type: string
+              tolerations:
+                default:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/master
+                  operator: Exists
+                description: Specifies tolerations needed for the result server to
+                  run on the nodes. This is useful in case the target set of nodes
+                  have custom taints that don't allow certain workloads to run. Defaults
+                  to allowing scheduling on master nodes.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
             type: object
           remediationEnforcement:
             description: 'Specifies what to do with remediations of Enforcement type.

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -346,6 +346,12 @@ The following attributes can be set in the `ScanSetting:
 * **autoUpdateRemediations**: Defines whether or not the remediations
   should be updated automatically in case the content updates.
 * **schedule**: Defines how often should the scan(s) be run in cron format.
+* **scanTolerations**: Specifies tolerations that will be set in the scan Pods
+  for scheduling. Defaults to allowing the scan to ignore taints. For
+  details on tolerations, see the
+  [Kubernetes documentation on this](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
+ * **roles**: Specifies the `node-role.kubernetes.io` label value that any scan of type `Node`
+  should be scheduled on.
 * **rawResultStorage.size**: Specifies the size of storage that should be asked
   for in order for the scan to store the raw results. (Defaults to 1Gi)
 * **rawResultStorage.rotation**: Specifies the amount of scans for which the raw
@@ -353,12 +359,14 @@ The following attributes can be set in the `ScanSetting:
   responsibility of administrators to store these results elsewhere before
   rotation happens. Note that a rotation policy of '0' disables rotation
   entirely. Defaults to 3.
-* **scanTolerations**: Specifies tolerations that will be set in the scan Pods
-  for scheduling. Defaults to allowing the scan to ignore taints. For
-  details on tolerations, see the
-  [Kubernetes documentation on this](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
- * **roles**: Specifies the `node-role.kubernetes.io` label value that any scan of type `Node`
-  should be scheduled on.
+* **rawResultStorage.nodeSelector**: By setting this, it's possible to
+  configure where the result server instances are run. These instances
+  will mount a Persistent Volume to store the raw results, so special
+  care should be taken to schedule these in trusted nodes.
+* **rawResultStorage.tolerations**:  Specifies tolerations needed
+  for the result server to run on the nodes. This is useful in
+  case the target set of nodes have custom taints that don't allow certain
+	workloads to run. Defaults to allowing scheduling on master nodes.
 
 A single `ScanSetting` object can also be reused for multiple scans,
 as it merely defines the settings.

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -142,6 +142,16 @@ type RawResultStorageSettings struct {
 	// The persistent volume will hold the raw results of the scan.
 	// +kubebuilder:default={"ReadWriteOnce"}
 	PVAccessModes []corev1.PersistentVolumeAccessMode `json:"pvAccessModes,omitempty"`
+	// By setting this, it's possible to configure where the result server instances
+	// are run. These instances will mount a Persistent Volume to store the raw
+	// results, so special care should be taken to schedule these in trusted nodes.
+	// +kubebuilder:default={"node-role.kubernetes.io/master": ""}
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	// Specifies tolerations needed for the result server to run on the nodes. This is useful
+	// in case the target set of nodes have custom taints that don't allow certain
+	// workloads to run. Defaults to allowing scheduling on master nodes.
+	// +kubebuilder:default={{key: "node-role.kubernetes.io/master", operator: "Exists", effect: "NoSchedule"}}
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // ComplianceScanSettings groups together settings of a ComplianceScan

--- a/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
@@ -756,6 +756,20 @@ func (in *RawResultStorageSettings) DeepCopyInto(out *RawResultStorageSettings) 
 		*out = make([]v1.PersistentVolumeAccessMode, len(*in))
 		copy(*out, *in)
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -183,16 +183,8 @@ func resultServer(scanInstance *compv1alpha1.ComplianceScan, labels map[string]s
 					},
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: map[string]string{
-						"node-role.kubernetes.io/master": "",
-					},
-					Tolerations: []corev1.Toleration{
-						{
-							Key:      "node-role.kubernetes.io/master",
-							Operator: corev1.TolerationOpExists,
-							Effect:   corev1.TaintEffectNoSchedule,
-						},
-					},
+					NodeSelector:       scanInstance.Spec.RawResultStorage.NodeSelector,
+					Tolerations:        scanInstance.Spec.RawResultStorage.Tolerations,
 					ServiceAccountName: resultserverSA,
 					SecurityContext: &corev1.PodSecurityContext{
 						FSGroup:      &podFSGroup,


### PR DESCRIPTION
This makes the aforementioned parameters configurable through the
ScanSettings object.

This enables deployers to configure where the Result Server will run,
and thus what node will host the Persistent Volume that will contain the
raw results.

This is needed for cases where the storage driver doesn't allow us to
schedule a pod that makes use of a persistent volume on the master
nodes.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>