### PR TITLE
Release v0.1.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.44] - 2021-10-20
+### Changes
+- Add Vincent Shen to OWNERS file
+- Add option to make scan scheduling strict/not strict
+- e2e: Fix TestRulesAreClassifiedAppropriately test
+- Switch to using openscap 1.3.5
+- Result Server: Make nodeSelector and tolerations configurable
+- Create a kubeletconfig per pool
+
 ## [0.1.43] - 2021-10-14
 ### Changes
 - Update api-resource-collector comment

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.43'
+    olm.skipRange: '>=0.1.17 <0.1.44'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.43
+  name: compliance-operator.v0.1.44
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1173,12 +1173,12 @@ spec:
                 - name: OPERATOR_NAME
                   value: compliance-operator
                 - name: RELATED_IMAGE_OPENSCAP
-                  value: quay.io/compliance-operator/openscap-ocp:latest
+                  value: quay.io/compliance-operator/openscap-ocp:1.3.5
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.43
+                  value: quay.io/compliance-operator/compliance-operator:0.1.44
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.43
+                image: quay.io/compliance-operator/compliance-operator:0.1.44
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources:
@@ -1503,4 +1503,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.43
+  version: 0.1.44

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancescans_crd.yaml
@@ -82,6 +82,16 @@ spec:
               rawResultStorage:
                 description: Specifies settings that pertain to raw result storage.
                 properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    default:
+                      node-role.kubernetes.io/master: ""
+                    description: By setting this, it's possible to configure where
+                      the result server instances are run. These instances will mount
+                      a Persistent Volume to store the raw results, so special care
+                      should be taken to schedule these in trusted nodes.
+                    type: object
                   pvAccessModes:
                     default:
                     - ReadWriteOnce
@@ -113,6 +123,54 @@ spec:
                       specified then this needs to be set.
                     nullable: true
                     type: string
+                  tolerations:
+                    default:
+                    - effect: NoSchedule
+                      key: node-role.kubernetes.io/master
+                      operator: Exists
+                    description: Specifies tolerations needed for the result server
+                      to run on the nodes. This is useful in case the target set of
+                      nodes have custom taints that don't allow certain workloads
+                      to run. Defaults to allowing scheduling on master nodes.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
                 type: object
               remediationEnforcement:
                 description: 'Specifies what to do with remediations of Enforcement
@@ -178,6 +236,13 @@ spec:
                 default: Node
                 description: The type of Compliance scan.
                 type: string
+              strictNodeScan:
+                default: true
+                description: Defines whether the scan should proceed if we're not
+                  able to scan all the nodes or not. `true` means that the operator
+                  should be strict and error out. `false` means that we don't need
+                  to be strict and we can proceed.
+                type: boolean
               tailoringConfigMap:
                 description: Is a reference to a ConfigMap that contains the tailoring
                   file. It assumes a key called `tailoring.xml` which will have the

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancesuites_crd.yaml
@@ -103,6 +103,17 @@ spec:
                     rawResultStorage:
                       description: Specifies settings that pertain to raw result storage.
                       properties:
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          default:
+                            node-role.kubernetes.io/master: ""
+                          description: By setting this, it's possible to configure
+                            where the result server instances are run. These instances
+                            will mount a Persistent Volume to store the raw results,
+                            so special care should be taken to schedule these in trusted
+                            nodes.
+                          type: object
                         pvAccessModes:
                           default:
                           - ReadWriteOnce
@@ -136,6 +147,57 @@ spec:
                             is no default class specified then this needs to be set.
                           nullable: true
                           type: string
+                        tolerations:
+                          default:
+                          - effect: NoSchedule
+                            key: node-role.kubernetes.io/master
+                            operator: Exists
+                          description: Specifies tolerations needed for the result
+                            server to run on the nodes. This is useful in case the
+                            target set of nodes have custom taints that don't allow
+                            certain workloads to run. Defaults to allowing scheduling
+                            on master nodes.
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     remediationEnforcement:
                       description: 'Specifies what to do with remediations of Enforcement
@@ -204,6 +266,13 @@ spec:
                       default: Node
                       description: The type of Compliance scan.
                       type: string
+                    strictNodeScan:
+                      default: true
+                      description: Defines whether the scan should proceed if we're
+                        not able to scan all the nodes or not. `true` means that the
+                        operator should be strict and error out. `false` means that
+                        we don't need to be strict and we can proceed.
+                      type: boolean
                     tailoringConfigMap:
                       description: Is a reference to a ConfigMap that contains the
                         tailoring file. It assumes a key called `tailoring.xml` which

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_scansettings_crd.yaml
@@ -56,6 +56,16 @@ spec:
           rawResultStorage:
             description: Specifies settings that pertain to raw result storage.
             properties:
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                default:
+                  node-role.kubernetes.io/master: ""
+                description: By setting this, it's possible to configure where the
+                  result server instances are run. These instances will mount a Persistent
+                  Volume to store the raw results, so special care should be taken
+                  to schedule these in trusted nodes.
+                type: object
               pvAccessModes:
                 default:
                 - ReadWriteOnce
@@ -87,6 +97,53 @@ spec:
                   needs to be set.
                 nullable: true
                 type: string
+              tolerations:
+                default:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/master
+                  operator: Exists
+                description: Specifies tolerations needed for the result server to
+                  run on the nodes. This is useful in case the target set of nodes
+                  have custom taints that don't allow certain workloads to run. Defaults
+                  to allowing scheduling on master nodes.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
             type: object
           remediationEnforcement:
             description: 'Specifies what to do with remediations of Enforcement type.
@@ -153,6 +210,13 @@ spec:
               format. Note the scan will still be triggered immediately, and the scheduled
               scans will start running only after the initial results are ready.
             type: string
+          strictNodeScan:
+            default: true
+            description: Defines whether the scan should proceed if we're not able
+              to scan all the nodes or not. `true` means that the operator should
+              be strict and error out. `false` means that we don't need to be strict
+              and we can proceed.
+            type: boolean
         type: object
     served: true
     storage: true

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.43"
+	Version = "0.1.44"
 )


### PR DESCRIPTION
## [0.1.44] - 2021-10-20
### Changes
- Add option to make scan scheduling strict/not strict
- Switch to using openscap 1.3.5
- Result Server: Make nodeSelector and tolerations configurable
- Create a kubeletconfig per pool