### PR TITLE
Bug 1965511: Implement version applicability for remediations

### DIFF
--- a/cmd/manager/aggregator_test.go
+++ b/cmd/manager/aggregator_test.go
@@ -1,50 +1,294 @@
 package main
 
 import (
+	"context"
+	"fmt"
+
+	backoff "github.com/cenkalti/backoff/v4"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	ocpcfgv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	fakerec "k8s.io/client-go/tools/record"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	compv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
 )
 
-var _ = Describe("Aggregator Empty Remediation Test", func() {
+type aggregatorCrClientFake struct {
+	client      runtimeclient.Client
+	scheme      *runtime.Scheme
+	recorder    record.EventRecorder
+	fakevgetter *fakeversionget
+}
 
-	var (
-		namespace          = "test-ns"
-		remediationName    = "testRem"
-		targetNodeSelector = map[string]string{
-			"hops": "malt",
-		}
-	)
-	nodeScanSettings := compv1alpha1.ComplianceScanSpec{
-		ScanType:     compv1alpha1.ScanTypeNode,
-		NodeSelector: targetNodeSelector,
-	}
+func (accrif *aggregatorCrClientFake) getClient() runtimeclient.Client {
+	return accrif.client
+}
 
-	nodeScan := &compv1alpha1.ComplianceScan{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testScanNode",
-			Namespace: namespace,
-		},
-		Spec: nodeScanSettings,
+func (accrif *aggregatorCrClientFake) getScheme() *runtime.Scheme {
+	return accrif.scheme
+}
+
+func (accrif *aggregatorCrClientFake) getRecorder() record.EventRecorder {
+	return accrif.recorder
+}
+
+func (accrif *aggregatorCrClientFake) getClientset() *kubernetes.Clientset {
+	return nil
+}
+
+func (accrif *aggregatorCrClientFake) versionGetter() discovery.ServerVersionInterface {
+	return accrif.fakevgetter
+}
+
+func (accrif *aggregatorCrClientFake) useEventRecorder(source string, config *rest.Config) error {
+	return nil
+}
+
+type fakeversionget struct {
+	version  string
+	throwErr bool
+}
+
+func (vg *fakeversionget) setVersion(version string) {
+	vg.version = version
+}
+
+func (vg *fakeversionget) setThrowErr(throw bool) {
+	vg.throwErr = throw
+}
+
+func (vg *fakeversionget) ServerVersion() (*version.Info, error) {
+	if !vg.throwErr {
+		return &version.Info{GitVersion: vg.version}, nil
 	}
-	emptyRem := &compv1alpha1.ComplianceRemediation{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      remediationName,
-			Namespace: namespace,
-		},
-		Spec: compv1alpha1.ComplianceRemediationSpec{
-			ComplianceRemediationSpecMeta: compv1alpha1.ComplianceRemediationSpecMeta{
-				Apply: true,
-			},
-			Current: compv1alpha1.ComplianceRemediationPayload{
-				Object: &unstructured.Unstructured{
-					Object: map[string]interface{}{},
+	return nil, backoff.Permanent(fmt.Errorf("Some error"))
+}
+
+var _ = Describe("Aggregator Tests", func() {
+	Context("Empty Remediations", func() {
+		It("Creates an empty remediation", func() {
+			var (
+				namespace          = "test-ns"
+				remediationName    = "testRem"
+				targetNodeSelector = map[string]string{
+					"hops": "malt",
+				}
+			)
+			nodeScanSettings := compv1alpha1.ComplianceScanSpec{
+				ScanType:     compv1alpha1.ScanTypeNode,
+				NodeSelector: targetNodeSelector,
+			}
+
+			nodeScan := &compv1alpha1.ComplianceScan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testScanNode",
+					Namespace: namespace,
 				},
-			},
-		},
-	}
-	canCreate, _ := canCreateRemediationObject(nodeScan, emptyRem.Spec.Current.Object)
-	Expect(canCreate).To(BeFalse())
+				Spec: nodeScanSettings,
+			}
+			emptyRem := &compv1alpha1.ComplianceRemediation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      remediationName,
+					Namespace: namespace,
+				},
+				Spec: compv1alpha1.ComplianceRemediationSpec{
+					ComplianceRemediationSpecMeta: compv1alpha1.ComplianceRemediationSpecMeta{
+						Apply: true,
+					},
+					Current: compv1alpha1.ComplianceRemediationPayload{
+						Object: &unstructured.Unstructured{
+							Object: map[string]interface{}{},
+						},
+					},
+				},
+			}
+			canCreate, _ := canCreateRemediationObject(nodeScan, emptyRem.Spec.Current.Object)
+			Expect(canCreate).To(BeFalse())
+		})
+	})
+
+	Context("Version filtering Remediations", func() {
+		var scan *compv1alpha1.ComplianceScan
+		var rem *compv1alpha1.ComplianceRemediation
+		var crClient *aggregatorCrClientFake
+		var fakerecorder *fakerec.FakeRecorder
+		var ctx context.Context
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			scheme := getScheme()
+
+			scan = &compv1alpha1.ComplianceScan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			}
+			rem = &compv1alpha1.ComplianceRemediation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "foo",
+					Namespace:   "bar",
+					Annotations: map[string]string{},
+				},
+			}
+
+			client := fake.NewFakeClientWithScheme(scheme, scan, rem)
+			fakerecorder = fakerec.NewFakeRecorder(1)
+			crClient = &aggregatorCrClientFake{
+				scheme:      scheme,
+				client:      client,
+				recorder:    fakerecorder,
+				fakevgetter: &fakeversionget{},
+			}
+		})
+
+		When("Using the openshift-specific annotation", func() {
+			var clusterOp *ocpcfgv1.ClusterOperator
+
+			BeforeEach(func() {
+				clusterOp = &ocpcfgv1.ClusterOperator{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "openshift-apiserver",
+					},
+				}
+				createErr := crClient.client.Create(ctx, clusterOp)
+				Expect(createErr).To(BeNil())
+			})
+
+			It("Does not skip the remediation if it's applicable", func() {
+				clusterOp.Status.Versions = append(clusterOp.Status.Versions,
+					ocpcfgv1.OperandVersion{
+						Name:    apiserverOperatorName,
+						Version: "4.10.0-0.nightly-2021-10-16-173656",
+					},
+				)
+				updateErr := crClient.client.Status().Update(ctx, clusterOp)
+				Expect(updateErr).To(BeNil())
+
+				rem.Annotations[compv1alpha1.OCPVersionDependencyAnnotation] = ">4.9.0"
+				skip, why := shouldSkipRemediation(scan, rem, crClient)
+				Expect(skip).To(BeFalse())
+				Expect(why).To(BeEmpty())
+				Expect(fakerecorder.Events).To(HaveLen(0))
+			})
+
+			It("Does not skip the remediation if it's applicable and URL-encoded", func() {
+				clusterOp.Status.Versions = append(clusterOp.Status.Versions,
+					ocpcfgv1.OperandVersion{
+						Name:    apiserverOperatorName,
+						Version: "4.10.0-0.nightly-2021-10-16-173656",
+					},
+				)
+				updateErr := crClient.client.Status().Update(ctx, clusterOp)
+				Expect(updateErr).To(BeNil())
+
+				rem.Annotations[compv1alpha1.OCPVersionDependencyAnnotation] = "&gt;=4.9.0"
+				skip, why := shouldSkipRemediation(scan, rem, crClient)
+				Expect(why).To(BeEmpty())
+				Expect(skip).To(BeFalse())
+				Expect(fakerecorder.Events).To(HaveLen(0))
+			})
+
+			It("Skips the remediation if it's not applicable", func() {
+				clusterOp.Status.Versions = append(clusterOp.Status.Versions,
+					ocpcfgv1.OperandVersion{
+						Name:    apiserverOperatorName,
+						Version: "4.10.16",
+					},
+				)
+				updateErr := crClient.client.Status().Update(ctx, clusterOp)
+				Expect(updateErr).To(BeNil())
+
+				rem.Annotations[compv1alpha1.OCPVersionDependencyAnnotation] = ">4.10.17"
+				skip, why := shouldSkipRemediation(scan, rem, crClient)
+				Expect(skip).To(BeTrue())
+				Expect(why).To(ContainSubstring("Cluster doesn't match version range"))
+				Expect(fakerecorder.Events).To(HaveLen(1))
+			})
+
+			It("Skips the remediation if it's unable to get the needed obejct", func() {
+				deleteErr := crClient.client.Delete(ctx, clusterOp)
+				Expect(deleteErr).To(BeNil())
+
+				rem.Annotations[compv1alpha1.OCPVersionDependencyAnnotation] = ">4.10.17"
+				skip, why := shouldSkipRemediation(scan, rem, crClient)
+				Expect(skip).To(BeTrue())
+				Expect(why).To(ContainSubstring("Unable to get OCP Version"))
+				Expect(fakerecorder.Events).To(HaveLen(1))
+			})
+
+			It("Skips the remediation if expected version field isn't there", func() {
+				rem.Annotations[compv1alpha1.OCPVersionDependencyAnnotation] = ">4.10.17"
+				skip, why := shouldSkipRemediation(scan, rem, crClient)
+				Expect(skip).To(BeTrue())
+				Expect(why).To(ContainSubstring("Unable to find OCP Version"))
+				Expect(fakerecorder.Events).To(HaveLen(1))
+			})
+
+			It("Skips the remediation if cluster operator OCP version is malformed", func() {
+				clusterOp.Status.Versions = append(clusterOp.Status.Versions,
+					ocpcfgv1.OperandVersion{
+						Name:    apiserverOperatorName,
+						Version: "4.10-foo",
+					},
+				)
+				updateErr := crClient.client.Status().Update(ctx, clusterOp)
+				Expect(updateErr).To(BeNil())
+
+				rem.Annotations[compv1alpha1.OCPVersionDependencyAnnotation] = ">4.10.17"
+				skip, why := shouldSkipRemediation(scan, rem, crClient)
+				Expect(skip).To(BeTrue())
+				Expect(why).To(ContainSubstring("Unable to parse version"))
+				Expect(fakerecorder.Events).To(HaveLen(1))
+			})
+		})
+
+		When("Using the kubernetes-specific annotation", func() {
+			It("Does not skip the remediation if it's applicable", func() {
+				crClient.fakevgetter.setVersion("v1.22.1+9312243")
+				rem.Annotations[compv1alpha1.K8SVersionDependencyAnnotation] = ">1.22.0"
+				skip, why := shouldSkipRemediation(scan, rem, crClient)
+				Expect(why).To(BeEmpty())
+				Expect(skip).To(BeFalse())
+				Expect(fakerecorder.Events).To(HaveLen(0))
+			})
+
+			It("Skips the remediation if it's not applicable", func() {
+				crClient.fakevgetter.setVersion("1.22.1")
+				rem.Annotations[compv1alpha1.K8SVersionDependencyAnnotation] = "<1.21.0"
+				skip, why := shouldSkipRemediation(scan, rem, crClient)
+				Expect(skip).To(BeTrue())
+				Expect(why).To(ContainSubstring("Cluster doesn't match version range"))
+				Expect(fakerecorder.Events).To(HaveLen(1))
+			})
+
+			It("Skips the remediation if there's an error getting the version", func() {
+				crClient.fakevgetter.setThrowErr(true)
+				rem.Annotations[compv1alpha1.K8SVersionDependencyAnnotation] = ">1.22.1"
+				skip, why := shouldSkipRemediation(scan, rem, crClient)
+				Expect(skip).To(BeTrue())
+				Expect(why).To(ContainSubstring("Some error"))
+				Expect(fakerecorder.Events).To(HaveLen(1))
+			})
+
+			It("Skips the remediation if kubelet version is malformed", func() {
+				crClient.fakevgetter.setVersion("1.22.1azxdf")
+				rem.Annotations[compv1alpha1.K8SVersionDependencyAnnotation] = ">4.10.17"
+				skip, why := shouldSkipRemediation(scan, rem, crClient)
+				Expect(skip).To(BeTrue())
+				Expect(why).To(ContainSubstring("Unable to parse version"))
+				Expect(fakerecorder.Events).To(HaveLen(1))
+			})
+		})
+	})
 })

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -340,6 +340,28 @@ rules:
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: remediation-aggregator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes  # Needed for version filtering
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators  # Needed for version filtering
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: rerunner

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -50,6 +50,19 @@ roleRef:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: remediation-aggregator
+subjects:
+- kind: ServiceAccount
+  name: remediation-aggregator
+  namespace: openshift-compliance
+roleRef:
+  kind: ClusterRole
+  name: remediation-aggregator
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: api-resource-collector
 subjects:
 - kind: ServiceAccount

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559 // indirect
 	github.com/antchfx/xmlquery v1.3.6
 	github.com/antchfx/xpath v1.1.11 // indirect
