### PR TITLE
Add option to make scan scheduling strict/not strict

### DIFF
--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -177,6 +177,13 @@ spec:
                 default: Node
                 description: The type of Compliance scan.
                 type: string
+              strictNodeScan:
+                default: true
+                description: Defines whether the scan should proceed if we're not
+                  able to scan all the nodes or not. `true` means that the operator
+                  should be strict and error out. `false` means that we don't need
+                  to be strict and we can proceed.
+                type: boolean
               tailoringConfigMap:
                 description: Is a reference to a ConfigMap that contains the tailoring
                   file. It assumes a key called `tailoring.xml` which will have the

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -203,6 +203,13 @@ spec:
                       default: Node
                       description: The type of Compliance scan.
                       type: string
+                    strictNodeScan:
+                      default: true
+                      description: Defines whether the scan should proceed if we're
+                        not able to scan all the nodes or not. `true` means that the
+                        operator should be strict and error out. `false` means that
+                        we don't need to be strict and we can proceed.
+                      type: boolean
                     tailoringConfigMap:
                       description: Is a reference to a ConfigMap that contains the
                         tailoring file. It assumes a key called `tailoring.xml` which

--- a/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
@@ -152,6 +152,13 @@ spec:
               format. Note the scan will still be triggered immediately, and the scheduled
               scans will start running only after the initial results are ready.
             type: string
+          strictNodeScan:
+            default: true
+            description: Defines whether the scan should proceed if we're not able
+              to scan all the nodes or not. `true` means that the operator should
+              be strict and error out. `false` means that we don't need to be strict
+              and we can proceed.
+            type: boolean
         type: object
     served: true
     storage: true

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -165,6 +165,13 @@ type ComplianceScanSettings struct {
 	// +kubebuilder:default={{operator: "Exists"}}
 	ScanTolerations []corev1.Toleration `json:"scanTolerations,omitempty"`
 
+	// Defines whether the scan should proceed if we're not able to
+	// scan all the nodes or not. `true` means that the operator
+	// should be strict and error out. `false` means that we don't
+	// need to be strict and we can proceed.
+	// +kubebuilder:default=true
+	StrictNodeScan *bool `json:"strictNodeScan,omitempty"`
+
 	// Specifies what to do with remediations of Enforcement type. If left empty,
 	// this defaults to "off" which doesn't create nor apply any enforcement remediations.
 	// If set to "all" this creates any enforcement remediations it encounters.
@@ -318,6 +325,15 @@ func (cs *ComplianceScan) RemediationEnforcementIsOff() bool {
 func (cs *ComplianceScan) RemediationEnforcementTypeMatches(etype string) bool {
 	return (strings.EqualFold(cs.Spec.RemediationEnforcement, RemediationEnforcementAll) ||
 		strings.EqualFold(cs.Spec.RemediationEnforcement, etype))
+}
+
+// GetScanType get's the scan type for a scan
+func (cs *ComplianceScan) IsStrictNodeScan() bool {
+	// strictNodeScan should be true by default
+	if cs.Spec.StrictNodeScan == nil {
+		return true
+	}
+	return *cs.Spec.StrictNodeScan
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
@@ -283,6 +283,11 @@ func (in *ComplianceScanSettings) DeepCopyInto(out *ComplianceScanSettings) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.StrictNodeScan != nil {
+		in, out := &in.StrictNodeScan, &out.StrictNodeScan
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Currently, when dealing with node scans, we only allow the scan to go
forward if the node is not unschedulable (via the unschedulable flag of
the Node object). However, for public cloud cases where there might be a
lot of ephemeral nodes (e.g. when a node autoscaler is being used), this
is not ideal as it's very difficult to do scans. On the other hand, if a
node became unready while the scan was on-going, we also return a
similar error.

So, to deal with this, the PR introduces the option `strictNodeScan`,
which enables an administrator to toggle whether we want to be strict
when getting results of a scan.

The default is `true`, which is the setting we were using before.
However, when set to `false`, the scan will not fail if a node is set to
`unschedulable` and will ignore "unschedulable" errors on the scan pods.
Thus allowing us to still get a subset of scans.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>