### PR TITLE
Make showing `NotApplicable` results optional

### DIFF
--- a/cmd/manager/aggregator.go
+++ b/cmd/manager/aggregator.go
@@ -541,6 +541,11 @@ func createResults(crClient aggregatorCrClient, scan *compv1alpha1.ComplianceSca
 		if checkResultExists {
 			// Copy resource version and other metadata needed for update
 			foundCheckResult.ObjectMeta.DeepCopyInto(&pr.CheckResult.ObjectMeta)
+		} else if !scan.Spec.ShowNotApplicable && pr.CheckResult.Status == compv1alpha1.CheckResultNotApplicable {
+			// If the result is not applicable we skip creation
+			// Note that updating a not-applicable result should still
+			// work in order to get older deployments to keep working.
+			continue
 		}
 		// check is owned by the scan
 		if err := createOrUpdateOneResult(crClient, scan, checkResultLabels, checkResultAnnotations, checkResultExists, pr.CheckResult); err != nil {

--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -235,6 +235,11 @@ spec:
                 default: Node
                 description: The type of Compliance scan.
                 type: string
+              showNotApplicable:
+                default: false
+                description: Determines whether to hide or show results that are not
+                  applicable.
+                type: boolean
               strictNodeScan:
                 default: true
                 description: Defines whether the scan should proceed if we're not

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -265,6 +265,11 @@ spec:
                       default: Node
                       description: The type of Compliance scan.
                       type: string
+                    showNotApplicable:
+                      default: false
+                      description: Determines whether to hide or show results that
+                        are not applicable.
+                      type: boolean
                     strictNodeScan:
                       default: true
                       description: Defines whether the scan should proceed if we're

--- a/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
@@ -209,6 +209,10 @@ spec:
               format. Note the scan will still be triggered immediately, and the scheduled
               scans will start running only after the initial results are ready.
             type: string
+          showNotApplicable:
+            default: false
+            description: Determines whether to hide or show results that are not applicable.
+            type: boolean
           strictNodeScan:
             default: true
             description: Defines whether the scan should proceed if we're not able

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -191,6 +191,10 @@ type ComplianceScanSettings struct {
 	// These objects will annotated in the content itself with:
 	//     complianceascode.io/enforcement-type: <type>
 	RemediationEnforcement string `json:"remediationEnforcement,omitempty"`
+
+	// Determines whether to hide or show results that are not applicable.
+	// +kubebuilder:default=false
+	ShowNotApplicable bool `json:"showNotApplicable,omitempty"`
 }
 
 // ComplianceScanSpec defines the desired state of ComplianceScan

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1021,7 +1021,8 @@ func TestE2E(t *testing.T) {
 						Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
 						NodeSelector: selectNone,
 						ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
-							Debug: true,
+							Debug:             true,
+							ShowNotApplicable: true,
 						},
 					},
 				}
@@ -1886,7 +1887,8 @@ func TestE2E(t *testing.T) {
 									Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 									Content:      "ssg-rhcos4-ds.xml",
 									ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
-										Debug: true,
+										Debug:             true,
+										ShowNotApplicable: true,
 									},
 									NodeSelector: map[string]string{
 										"node-role.kubernetes.io/worker": "",


### PR DESCRIPTION
This adds the ability to optionally show or not show the `NotApplicable`
results as part of the compliance results. We've noticed that people get
concerned with the quantity of `NotApplicable` results, which will
increase as we add specific checks for different platforms.

This reduces the user's burden by skipping showing NotApplicable results
if the `showNotApplicable` is set to `false`. This also makes that
option the default.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>