### PR TITLE
Add "infrastructure" to resources we always fetch

### DIFF
--- a/cmd/manager/scap.go
+++ b/cmd/manager/scap.go
@@ -146,6 +146,10 @@ func (c *scapContentDataStream) FigureResources(profile string) error {
 			ObjPath:  "/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver",
 			DumpPath: "/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver",
 		},
+		{
+			ObjPath:  "/apis/config.openshift.io/v1/infrastructures/cluster",
+			DumpPath: "/apis/config.openshift.io/v1/infrastructures/cluster",
+		},
 	}
 	effectiveProfile := profile
 


### PR DESCRIPTION
the "infrastructure/cluster" resource helps us determine the platform
we're running at. We add it to the list of resources we always fetch to
be able to write a CPE that will verify if we're on top of a certain
cloud. e.g. AWS.

Co-Authored-By: vincent056 <wenshen@redhat.com>
Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>