### PR TITLE
Release v0.1.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.46] - 2021-12-01
+### Changes
+- metrics: Add ComplianceSuite status gauge and alert
+- Make shoting `NotApplicable` results optional
+- Support deployments on all namespaces
+- Log creation of default objects
+- Fix documentation for remediation templating
+
 ## [0.1.45] - 2021-10-28
 ### Changes
 - Add a more verbose Changelog for the recent versions

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -159,13 +159,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.17 <0.1.45'
+    olm.skipRange: '>=0.1.17 <0.1.46'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     repository: https://github.com/openshift/compliance-operator
     support: Red Hat Inc.
-  name: compliance-operator.v0.1.45
+  name: compliance-operator.v0.1.46
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1192,10 +1192,10 @@ spec:
                 - name: RELATED_IMAGE_OPENSCAP
                   value: quay.io/compliance-operator/openscap-ocp:1.3.5
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/compliance-operator/compliance-operator:0.1.45
+                  value: quay.io/compliance-operator/compliance-operator:0.1.46
                 - name: RELATED_IMAGE_PROFILE
                   value: quay.io/complianceascode/ocp4:latest
-                image: quay.io/compliance-operator/compliance-operator:0.1.45
+                image: quay.io/compliance-operator/compliance-operator:0.1.46
                 imagePullPolicy: Always
                 name: compliance-operator
                 resources:
@@ -1520,4 +1520,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.45
+  version: 0.1.46

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancescans_crd.yaml
@@ -236,6 +236,11 @@ spec:
                 default: Node
                 description: The type of Compliance scan.
                 type: string
+              showNotApplicable:
+                default: false
+                description: Determines whether to hide or show results that are not
+                  applicable.
+                type: boolean
               strictNodeScan:
                 default: true
                 description: Defines whether the scan should proceed if we're not

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_compliancesuites_crd.yaml
@@ -266,6 +266,11 @@ spec:
                       default: Node
                       description: The type of Compliance scan.
                       type: string
+                    showNotApplicable:
+                      default: false
+                      description: Determines whether to hide or show results that
+                        are not applicable.
+                      type: boolean
                     strictNodeScan:
                       default: true
                       description: Defines whether the scan should proceed if we're

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance.openshift.io_scansettings_crd.yaml
@@ -210,6 +210,10 @@ spec:
               format. Note the scan will still be triggered immediately, and the scheduled
               scans will start running only after the initial results are ready.
             type: string
+          showNotApplicable:
+            default: false
+            description: Determines whether to hide or show results that are not applicable.
+            type: boolean
           strictNodeScan:
             default: true
             description: Defines whether the scan should proceed if we're not able

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.45"
+	Version = "0.1.46"
 )


### PR DESCRIPTION
## [0.1.46] - 2021-12-01
### Changes
- metrics: Add ComplianceSuite status gauge and alert
- Make shoting `NotApplicable` results optional
- Support deployments on all namespaces
- Log creation of default objects
- Fix documentation for remediation templating