### PR TITLE
ClusterRole api-resource-collector: Add permissions to list/get machineset

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1194,3 +1194,12 @@ rules:
   - kubeadmin
   verbs:
   - get
+# Necessary to check EBS encryption for PCIDSS requirements
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - machinesets
+  verbs:
+  - get
+  - list
+


### PR DESCRIPTION
We want to add extra permissions in the cluster role  to get and list machineset.
This is necessary for req 3.4.1 pcidss, where we want to check ebs encryption on the machinesets
`    {{{ openshift_filtered_cluster_setting({'/apis/machine.openshift.io/v1beta1/machinesets?limit=500': '[.items[] | .spec.template.spec.providerSpec.value.blockDevices[0].ebs.encrypted] | map(. == true)'}) | indent(4) }}}
`
