### PR TITLE
Support deployments on all namespaces

### DIFF
--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1501,7 +1501,7 @@ spec:
     type: SingleNamespace
   - supported: true
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - security


### PR DESCRIPTION
This ensures that we support that the operator listens on all
namespaces. While this is not a big nor difficult change by itself, it
does require us to make a decision on where to deploy the default
profiles/profilebundles.

In the case where the operator is deployed on all namespaces, only the
operator namespace (openshift-compliance if using the recommendation)
will get our defaults.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>