### PR TITLE
Release v0.1.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.45] - 2021-10-28
+### Changes
+- Add a more verbose Changelog for the recent versions
+- Add "infrastructure" to resources we always fetch
+- Remove permissions for aggregator to list nodes
+- Fix Kubernetes version dependency parsing bug
+- Implement version applicability for remediations
+- Add permissions to get and list machineset in preparation for implementation of req 3.4.1 pcidss
+- Add support for rendering variable in rule objects
+
 ## [0.1.44] - 2021-10-20
 ### Changes
  - enhancements

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.44'
+    olm.skipRange: '>=0.1.17 <0.1.45'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.44
+  name: compliance-operator.v0.1.45
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -343,6 +343,16 @@ spec:
           - update
           - delete
         serviceAccountName: compliance-operator
+      - rules:
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusteroperators
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: remediation-aggregator
       - rules:
         - apiGroups:
           - operator.openshift.io
@@ -1141,6 +1151,13 @@ spec:
           - secrets
           verbs:
           - get
+        - apiGroups:
+          - machine.openshift.io
+          resources:
+          - machinesets
+          verbs:
+          - get
+          - list
         serviceAccountName: api-resource-collector
       deployments:
       - name: compliance-operator
@@ -1175,10 +1192,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.5
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.44
+                  value: quay.io/compliance-operator/compliance-operator:0.1.45
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.44
+                image: quay.io/compliance-operator/compliance-operator:0.1.45
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources:
@@ -1503,4 +1520,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.44
+  version: 0.1.45

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.44"
+	Version = "0.1.45"
 )


### PR DESCRIPTION
## [0.1.45] - 2021-10-28
### Changes
- Add a more verbose Changelog for the recent versions
- Add "infrastructure" to resources we always fetch
- Remove permissions for aggregator to list nodes
- Fix Kubernetes version dependency parsing bug
- Implement version applicability for remediations
- Add permissions to get and list machineset in preparation for implementation of req 3.4.1 pcidss
- Add support for rendering variable in rule objects