### PR TITLE
Remove permissions for aggregator to list nodes

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -345,14 +345,6 @@ metadata:
   name: remediation-aggregator
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - nodes  # Needed for version filtering
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - config.openshift.io
   resources:
   - clusteroperators  # Needed for version filtering


### PR DESCRIPTION
This was part of an initial iteration of the version dependency filtering
which wasn't used. So, these permissions are not really needed.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>