+	github.com/blang/semver/v4 v4.0.0
 	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/clarketm/json v1.15.7
 	github.com/coreos/ignition/v2 v2.9.0

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,8 @@ github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=

--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -43,20 +43,51 @@ const (
 )
 
 const (
-	// OutdatedRemediationLabel specifies that the remediation has been superseded by a newer version
-	OutdatedRemediationLabel               = "complianceoperator.openshift.io/outdated-remediation"
-	RemediationHasUnmetDependenciesLabel   = "compliance.openshift.io/has-unmet-dependencies"
-	RemediationUnsetValueLabel             = "compliance.openshift.io/has-unset-variable"
+	// OutdatedRemediationLabel specifies that the remediation has been superseded by a newer version.
+	OutdatedRemediationLabel = "complianceoperator.openshift.io/outdated-remediation"
+	// RemediationHasUnmetDependenciesLabel specifies that a remediation has unmet dependencies
+	// and thus cannot be applied.
+	RemediationHasUnmetDependenciesLabel = "compliance.openshift.io/has-unmet-dependencies"
+	// RemediationUnsetValueLabel specifies that a remediation requires a value
+	// to be set.
+	RemediationUnsetValueLabel = "compliance.openshift.io/has-unset-variable"
+	// RemediationValueRequiredProcessedLabel specifies that a remediation's needed value
+	// has been processed.
 	RemediationValueRequiredProcessedLabel = "compliance.openshift.io/value-required-processed"
+	// RemediationCreatedByOperatorAnnotation specifies that a remediation was
+	// created by the Compliance Operator; this is used for the Compliance Operator to
+	// know whether it can delete the object or not when un-applying a remediation.
 	RemediationCreatedByOperatorAnnotation = "compliance.openshift.io/remediation"
-	RemediationDependencyAnnotation        = "compliance.openshift.io/depends-on"
-	RemediationObjectDependencyAnnotation  = "compliance.openshift.io/depends-on-obj"
-	RemediationDependenciesMetAnnotation   = "compliance.openshift.io/dependencies-met"
-	RemediationOptionalAnnotation          = "compliance.openshift.io/optional"
-	RemediationEnforcementTypeAnnotation   = "compliance.openshift.io/enforcement-type"
-	RemediationValueRequiredAnnotation     = "compliance.openshift.io/value-required"
-	RemediationUnsetValueAnnotation        = "compliance.openshift.io/unset-value"
-	RemediationValueUsedAnnotation         = "compliance.openshift.io/xccdf-value-used"
+	// RemediationDependencyAnnotation specifies that a remediation depends on
+	// an XCCDF rule passing in order to be applied.
+	RemediationDependencyAnnotation = "compliance.openshift.io/depends-on"
+	// RemediationObjectDependencyAnnotation specifies that a remediation depends on
+	// another Kubernetes object existing in order to be applied.
+	RemediationObjectDependencyAnnotation = "compliance.openshift.io/depends-on-obj"
+	// RemediationDependenciesMetAnnotation specifies that a remediation's dependencies
+	// have been met.
+	RemediationDependenciesMetAnnotation = "compliance.openshift.io/dependencies-met"
+	// RemediationOptionalAnnotation specifies that a remediation is optional,
+	// and thus failures applying it are to be ignored.
+	RemediationOptionalAnnotation = "compliance.openshift.io/optional"
+	// RemediationEnforcementTypeAnnotation specifies that a remediation is
+	// of a certain policy enforcement type. This generally marks the engine
+	// that the policy will be evaluated with. e.g. gatekeeper
+	RemediationEnforcementTypeAnnotation = "compliance.openshift.io/enforcement-type"
+	// RemediationValueRequiredAnnotation specifies that a remediation requires
+	// a value to be set before being applied.
+	RemediationValueRequiredAnnotation = "compliance.openshift.io/value-required"
+	// RemediationUnsetValueAnnotation specifies the unset value that's missing
+	// for the remediation
+	RemediationUnsetValueAnnotation = "compliance.openshift.io/unset-value"
+	// RemediationValueUsedAnnotation specifies the values used for a remediation
+	RemediationValueUsedAnnotation = "compliance.openshift.io/xccdf-value-used"
+	// OCPVersionDependencyAnnotation specifies that the OCP cluster needs to fall
+	// into a range in order to be applied
+	OCPVersionDependencyAnnotation = "compliance.openshift.io/ocp-version"
+	// K8SVersionDependencyAnnotation specifies that the k8s cluster needs to fall
+	// into a range in order to be applied
+	K8SVersionDependencyAnnotation = "compliance.openshift.io/k8s-version"
 )
 
 var (

--- a/vendor/github.com/blang/semver/v4/LICENSE
+++ b/vendor/github.com/blang/semver/v4/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2014 Benedikt Lang <github at benediktlang.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/vendor/github.com/blang/semver/v4/go.mod
+++ b/vendor/github.com/blang/semver/v4/go.mod
@@ -1,0 +1,3 @@
+module github.com/blang/semver/v4
+
+go 1.14

--- a/vendor/github.com/blang/semver/v4/json.go
+++ b/vendor/github.com/blang/semver/v4/json.go
@@ -1,0 +1,23 @@
+package semver
+
+import (
+	"encoding/json"
+)
+
+// MarshalJSON implements the encoding/json.Marshaler interface.
+func (v Version) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.String())
+}
+
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface.
+func (v *Version) UnmarshalJSON(data []byte) (err error) {
+	var versionString string
+
+	if err = json.Unmarshal(data, &versionString); err != nil {
+		return
+	}
+
+	*v, err = Parse(versionString)
+
+	return
+}

