### PR TITLE
Fix Kubernetes version dependency parsing bug

### DIFF
--- a/pkg/utils/parse_arf_result.go
+++ b/pkg/utils/parse_arf_result.go
@@ -933,12 +933,12 @@ func handleVersionDependencyAnnotation(u *unstructured.Unstructured, annotations
 		delete(inAnns, ocpVersionAnnotationKey)
 	}
 
-	if k8svrange, hasKubeDepKey := inAnns[kubeDependencyAnnotationKey]; hasKubeDepKey {
+	if k8svrange, hasKubeDepKey := inAnns[k8sVersionAnnotationKey]; hasKubeDepKey {
 		// set dependencies
 		annotations[compv1alpha1.K8SVersionDependencyAnnotation] = k8svrange
 
 		// reset metadata of output object
-		delete(inAnns, kubeDependencyAnnotationKey)
+		delete(inAnns, k8sVersionAnnotationKey)
 	}
 
 	u.SetAnnotations(inAnns)


### PR DESCRIPTION
The ARF parser was fetching the wrong annotation key, which wouldn't
have resulted in the appropriate behavior.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>