### PR TITLE
metrics: Add ComplianceSuite status gauge and alert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,6 +383,8 @@ deploy-local: namespace image-to-cluster deploy-crds ## Deploy the operator from
 	$(SED) 's%$(IMAGE_REPO)/$(APP_NAME):latest%$(RELATED_IMAGE_OPERATOR_PATH)%' deploy/operator.yaml
 	$(SED) 's%$(IMAGE_REPO)/$(RELATED_IMAGE_OPENSCAP_NAME):$(RELATED_IMAGE_OPENSCAP_TAG)%$(RELATED_IMAGE_OPENSCAP_PATH)%' deploy/operator.yaml
 	@oc apply -n $(NAMESPACE) -f deploy/
+	@oc apply -f deploy/olm-catalog/compliance-operator/manifests/monitoring_clusterrolebinding.yaml
+	@oc apply -f deploy/olm-catalog/compliance-operator/manifests/monitoring_clusterrole.yaml
 	@$(SED) 's%$(RELATED_IMAGE_OPERATOR_PATH)%$(IMAGE_REPO)/$(APP_NAME):latest%' deploy/operator.yaml
 	@$(SED) 's%$(RELATED_IMAGE_OPENSCAP_PATH)%$(IMAGE_REPO)/$(RELATED_IMAGE_OPENSCAP_NAME):$(RELATED_IMAGE_OPENSCAP_TAG)%' deploy/operator.yaml
 	@oc set triggers -n $(NAMESPACE) deployment/compliance-operator --from-image openshift/compliance-operator:latest -c compliance-operator

--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ The compliance-operator exposes the following metrics to Prometheus when cluster
     # TYPE compliance_operator_compliance_scan_error_total counter
     compliance_operator_compliance_scan_error_total{name="scan-name",error="some_error"} 1
 
+    # HELP compliance_operator_compliance_state A gauge for the compliance state of a ComplianceSuite. Set to 0 when COMPLIANT, 1 when NON-COMPLIANT, 2 when INCONSISTENT, and 3 when ERROR
+    # TYPE compliance_operator_compliance_state gauge
+    compliance_operator_compliance_state{name="some-compliance-suite"} 1
+
 After logging into the console, navigating to Monitoring -> Metrics, the compliance_operator* metrics can be queried using the metrics dashboard. The `{__name__=~"compliance.*"}` query can be used to view the full set of metrics.
 
 Testing for the metrics from the cli can also be done directly with a pod that curls the metrics service. This is useful for troubleshooting.


### PR DESCRIPTION
* Add the compliance_operator_compliance_state gauge metric that switches to 1 for a ComplianceSuite with a NON-COMPLIANT result, 0 when COMPLIANT, and 2 when INCONSISTENT.
* Create a PrometheusRule warning alert for the gauge.
* Makefile: Apply Prometheus permissions from the manifest directory when running `make deploy-local`

@JAORMX @jhrozek @Vincent056 