--- a/vendor/github.com/blang/semver/v4/range.go
+++ b/vendor/github.com/blang/semver/v4/range.go
@@ -1,0 +1,416 @@
+package semver
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type wildcardType int
+
+const (
+	noneWildcard  wildcardType = iota
+	majorWildcard wildcardType = 1
+	minorWildcard wildcardType = 2
+	patchWildcard wildcardType = 3
+)
+
+func wildcardTypefromInt(i int) wildcardType {
+	switch i {
+	case 1:
+		return majorWildcard
+	case 2:
+		return minorWildcard
+	case 3:
+		return patchWildcard
+	default:
+		return noneWildcard
+	}
+}
+
+type comparator func(Version, Version) bool
+
+var (
+	compEQ comparator = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == 0
+	}
+	compNE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) != 0
+	}
+	compGT = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == 1
+	}
+	compGE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) >= 0
+	}
+	compLT = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == -1
+	}
+	compLE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) <= 0
+	}
+)
+
+type versionRange struct {
+	v Version
+	c comparator
+}
+
+// rangeFunc creates a Range from the given versionRange.
+func (vr *versionRange) rangeFunc() Range {
+	return Range(func(v Version) bool {
+		return vr.c(v, vr.v)
+	})
+}
+
+// Range represents a range of versions.
+// A Range can be used to check if a Version satisfies it:
+//
+//     range, err := semver.ParseRange(">1.0.0 <2.0.0")
+//     range(semver.MustParse("1.1.1") // returns true
+type Range func(Version) bool
+
+// OR combines the existing Range with another Range using logical OR.
+func (rf Range) OR(f Range) Range {
+	return Range(func(v Version) bool {
+		return rf(v) || f(v)
+	})
+}
+
+// AND combines the existing Range with another Range using logical AND.
+func (rf Range) AND(f Range) Range {
+	return Range(func(v Version) bool {
+		return rf(v) && f(v)
+	})
+}
+
+// ParseRange parses a range and returns a Range.
+// If the range could not be parsed an error is returned.
+//
+// Valid ranges are:
+//   - "<1.0.0"
+//   - "<=1.0.0"
+//   - ">1.0.0"
+//   - ">=1.0.0"
+//   - "1.0.0", "=1.0.0", "==1.0.0"
+//   - "!1.0.0", "!=1.0.0"
+//
+// A Range can consist of multiple ranges separated by space:
+// Ranges can be linked by logical AND:
+//   - ">1.0.0 <2.0.0" would match between both ranges, so "1.1.1" and "1.8.7" but not "1.0.0" or "2.0.0"
+//   - ">1.0.0 <3.0.0 !2.0.3-beta.2" would match every version between 1.0.0 and 3.0.0 except 2.0.3-beta.2
+//
+// Ranges can also be linked by logical OR:
+//   - "<2.0.0 || >=3.0.0" would match "1.x.x" and "3.x.x" but not "2.x.x"
+//
+// AND has a higher precedence than OR. It's not possible to use brackets.
+//
+// Ranges can be combined by both AND and OR
+//
+//  - `>1.0.0 <2.0.0 || >3.0.0 !4.2.1` would match `1.2.3`, `1.9.9`, `3.1.1`, but not `4.2.1`, `2.1.1`
+func ParseRange(s string) (Range, error) {
+	parts := splitAndTrim(s)
+	orParts, err := splitORParts(parts)
+	if err != nil {
+		return nil, err
+	}
+	expandedParts, err := expandWildcardVersion(orParts)
+	if err != nil {
+		return nil, err
+	}
+	var orFn Range
+	for _, p := range expandedParts {
+		var andFn Range
+		for _, ap := range p {
+			opStr, vStr, err := splitComparatorVersion(ap)
+			if err != nil {
+				return nil, err
+			}
+			vr, err := buildVersionRange(opStr, vStr)
+			if err != nil {
+				return nil, fmt.Errorf("Could not parse Range %q: %s", ap, err)
+			}
+			rf := vr.rangeFunc()
+
+			// Set function
+			if andFn == nil {
+				andFn = rf
+			} else { // Combine with existing function
+				andFn = andFn.AND(rf)
+			}
+		}
+		if orFn == nil {
+			orFn = andFn
+		} else {
+			orFn = orFn.OR(andFn)
+		}
+
+	}
+	return orFn, nil
+}
+
+// splitORParts splits the already cleaned parts by '||'.
+// Checks for invalid positions of the operator and returns an
+// error if found.
+func splitORParts(parts []string) ([][]string, error) {
+	var ORparts [][]string
+	last := 0
+	for i, p := range parts {
+		if p == "||" {
+			if i == 0 {
+				return nil, fmt.Errorf("First element in range is '||'")
+			}
+			ORparts = append(ORparts, parts[last:i])
+			last = i + 1
+		}
+	}
+	if last == len(parts) {
+		return nil, fmt.Errorf("Last element in range is '||'")
+	}
+	ORparts = append(ORparts, parts[last:])
+	return ORparts, nil
+}
+
+// buildVersionRange takes a slice of 2: operator and version
+// and builds a versionRange, otherwise an error.
+func buildVersionRange(opStr, vStr string) (*versionRange, error) {
+	c := parseComparator(opStr)
+	if c == nil {
+		return nil, fmt.Errorf("Could not parse comparator %q in %q", opStr, strings.Join([]string{opStr, vStr}, ""))
+	}
+	v, err := Parse(vStr)
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse version %q in %q: %s", vStr, strings.Join([]string{opStr, vStr}, ""), err)
+	}
+
+	return &versionRange{
+		v: v,
+		c: c,
+	}, nil
+
+}
+
+// inArray checks if a byte is contained in an array of bytes
+func inArray(s byte, list []byte) bool {
+	for _, el := range list {
+		if el == s {
+			return true
+		}
+	}
+	return false
+}
+
+// splitAndTrim splits a range string by spaces and cleans whitespaces
+func splitAndTrim(s string) (result []string) {
+	last := 0
+	var lastChar byte
+	excludeFromSplit := []byte{'>', '<', '='}
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' && !inArray(lastChar, excludeFromSplit) {
+			if last < i-1 {
+				result = append(result, s[last:i])
+			}
+			last = i + 1
+		} else if s[i] != ' ' {
+			lastChar = s[i]
+		}
+	}
+	if last < len(s)-1 {
+		result = append(result, s[last:])
+	}
+
+	for i, v := range result {
+		result[i] = strings.Replace(v, " ", "", -1)
+	}
+
+	// parts := strings.Split(s, " ")
+	// for _, x := range parts {
+	// 	if s := strings.TrimSpace(x); len(s) != 0 {
+	// 		result = append(result, s)
+	// 	}
+	// }
+	return
+}
+
+// splitComparatorVersion splits the comparator from the version.
+// Input must be free of leading or trailing spaces.
+func splitComparatorVersion(s string) (string, string, error) {
+	i := strings.IndexFunc(s, unicode.IsDigit)
+	if i == -1 {
+		return "", "", fmt.Errorf("Could not get version from string: %q", s)
+	}
+	return strings.TrimSpace(s[0:i]), s[i:], nil
+}
+
+// getWildcardType will return the type of wildcard that the
+// passed version contains
+func getWildcardType(vStr string) wildcardType {
+	parts := strings.Split(vStr, ".")
+	nparts := len(parts)
+	wildcard := parts[nparts-1]
+
+	possibleWildcardType := wildcardTypefromInt(nparts)
+	if wildcard == "x" {
+		return possibleWildcardType
+	}
+
+	return noneWildcard
+}
+
+// createVersionFromWildcard will convert a wildcard version
+// into a regular version, replacing 'x's with '0's, handling
+// special cases like '1.x.x' and '1.x'
+func createVersionFromWildcard(vStr string) string {
+	// handle 1.x.x
+	vStr2 := strings.Replace(vStr, ".x.x", ".x", 1)
+	vStr2 = strings.Replace(vStr2, ".x", ".0", 1)
+	parts := strings.Split(vStr2, ".")
+
+	// handle 1.x
+	if len(parts) == 2 {
+		return vStr2 + ".0"
+	}
+
+	return vStr2
+}
+
+// incrementMajorVersion will increment the major version
+// of the passed version
+func incrementMajorVersion(vStr string) (string, error) {
+	parts := strings.Split(vStr, ".")
+	i, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return "", err
+	}
+	parts[0] = strconv.Itoa(i + 1)
+
+	return strings.Join(parts, "."), nil
+}
+
+// incrementMajorVersion will increment the minor version
+// of the passed version
+func incrementMinorVersion(vStr string) (string, error) {
+	parts := strings.Split(vStr, ".")
+	i, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", err
+	}
+	parts[1] = strconv.Itoa(i + 1)
+
+	return strings.Join(parts, "."), nil
+}
+
+// expandWildcardVersion will expand wildcards inside versions
+// following these rules:
+//
+// * when dealing with patch wildcards:
+// >= 1.2.x    will become    >= 1.2.0
+// <= 1.2.x    will become    <  1.3.0
+// >  1.2.x    will become    >= 1.3.0
+// <  1.2.x    will become    <  1.2.0
+// != 1.2.x    will become    <  1.2.0 >= 1.3.0
+//
+// * when dealing with minor wildcards:
+// >= 1.x      will become    >= 1.0.0
+// <= 1.x      will become    <  2.0.0
+// >  1.x      will become    >= 2.0.0
+// <  1.0      will become    <  1.0.0
+// != 1.x      will become    <  1.0.0 >= 2.0.0
+//
+// * when dealing with wildcards without
+// version operator:
+// 1.2.x       will become    >= 1.2.0 < 1.3.0
+// 1.x         will become    >= 1.0.0 < 2.0.0
+func expandWildcardVersion(parts [][]string) ([][]string, error) {
+	var expandedParts [][]string
+	for _, p := range parts {
+		var newParts []string
+		for _, ap := range p {
+			if strings.Contains(ap, "x") {
+				opStr, vStr, err := splitComparatorVersion(ap)
+				if err != nil {
+					return nil, err
+				}
+
+				versionWildcardType := getWildcardType(vStr)
+				flatVersion := createVersionFromWildcard(vStr)
+
+				var resultOperator string
+				var shouldIncrementVersion bool
+				switch opStr {
+				case ">":
+					resultOperator = ">="
+					shouldIncrementVersion = true
+				case ">=":
+					resultOperator = ">="
+				case "<":
+					resultOperator = "<"
+				case "<=":
+					resultOperator = "<"
+					shouldIncrementVersion = true
+				case "", "=", "==":
+					newParts = append(newParts, ">="+flatVersion)
+					resultOperator = "<"
+					shouldIncrementVersion = true
+				case "!=", "!":
+					newParts = append(newParts, "<"+flatVersion)
+					resultOperator = ">="
+					shouldIncrementVersion = true
+				}
+
+				var resultVersion string
+				if shouldIncrementVersion {
+					switch versionWildcardType {
+					case patchWildcard:
+						resultVersion, _ = incrementMinorVersion(flatVersion)
+					case minorWildcard:
+						resultVersion, _ = incrementMajorVersion(flatVersion)
+					}
+				} else {
+					resultVersion = flatVersion
+				}
+
+				ap = resultOperator + resultVersion
+			}
+			newParts = append(newParts, ap)
+		}
+		expandedParts = append(expandedParts, newParts)
+	}
+
+	return expandedParts, nil
+}
+
+func parseComparator(s string) comparator {
+	switch s {
+	case "==":
+		fallthrough
+	case "":
+		fallthrough
+	case "=":
+		return compEQ
+	case ">":
+		return compGT
+	case ">=":
+		return compGE
+	case "<":
+		return compLT
+	case "<=":
+		return compLE
+	case "!":
+		fallthrough
+	case "!=":
+		return compNE
+	}
+
+	return nil
+}
+
+// MustParseRange is like ParseRange but panics if the range cannot be parsed.
+func MustParseRange(s string) Range {
+	r, err := ParseRange(s)
+	if err != nil {
+		panic(`semver: ParseRange(` + s + `): ` + err.Error())
+	}
+	return r
+}

