### PR TITLE
e2e: Fix TestRulesAreClassifiedAppropriately test

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -509,7 +509,7 @@ func TestE2E(t *testing.T) {
 						compv1alpha1.CheckTypeNode,
 					},
 					{
-						"ocp4-kubeadmin-removed",
+						"ocp4-general-apply-scc",
 						compv1alpha1.CheckTypeNone,
 					},
 				} {


### PR DESCRIPTION
the test `TestRulesAreClassifiedAppropriately` depended on the
kubeadmin-removed rule to be MANUAL, however, it's now automated and
classified as `Platform` instead of "None", so... let's use another rule
for this test.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>