### PR TITLE
Add extra space optional around variable during parsing

### DIFF
--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -640,7 +640,7 @@ func ParseRulesAndDo(contentDom *xmlquery.Node, stdParser *referenceParser, pb *
 			}
 			var valueRendered []string
 			if description != nil {
-				p.Description, valueRendered, err = utils.RenderValues(utils.XmlNodeAsMarkdownPreRender(description), valuesList)
+				p.Description, valueRendered, err = utils.RenderValues(utils.XmlNodeAsMarkdownPreRender(description, true), valuesList)
 
 				if err != nil {
 					log.Error(err, "couldn't render variable in rules")
@@ -650,7 +650,7 @@ func ParseRulesAndDo(contentDom *xmlquery.Node, stdParser *referenceParser, pb *
 			}
 
 			if rationale != nil {
-				p.Rationale, valueRendered, err = utils.RenderValues(utils.XmlNodeAsMarkdownPreRender(rationale), valuesList)
+				p.Rationale, valueRendered, err = utils.RenderValues(utils.XmlNodeAsMarkdownPreRender(rationale, true), valuesList)
 				if err != nil {
 					log.Error(err, "couldn't render variable in rules")
 				} else if len(valueRendered) > 0 {

--- a/pkg/utils/xml2text.go
+++ b/pkg/utils/xml2text.go
@@ -12,24 +12,24 @@ import (
 	"github.com/pkg/errors"
 )
 
-func XmlNodeAsMarkdownPreRender(node *xmlquery.Node) string {
-	return xmlToMarkdown(node.OutputXML(false), true)
+func XmlNodeAsMarkdownPreRender(node *xmlquery.Node, needsSpace bool) string {
+	return xmlToMarkdown(node.OutputXML(false), true, needsSpace)
 }
 
 func XmlNodeAsMarkdown(node *xmlquery.Node) string {
-	return xmlToMarkdown(node.OutputXML(false), false)
+	return xmlToMarkdown(node.OutputXML(false), false, false)
 }
 
-func xmlToMarkdown(in string, preRender bool) string {
+func xmlToMarkdown(in string, preRender bool, needsSpace bool) string {
 
-	text, err := html2text.FromString(xmlToHtml(in, preRender), html2text.Options{PrettyTables: true, OmitLinks: false})
+	text, err := html2text.FromString(xmlToHtml(in, preRender, needsSpace), html2text.Options{PrettyTables: true, OmitLinks: false})
 	if err != nil {
 		return in
 	}
 	return text
 }
 
-func xmlToHtml(in string, preRender bool) string {
+func xmlToHtml(in string, preRender bool, needsSpace bool) string {
 	builder := strings.Builder{}
 	decoder := xml.NewDecoder(strings.NewReader(in))
 	for {
@@ -47,7 +47,7 @@ func xmlToHtml(in string, preRender bool) string {
 			if preRender && tok.Name.Local == "sub" && len(tok.Attr) > 1 {
 				if strings.HasPrefix(tok.Attr[0].Value, valuePrefix) {
 					// Have the check in nested if statment to avoid array out of bond
-					builder.WriteString(formateXccdfVar(tok.Attr[0].Value))
+					builder.WriteString(formateXccdfVar(tok.Attr[0].Value, needsSpace))
 				} else {
 					builder.WriteString(formatElement(tok.Name, "<"))
 				}
@@ -64,8 +64,11 @@ func xmlToHtml(in string, preRender bool) string {
 	return builder.String()
 }
 
-func formateXccdfVar(in string) string {
-	return " {{." + strings.TrimPrefix(in, valuePrefix) + "}} "
+func formateXccdfVar(in string, needsSpace bool) string {
+	if needsSpace {
+		return " {{." + strings.TrimPrefix(in, valuePrefix) + "}} "
+	}
+	return "{{." + strings.TrimPrefix(in, valuePrefix) + "}}"
 }
 
 func formatElement(elName xml.Name, tag string) string {

--- a/pkg/utils/xml2text_test.go
+++ b/pkg/utils/xml2text_test.go
@@ -15,11 +15,11 @@ var _ = Describe("XML conversions", func() {
 			const (
 				text = "System running in FIPS mode is indicated by kernel parameter 'crypto.fips_enabled'. This parameter should be set to 1 in FIPS mode. To enable FIPS mode, run the following command:\n\nfips-mode-setup --enable"
 			)
-			Expect(xmlToMarkdown(validXml, false)).To(Equal(text))
+			Expect(xmlToMarkdown(validXml, false, false)).To(Equal(text))
 		})
 
 		It("Should handle empty input", func() {
-			Expect(xmlToMarkdown("", false)).To(Equal(""))
+			Expect(xmlToMarkdown("", false, false)).To(Equal(""))
 		})
 
 	})
@@ -29,11 +29,11 @@ var _ = Describe("XML conversions", func() {
 			const (
 				html = "System running in FIPS mode is indicated by kernel parameter<code>'crypto.fips_enabled'</code>. This parameter should be set to<code>1</code>in FIPS mode.\nTo enable FIPS mode, run the following command:<p><pre>fips-mode-setup --enable</pre></p>"
 			)
-			Expect(xmlToHtml(validXml, false)).To(Equal(html))
+			Expect(xmlToHtml(validXml, false, false)).To(Equal(html))
 		})
 
 		It("Should pass through unknown namespaces", func() {
-			Expect(xmlToHtml("kernel parameter<xxx:code>&#39;crypto.fips_enabled&#39;</xxx:code>", false)).To(Equal("kernel parameter<xxx:code>'crypto.fips_enabled'</xxx:code>"))
+			Expect(xmlToHtml("kernel parameter<xxx:code>&#39;crypto.fips_enabled&#39;</xxx:code>", false, false)).To(Equal("kernel parameter<xxx:code>'crypto.fips_enabled'</xxx:code>"))
 		})
 	})
 
@@ -48,7 +48,7 @@ var _ = Describe("XML conversions", func() {
 			"var_selinux_policy_name-2": "2138",
 			"something":                 "1908",
 		}
-		preRender := xmlToMarkdown(html, true)
+		preRender := xmlToMarkdown(html, true, true)
 		It("Should parse", func() {
 			Expect(preRender).To(Equal(expectedHtml))
 		})


### PR DESCRIPTION
Since we are introducing the variable for API Resource Path for HyperShift, we don't want extra space around the variable as we do in the description, and rationale, hence we added a boolean to make it optional.