--- a/vendor/github.com/blang/semver/v4/semver.go
+++ b/vendor/github.com/blang/semver/v4/semver.go
@@ -1,0 +1,476 @@
+package semver
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	numbers  string = "0123456789"
+	alphas          = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"
+	alphanum        = alphas + numbers
+)
+
+// SpecVersion is the latest fully supported spec version of semver
+var SpecVersion = Version{
+	Major: 2,
+	Minor: 0,
+	Patch: 0,
+}
+
+// Version represents a semver compatible version
+type Version struct {
+	Major uint64
+	Minor uint64
+	Patch uint64
+	Pre   []PRVersion
+	Build []string //No Precedence
+}
+
+// Version to string
+func (v Version) String() string {
+	b := make([]byte, 0, 5)
+	b = strconv.AppendUint(b, v.Major, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Minor, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Patch, 10)
+
+	if len(v.Pre) > 0 {
+		b = append(b, '-')
+		b = append(b, v.Pre[0].String()...)
+
+		for _, pre := range v.Pre[1:] {
+			b = append(b, '.')
+			b = append(b, pre.String()...)
+		}
+	}
+
+	if len(v.Build) > 0 {
+		b = append(b, '+')
+		b = append(b, v.Build[0]...)
+
+		for _, build := range v.Build[1:] {
+			b = append(b, '.')
+			b = append(b, build...)
+		}
+	}
+
+	return string(b)
+}
+
+// FinalizeVersion discards prerelease and build number and only returns
+// major, minor and patch number.
+func (v Version) FinalizeVersion() string {
+	b := make([]byte, 0, 5)
+	b = strconv.AppendUint(b, v.Major, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Minor, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Patch, 10)
+	return string(b)
+}
+
+// Equals checks if v is equal to o.
+func (v Version) Equals(o Version) bool {
+	return (v.Compare(o) == 0)
+}
+
+// EQ checks if v is equal to o.
+func (v Version) EQ(o Version) bool {
+	return (v.Compare(o) == 0)
+}
+
+// NE checks if v is not equal to o.
+func (v Version) NE(o Version) bool {
+	return (v.Compare(o) != 0)
+}
+
+// GT checks if v is greater than o.
+func (v Version) GT(o Version) bool {
+	return (v.Compare(o) == 1)
+}
+
+// GTE checks if v is greater than or equal to o.
+func (v Version) GTE(o Version) bool {
+	return (v.Compare(o) >= 0)
+}
+
+// GE checks if v is greater than or equal to o.
+func (v Version) GE(o Version) bool {
+	return (v.Compare(o) >= 0)
+}
+
+// LT checks if v is less than o.
+func (v Version) LT(o Version) bool {
+	return (v.Compare(o) == -1)
+}
+
+// LTE checks if v is less than or equal to o.
+func (v Version) LTE(o Version) bool {
+	return (v.Compare(o) <= 0)
+}
+
+// LE checks if v is less than or equal to o.
+func (v Version) LE(o Version) bool {
+	return (v.Compare(o) <= 0)
+}
+
+// Compare compares Versions v to o:
+// -1 == v is less than o
+// 0 == v is equal to o
+// 1 == v is greater than o
+func (v Version) Compare(o Version) int {
+	if v.Major != o.Major {
+		if v.Major > o.Major {
+			return 1
+		}
+		return -1
+	}
+	if v.Minor != o.Minor {
+		if v.Minor > o.Minor {
+			return 1
+		}
+		return -1
+	}
+	if v.Patch != o.Patch {
+		if v.Patch > o.Patch {
+			return 1
+		}
+		return -1
+	}
+
+	// Quick comparison if a version has no prerelease versions
+	if len(v.Pre) == 0 && len(o.Pre) == 0 {
+		return 0
+	} else if len(v.Pre) == 0 && len(o.Pre) > 0 {
+		return 1
+	} else if len(v.Pre) > 0 && len(o.Pre) == 0 {
+		return -1
+	}
+
+	i := 0
+	for ; i < len(v.Pre) && i < len(o.Pre); i++ {
+		if comp := v.Pre[i].Compare(o.Pre[i]); comp == 0 {
+			continue
+		} else if comp == 1 {
+			return 1
+		} else {
+			return -1
+		}
+	}
+
+	// If all pr versions are the equal but one has further prversion, this one greater
+	if i == len(v.Pre) && i == len(o.Pre) {
+		return 0
+	} else if i == len(v.Pre) && i < len(o.Pre) {
+		return -1
+	} else {
+		return 1
+	}
+
+}
+
+// IncrementPatch increments the patch version
+func (v *Version) IncrementPatch() error {
+	v.Patch++
+	return nil
+}
+
+// IncrementMinor increments the minor version
+func (v *Version) IncrementMinor() error {
+	v.Minor++
+	v.Patch = 0
+	return nil
+}
+
+// IncrementMajor increments the major version
+func (v *Version) IncrementMajor() error {
+	v.Major++
+	v.Minor = 0
+	v.Patch = 0
+	return nil
+}
+
+// Validate validates v and returns error in case
+func (v Version) Validate() error {
+	// Major, Minor, Patch already validated using uint64
+
+	for _, pre := range v.Pre {
+		if !pre.IsNum { //Numeric prerelease versions already uint64
+			if len(pre.VersionStr) == 0 {
+				return fmt.Errorf("Prerelease can not be empty %q", pre.VersionStr)
+			}
+			if !containsOnly(pre.VersionStr, alphanum) {
+				return fmt.Errorf("Invalid character(s) found in prerelease %q", pre.VersionStr)
+			}
+		}
+	}
+
+	for _, build := range v.Build {
+		if len(build) == 0 {
+			return fmt.Errorf("Build meta data can not be empty %q", build)
+		}
+		if !containsOnly(build, alphanum) {
+			return fmt.Errorf("Invalid character(s) found in build meta data %q", build)
+		}
+	}
+
+	return nil
+}
+
+// New is an alias for Parse and returns a pointer, parses version string and returns a validated Version or error
+func New(s string) (*Version, error) {
+	v, err := Parse(s)
+	vp := &v
+	return vp, err
+}
+
+// Make is an alias for Parse, parses version string and returns a validated Version or error
+func Make(s string) (Version, error) {
+	return Parse(s)
+}
+
+// ParseTolerant allows for certain version specifications that do not strictly adhere to semver
+// specs to be parsed by this library. It does so by normalizing versions before passing them to
+// Parse(). It currently trims spaces, removes a "v" prefix, adds a 0 patch number to versions
+// with only major and minor components specified, and removes leading 0s.
+func ParseTolerant(s string) (Version, error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	// Remove leading zeros.
+	for i, p := range parts {
+		if len(p) > 1 {
+			p = strings.TrimLeft(p, "0")
+			if len(p) == 0 || !strings.ContainsAny(p[0:1], "0123456789") {
+				p = "0" + p
+			}
+			parts[i] = p
+		}
+	}
+	// Fill up shortened versions.
+	if len(parts) < 3 {
+		if strings.ContainsAny(parts[len(parts)-1], "+-") {
+			return Version{}, errors.New("Short version cannot contain PreRelease/Build meta data")
+		}
+		for len(parts) < 3 {
+			parts = append(parts, "0")
+		}
+	}
+	s = strings.Join(parts, ".")
+
+	return Parse(s)
+}
+
+// Parse parses version string and returns a validated Version or error
+func Parse(s string) (Version, error) {
+	if len(s) == 0 {
+		return Version{}, errors.New("Version string empty")
+	}
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) != 3 {
+		return Version{}, errors.New("No Major.Minor.Patch elements found")
+	}
+
+	// Major
+	if !containsOnly(parts[0], numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in major number %q", parts[0])
+	}
+	if hasLeadingZeroes(parts[0]) {
+		return Version{}, fmt.Errorf("Major number must not contain leading zeroes %q", parts[0])
+	}
+	major, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	// Minor
+	if !containsOnly(parts[1], numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in minor number %q", parts[1])
+	}
+	if hasLeadingZeroes(parts[1]) {
+		return Version{}, fmt.Errorf("Minor number must not contain leading zeroes %q", parts[1])
+	}
+	minor, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	v := Version{}
+	v.Major = major
+	v.Minor = minor
+
+	var build, prerelease []string
+	patchStr := parts[2]
+
+	if buildIndex := strings.IndexRune(patchStr, '+'); buildIndex != -1 {
+		build = strings.Split(patchStr[buildIndex+1:], ".")
+		patchStr = patchStr[:buildIndex]
+	}
+
+	if preIndex := strings.IndexRune(patchStr, '-'); preIndex != -1 {
+		prerelease = strings.Split(patchStr[preIndex+1:], ".")
+		patchStr = patchStr[:preIndex]
+	}
+
+	if !containsOnly(patchStr, numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in patch number %q", patchStr)
+	}
+	if hasLeadingZeroes(patchStr) {
+		return Version{}, fmt.Errorf("Patch number must not contain leading zeroes %q", patchStr)
+	}
+	patch, err := strconv.ParseUint(patchStr, 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	v.Patch = patch
+
+	// Prerelease
+	for _, prstr := range prerelease {
+		parsedPR, err := NewPRVersion(prstr)
+		if err != nil {
+			return Version{}, err
+		}
+		v.Pre = append(v.Pre, parsedPR)
+	}
+
+	// Build meta data
+	for _, str := range build {
+		if len(str) == 0 {
+			return Version{}, errors.New("Build meta data is empty")
+		}
+		if !containsOnly(str, alphanum) {
+			return Version{}, fmt.Errorf("Invalid character(s) found in build meta data %q", str)
+		}
+		v.Build = append(v.Build, str)
+	}
+
+	return v, nil
+}
+
+// MustParse is like Parse but panics if the version cannot be parsed.
+func MustParse(s string) Version {
+	v, err := Parse(s)
+	if err != nil {
+		panic(`semver: Parse(` + s + `): ` + err.Error())
+	}
+	return v
+}
+
+// PRVersion represents a PreRelease Version
+type PRVersion struct {
+	VersionStr string
+	VersionNum uint64
+	IsNum      bool
+}
+
+// NewPRVersion creates a new valid prerelease version
+func NewPRVersion(s string) (PRVersion, error) {
+	if len(s) == 0 {
+		return PRVersion{}, errors.New("Prerelease is empty")
+	}
+	v := PRVersion{}
+	if containsOnly(s, numbers) {
+		if hasLeadingZeroes(s) {
+			return PRVersion{}, fmt.Errorf("Numeric PreRelease version must not contain leading zeroes %q", s)
+		}
+		num, err := strconv.ParseUint(s, 10, 64)
+
+		// Might never be hit, but just in case
+		if err != nil {
+			return PRVersion{}, err
+		}
+		v.VersionNum = num
+		v.IsNum = true
+	} else if containsOnly(s, alphanum) {
+		v.VersionStr = s
+		v.IsNum = false
+	} else {
+		return PRVersion{}, fmt.Errorf("Invalid character(s) found in prerelease %q", s)
+	}
+	return v, nil
+}
+
+// IsNumeric checks if prerelease-version is numeric
+func (v PRVersion) IsNumeric() bool {
+	return v.IsNum
+}
+
+// Compare compares two PreRelease Versions v and o:
+// -1 == v is less than o
+// 0 == v is equal to o
+// 1 == v is greater than o
+func (v PRVersion) Compare(o PRVersion) int {
+	if v.IsNum && !o.IsNum {
+		return -1
+	} else if !v.IsNum && o.IsNum {
+		return 1
+	} else if v.IsNum && o.IsNum {
+		if v.VersionNum == o.VersionNum {
+			return 0
+		} else if v.VersionNum > o.VersionNum {
+			return 1
+		} else {
+			return -1
+		}
+	} else { // both are Alphas
+		if v.VersionStr == o.VersionStr {
+			return 0
+		} else if v.VersionStr > o.VersionStr {
+			return 1
+		} else {
+			return -1
+		}
+	}
+}
+
+// PreRelease version to string
+func (v PRVersion) String() string {
+	if v.IsNum {
+		return strconv.FormatUint(v.VersionNum, 10)
+	}
+	return v.VersionStr
+}
+
+func containsOnly(s string, set string) bool {
+	return strings.IndexFunc(s, func(r rune) bool {
+		return !strings.ContainsRune(set, r)
+	}) == -1
+}
+
+func hasLeadingZeroes(s string) bool {
+	return len(s) > 1 && s[0] == '0'
+}
+
+// NewBuildVersion creates a new valid build version
+func NewBuildVersion(s string) (string, error) {
+	if len(s) == 0 {
+		return "", errors.New("Buildversion is empty")
+	}
+	if !containsOnly(s, alphanum) {
+		return "", fmt.Errorf("Invalid character(s) found in build meta data %q", s)
+	}
+	return s, nil
+}
+
+// FinalizeVersion returns the major, minor and patch number only and discards
+// prerelease and build number.
+func FinalizeVersion(s string) (string, error) {
+	v, err := Parse(s)
+	if err != nil {
+		return "", err
+	}
+	v.Pre = nil
+	v.Build = nil
+
+	finalVer := v.String()
+	return finalVer, nil
+}

--- a/vendor/github.com/blang/semver/v4/sort.go
+++ b/vendor/github.com/blang/semver/v4/sort.go
@@ -1,0 +1,28 @@
+package semver
+
+import (
+	"sort"
+)
+
+// Versions represents multiple versions.
+type Versions []Version
+
+// Len returns length of version collection
+func (s Versions) Len() int {
+	return len(s)
+}
+
+// Swap swaps two versions inside the collection by its indices
+func (s Versions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less checks if version at index i is less than version at index j
+func (s Versions) Less(i, j int) bool {
+	return s[i].LT(s[j])
+}
+
+// Sort sorts a slice of versions
+func Sort(versions []Version) {
+	sort.Sort(Versions(versions))
+}

--- a/vendor/github.com/blang/semver/v4/sql.go
+++ b/vendor/github.com/blang/semver/v4/sql.go
@@ -1,0 +1,30 @@
+package semver
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// Scan implements the database/sql.Scanner interface.
+func (v *Version) Scan(src interface{}) (err error) {
+	var str string
+	switch src := src.(type) {
+	case string:
+		str = src
+	case []byte:
+		str = string(src)
+	default:
+		return fmt.Errorf("version.Scan: cannot convert %T to string", src)
+	}
+
+	if t, err := Parse(str); err == nil {
+		*v = t
+	}
+
+	return
+}
+
+// Value implements the database/sql/driver.Valuer interface.
+func (v Version) Value() (driver.Value, error) {
+	return v.String(), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -24,6 +24,9 @@ github.com/antchfx/xpath
 github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.1+incompatible
 github.com/blang/semver
+# github.com/blang/semver/v4 v4.0.0
+## explicit
+github.com/blang/semver/v4
 # github.com/cenkalti/backoff/v4 v4.1.1
 ## explicit
 github.com/cenkalti/backoff/v4


### PR DESCRIPTION
This PR enables us to specify the OCP and Kubernetes version
applicability through annotations in the remediation objects.

This will read the following annotation keys:

    complianceascode.io/ocp-version

and

    complianceascode.io/k8s-version

Which allow us for defining ranges in semver format. e.g. `>4.10.1`

This is done through the `github.com/blang/semver/` library, which has
further descriptions about the range format.

When detecting the aforementioned annotations, they'll be transformed to
Compliance Operator equivalent ones. e.g. using the
`compliance.openshift.io/` prefix, as opposed to `complianceascode.io/`.

When a remediation is skipped due to this mechanism, an appropriate
event will be generated.

e.g.

```
0s          Warning   SkippingRemediation                compliancescan/upstream-rhcos4-moderate-worker                                     Skipping ComplianceRemediation 'openshift-compliance/upstream-rhcos4-moderate-worker-configure-usbguard-auditbackend'. Cluster doesn't match version range >=4.12.0
```

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>