### PR TITLE
ScanSetting: Introduce special `@all` role to match all nodes

### DIFF
--- a/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
@@ -155,7 +155,14 @@ spec:
               <type>'
             type: string
           roles:
-            description: The list of roles to apply node-specific checks to
+            description: "The list of roles to apply node-specific checks to. \n This
+              will be translated to the standard Kubernetes role label `node-role.kubernetes.io/<role
+              name>`. \n It's also possible to specify `@all` as a role, which will
+              run a scan on all nodes by not specifying a node selector as we normally
+              do. The usage of `@all` in OpenShift is discouraged as the operator
+              won't be able to apply remediations unless roles are specified. \n Note
+              that tolerations must still be configured for the opeartor to appropriately
+              schedule scans."
             items:
               type: string
             type: array

--- a/go.sum
+++ b/go.sum
@@ -162,7 +162,6 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
-github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
@@ -171,7 +170,6 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/brancz/gojsontoyaml v0.0.0-20191212081931-bf2969bbd742/go.mod h1:IyUJYN1gvWjtLF5ZuygmxbnsAyP3aJS6cHzIuZY50B0=
@@ -231,7 +229,6 @@ github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3/go.mod h1:IV7qH
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v1.0.1 h1:IfVOxKbjyBn9maoye2JN95pgGYOmPkQVqxtOu7rtNIc=
 github.com/containerd/ttrpc v1.0.1/go.mod h1:UAxOpgT9ziI0gJrmKvgcZivgxOp8iFPSk8httJEt98Y=
-github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd h1:JNn81o/xG+8NEo3bC/vx9pbi/g2WI8mtP2/nXzu297Y=
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/containers/image v3.0.2+incompatible/go.mod h1:8Vtij257IWSanUQKe1tAeNOm2sRVkSqQTVQ1IlwI3+M=
 github.com/containers/image/v5 v5.5.1/go.mod h1:4PyNYR0nwlGq/ybVJD9hWlhmIsNra4Q8uOQX2s6E2uM=
@@ -318,7 +315,6 @@ github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avu
 github.com/docker/go-connections v0.3.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
-github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ+oDZB4KHQFypsfjYlq/C4rfL7D3g8=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
 github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQV8=
@@ -709,7 +705,6 @@ github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v1.7.7/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
-github.com/itchyny/go-flags v1.5.0 h1:Z5q2ist2sfDjDlExVPBrMqlsEDxDR2h4zuOElB0OEYI=
 github.com/itchyny/go-flags v1.5.0/go.mod h1:lenkYuCobuxLBAd/HGFE4LRoW8D3B6iXRQfWYJ+MNbA=
 github.com/itchyny/gojq v0.12.4 h1:8zgOZWMejEWCLjbF/1mWY7hY7QEARm7dtuhC6Bp4R8o=
 github.com/itchyny/gojq v0.12.4/go.mod h1:EQUSKgW/YaOxmXpAwGiowFDO4i2Rmtk5+9dFyeiymAg=
@@ -823,7 +818,6 @@ github.com/mattn/go-isatty v0.0.6/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/mattn/go-isatty v0.0.13 h1:qdl+GuBjcsKKDco5BsxPJlId98mSWNKqYA+Co0SC1yA=
 github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -951,7 +945,6 @@ github.com/opencontainers/runc v0.0.0-20191031171055-b133feaeeb2e/go.mod h1:qT5X
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc90 h1:4+xo8mtWixbHoEm451+WJNUrq12o2/tDsyK9Vgc/NcA=
 github.com/opencontainers/runc v1.0.0-rc90/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
-github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700 h1:eNUVfm/RFLIi1G7flU5/ZRTHvd4kcVuzfRnL6OFlzCI=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
@@ -982,13 +975,10 @@ github.com/operator-framework/operator-registry v1.13.4/go.mod h1:YhnIzOVjRU2ZwZ
 github.com/operator-framework/operator-sdk v0.19.4 h1:QI6k+WBDAXagx2OunEajQLa8LZwmRXu+x/SwmVZ/CCw=
 github.com/operator-framework/operator-sdk v0.19.4/go.mod h1:+gIlE/CfBGFGj51qJ2sLTPZWE1X27cKtjZ0m5vwY8Hw=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
-github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
-github.com/otiai10/curr v1.0.0 h1:TJIWdbX0B+kpNagQrjgq8bCMrbhiuX73M2XwgtDMoOI=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
-github.com/otiai10/mint v1.3.1 h1:BCmzIS3n71sGfHB5NMNDB3lHYPz8fWSkCAErHed//qc=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1166,7 +1156,6 @@ github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf h1:pvbZ0lM0XWPBqUKqFU8cma
 github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf/go.mod h1:RJID2RhlZKId02nZ62WenDCkgHFerpIOmW0iT7GKmXM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v0.0.0-20170130113145-4d4bfba8f1d1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -1517,7 +1506,6 @@ golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44 h1:Bli41pIlzTzf3KEY06n+xnzK/BESIg2ze4Pgfh/aI8c=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b h1:qh4f65QIVFjq9eBURLEYWqaEXmOyqdUyiBSgaXWccWk=
 golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1785,7 +1773,6 @@ gopkg.in/yaml.v3 v3.0.0-20191010095647-fc94e3f71652/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 helm.sh/helm/v3 v3.2.4/go.mod h1:ZaXz/vzktgwjyGGFbUWtIQkscfE7WYoRGP2szqAFHR0=

--- a/pkg/apis/compliance/v1alpha1/scansetting_types.go
+++ b/pkg/apis/compliance/v1alpha1/scansetting_types.go
@@ -4,6 +4,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	AllRoles = "@all"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ScanSetting is the Schema for the scansettings API
@@ -15,7 +19,19 @@ type ScanSetting struct {
 
 	ComplianceSuiteSettings `json:",inline"`
 	ComplianceScanSettings  `json:",inline"`
-	// The list of roles to apply node-specific checks to
+	// The list of roles to apply node-specific checks to.
+	//
+	// This will be translated to the standard Kubernetes
+	// role label `node-role.kubernetes.io/<role name>`.
+	//
+	// It's also possible to specify `@all` as a role, which
+	// will run a scan on all nodes by not specifying a node
+	// selector as we normally do. The usage of `@all` in
+	// OpenShift is discouraged as the operator won't
+	// be able to apply remediations unless roles are specified.
+	//
+	// Note that tolerations must still be configured for
+	// the opeartor to appropriately schedule scans.
 	Roles []string `json:"roles,omitempty"`
 }
 

--- a/pkg/utils/nodeutils.go
+++ b/pkg/utils/nodeutils.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	cmpv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
 )
 
 const (
@@ -122,6 +124,9 @@ func McfgPoolLabelMatches(nodeSelector map[string]string, pool *mcfgv1.MachineCo
 }
 
 func GetNodeRoleSelector(role string) map[string]string {
+	if role == cmpv1alpha1.AllRoles {
+		return map[string]string{}
+	}
 	return map[string]string{
 		nodeRolePrefix + role: "",
 	}

--- a/pkg/utils/nodeutils_test.go
+++ b/pkg/utils/nodeutils_test.go
@@ -2,158 +2,181 @@ package utils_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/compliance-operator/pkg/utils"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/compliance-operator/pkg/utils"
 )
 
 var _ = Describe("Nodeutils", func() {
-	Context("MachineConfig Pool with one custom KubeletConfig", func() {
-		targetNodeSelector := map[string]string{
-			"test-node-role": "",
-		}
-		const expKC string = "99-worker-generated-kubelet"
+	When("Testing IsMcfgPoolUsingKC", func() {
+		Context("MachineConfig Pool with one custom KubeletConfig", func() {
+			targetNodeSelector := map[string]string{
+				"test-node-role": "",
+			}
+			const expKC string = "99-worker-generated-kubelet"
 
-		mcp := &mcfgv1.MachineConfigPool{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "MachineConfigPool",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "testPool Name",
-			},
-			Spec: mcfgv1.MachineConfigPoolSpec{
-				NodeSelector: &metav1.LabelSelector{
-					MatchLabels: targetNodeSelector,
+			mcp := &mcfgv1.MachineConfigPool{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "MachineConfigPool",
+					APIVersion: "v1",
 				},
-				Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{
-					Source: []corev1.ObjectReference{
-						{
-							APIVersion: "machineconfiguration.openshift.io/v1",
-							Kind:       "MachineConfig",
-							Name:       "01-worker-kubelet",
-						},
-						{
-							APIVersion: "machineconfiguration.openshift.io/v1",
-							Kind:       "MachineConfig",
-							Name:       "99-worker-generated-kubelet",
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testPool Name",
+				},
+				Spec: mcfgv1.MachineConfigPoolSpec{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: targetNodeSelector,
+					},
+					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{
+						Source: []corev1.ObjectReference{
+							{
+								APIVersion: "machineconfiguration.openshift.io/v1",
+								Kind:       "MachineConfig",
+								Name:       "01-worker-kubelet",
+							},
+							{
+								APIVersion: "machineconfiguration.openshift.io/v1",
+								Kind:       "MachineConfig",
+								Name:       "99-worker-generated-kubelet",
+							},
 						},
 					},
 				},
-			},
-		}
-		isUsingKC, kc, err := utils.IsMcfgPoolUsingKC(mcp)
-		It("Get correct custom KC name", func() {
-			Expect(err).To(BeNil())
-			Expect(isUsingKC).To(BeTrue())
-			Expect(kc).To(Equal(expKC))
+			}
+			It("Gets correct custom KC name", func() {
+				isUsingKC, kc, err := utils.IsMcfgPoolUsingKC(mcp)
+				Expect(err).To(BeNil())
+				Expect(isUsingKC).To(BeTrue())
+				Expect(kc).To(Equal(expKC))
+
+			})
 
 		})
 
-	})
+		Context("MachineConfig Pool with no custom KubeletConfig", func() {
+			targetNodeSelector := map[string]string{
+				"test-node-role": "",
+			}
 
-	Context("MachineConfig Pool with no custom KubeletConfig", func() {
-		targetNodeSelector := map[string]string{
-			"test-node-role": "",
-		}
-
-		mcp := &mcfgv1.MachineConfigPool{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "MachineConfigPool",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "testPool Name",
-			},
-			Spec: mcfgv1.MachineConfigPoolSpec{
-				NodeSelector: &metav1.LabelSelector{
-					MatchLabels: targetNodeSelector,
+			mcp := &mcfgv1.MachineConfigPool{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "MachineConfigPool",
+					APIVersion: "v1",
 				},
-				Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{
-					Source: []corev1.ObjectReference{
-						{
-							APIVersion: "machineconfiguration.openshift.io/v1",
-							Kind:       "MachineConfig",
-							Name:       "01-worker-kubelet",
-						},
-						{
-							APIVersion: "machineconfiguration.openshift.io/v1",
-							Kind:       "MachineConfig",
-							Name:       "50-workers-chrony-configuration",
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testPool Name",
+				},
+				Spec: mcfgv1.MachineConfigPoolSpec{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: targetNodeSelector,
+					},
+					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{
+						Source: []corev1.ObjectReference{
+							{
+								APIVersion: "machineconfiguration.openshift.io/v1",
+								Kind:       "MachineConfig",
+								Name:       "01-worker-kubelet",
+							},
+							{
+								APIVersion: "machineconfiguration.openshift.io/v1",
+								Kind:       "MachineConfig",
+								Name:       "50-workers-chrony-configuration",
+							},
 						},
 					},
 				},
-			},
-		}
-		isUsingKC, kc, err := utils.IsMcfgPoolUsingKC(mcp)
-		It("Get correct custom KC name", func() {
-			Expect(err).To(BeNil())
-			Expect(isUsingKC).To(BeFalse())
-			Expect(kc).To(BeEmpty())
+			}
+			It("Get correct custom KC name", func() {
+				isUsingKC, kc, err := utils.IsMcfgPoolUsingKC(mcp)
+				Expect(err).To(BeNil())
+				Expect(isUsingKC).To(BeFalse())
+				Expect(kc).To(BeEmpty())
+
+			})
 
 		})
 
-	})
+		Context("MachineConfig Pool with many custom KubeletConfig", func() {
+			targetNodeSelector := map[string]string{
+				"test-node-role": "",
+			}
+			const expKC string = "99-worker-generated-kubelet-3"
 
-	Context("MachineConfig Pool with many custom KubeletConfig", func() {
-		targetNodeSelector := map[string]string{
-			"test-node-role": "",
-		}
-		const expKC string = "99-worker-generated-kubelet-3"
-
-		mcp := &mcfgv1.MachineConfigPool{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "MachineConfigPool",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "testPool Name",
-			},
-			Spec: mcfgv1.MachineConfigPoolSpec{
-				NodeSelector: &metav1.LabelSelector{
-					MatchLabels: targetNodeSelector,
+			mcp := &mcfgv1.MachineConfigPool{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "MachineConfigPool",
+					APIVersion: "v1",
 				},
-				Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{
-					Source: []corev1.ObjectReference{
-						{
-							APIVersion: "machineconfiguration.openshift.io/v1",
-							Kind:       "MachineConfig",
-							Name:       "01-worker-kubelet",
-						},
-						{
-							APIVersion: "machineconfiguration.openshift.io/v1",
-							Kind:       "MachineConfig",
-							Name:       "99-worker-generated-kubelet",
-						},
-						{
-							APIVersion: "machineconfiguration.openshift.io/v1",
-							Kind:       "MachineConfig",
-							Name:       "99-worker-generated-kubelet-1",
-						},
-						{
-							APIVersion: "machineconfiguration.openshift.io/v1",
-							Kind:       "MachineConfig",
-							Name:       "99-worker-generated-kubelet-2",
-						},
-						{
-							APIVersion: "machineconfiguration.openshift.io/v1",
-							Kind:       "MachineConfig",
-							Name:       "99-worker-generated-kubelet-3",
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testPool Name",
+				},
+				Spec: mcfgv1.MachineConfigPoolSpec{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: targetNodeSelector,
+					},
+					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{
+						Source: []corev1.ObjectReference{
+							{
+								APIVersion: "machineconfiguration.openshift.io/v1",
+								Kind:       "MachineConfig",
+								Name:       "01-worker-kubelet",
+							},
+							{
+								APIVersion: "machineconfiguration.openshift.io/v1",
+								Kind:       "MachineConfig",
+								Name:       "99-worker-generated-kubelet",
+							},
+							{
+								APIVersion: "machineconfiguration.openshift.io/v1",
+								Kind:       "MachineConfig",
+								Name:       "99-worker-generated-kubelet-1",
+							},
+							{
+								APIVersion: "machineconfiguration.openshift.io/v1",
+								Kind:       "MachineConfig",
+								Name:       "99-worker-generated-kubelet-2",
+							},
+							{
+								APIVersion: "machineconfiguration.openshift.io/v1",
+								Kind:       "MachineConfig",
+								Name:       "99-worker-generated-kubelet-3",
+							},
 						},
 					},
 				},
-			},
-		}
-		isUsingKC, kc, err := utils.IsMcfgPoolUsingKC(mcp)
-		It("Get correct custom KC name", func() {
-			Expect(err).To(BeNil())
-			Expect(isUsingKC).To(BeTrue())
-			Expect(kc).To(Equal(expKC))
+			}
+			It("Get correct custom KC name", func() {
+				isUsingKC, kc, err := utils.IsMcfgPoolUsingKC(mcp)
+				Expect(err).To(BeNil())
+				Expect(isUsingKC).To(BeTrue())
+				Expect(kc).To(Equal(expKC))
+
+			})
 
 		})
-
 	})
 
+	When("Testing getting labels from roles", func() {
+		DescribeTable("Gets expected output",
+			func(role string, expectation map[string]string) {
+				got := utils.GetNodeRoleSelector(role)
+				Expect(got).To(HaveLen(len(expectation)),
+					"node selector wasn't of expected length")
+				for expectKey, expectVal := range expectation {
+					gotVal, ok := got[expectKey]
+					Expect(ok).To(BeTrue(),
+						"node selector didn't have expected key '%s'", expectKey)
+					Expect(gotVal).To(Equal(expectVal),
+						"node selector didn't have expected value '%s'", expectVal)
+				}
+			},
+			Entry("master", "master", map[string]string{"node-role.kubernetes.io/master": ""}),
+			Entry("worker", "worker", map[string]string{"node-role.kubernetes.io/worker": ""}),
+			Entry("@all", "@all", map[string]string{}),
+		)
+	})
 })

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table.go
@@ -1,0 +1,110 @@
+/*
+
+Table provides a simple DSL for Ginkgo-native Table-Driven Tests
+
+The godoc documentation describes Table's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo#table-driven-tests
+
+*/
+
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/onsi/ginkgo/internal/global"
+	"github.com/onsi/ginkgo/types"
+)
+
+/*
+DescribeTable describes a table-driven test.
+
+For example:
+
+    DescribeTable("a simple table",
+        func(x int, y int, expected bool) {
+            Ω(x > y).Should(Equal(expected))
+        },
+        Entry("x > y", 1, 0, true),
+        Entry("x == y", 0, 0, false),
+        Entry("x < y", 0, 1, false),
+    )
+
+The first argument to `DescribeTable` is a string description.
+The second argument is a function that will be run for each table entry.  Your assertions go here - the function is equivalent to a Ginkgo It.
+The subsequent arguments must be of type `TableEntry`.  We recommend using the `Entry` convenience constructors.
+
+The `Entry` constructor takes a string description followed by an arbitrary set of parameters.  These parameters are passed into your function.
+
+Under the hood, `DescribeTable` simply generates a new Ginkgo `Describe`.  Each `Entry` is turned into an `It` within the `Describe`.
+
+It's important to understand that the `Describe`s and `It`s are generated at evaluation time (i.e. when Ginkgo constructs the tree of tests and before the tests run).
+
+Individual Entries can be focused (with FEntry) or marked pending (with PEntry or XEntry).  In addition, the entire table can be focused or marked pending with FDescribeTable and PDescribeTable/XDescribeTable.
+
+A description function can be passed to Entry in place of the description. The function is then fed with the entry parameters to generate the description of the It corresponding to that particular Entry.
+
+For example:
+
+	describe := func(desc string) func(int, int, bool) string {
+		return func(x, y int, expected bool) string {
+			return fmt.Sprintf("%s x=%d y=%d expected:%t", desc, x, y, expected)
+		}
+	}
+
+	DescribeTable("a simple table",
+		func(x int, y int, expected bool) {
+			Ω(x > y).Should(Equal(expected))
+		},
+		Entry(describe("x > y"), 1, 0, true),
+		Entry(describe("x == y"), 0, 0, false),
+		Entry(describe("x < y"), 0, 1, false),
+	)
+*/
+func DescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypeNone)
+	return true
+}
+
+/*
+You can focus a table with `FDescribeTable`.  This is equivalent to `FDescribe`.
+*/
+func FDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypeFocused)
+	return true
+}
+
+/*
+You can mark a table as pending with `PDescribeTable`.  This is equivalent to `PDescribe`.
+*/
+func PDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypePending)
+	return true
+}
+
+/*
+You can mark a table as pending with `XDescribeTable`.  This is equivalent to `XDescribe`.
+*/
+func XDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypePending)
+	return true
+}
+
+func describeTable(description string, itBody interface{}, entries []TableEntry, flag types.FlagType) {
+	itBodyValue := reflect.ValueOf(itBody)
+	if itBodyValue.Kind() != reflect.Func {
+		panic(fmt.Sprintf("DescribeTable expects a function, got %#v", itBody))
+	}
+
+	global.Suite.PushContainerNode(
+		description,
+		func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		},
+		flag,
+		codelocation.New(2),
+	)
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
@@ -1,0 +1,129 @@
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/onsi/ginkgo/internal/global"
+	"github.com/onsi/ginkgo/types"
+)
+
+/*
+TableEntry represents an entry in a table test.  You generally use the `Entry` constructor.
+*/
+type TableEntry struct {
+	Description  interface{}
+	Parameters   []interface{}
+	Pending      bool
+	Focused      bool
+	codeLocation types.CodeLocation
+}
+
+func (t TableEntry) generateIt(itBody reflect.Value) {
+	var description string
+	descriptionValue := reflect.ValueOf(t.Description)
+	switch descriptionValue.Kind() {
+	case reflect.String:
+		description = descriptionValue.String()
+	case reflect.Func:
+		values := castParameters(descriptionValue, t.Parameters)
+		res := descriptionValue.Call(values)
+		if len(res) != 1 {
+			panic(fmt.Sprintf("The describe function should return only a value, returned %d", len(res)))
+		}
+		if res[0].Kind() != reflect.String {
+			panic(fmt.Sprintf("The describe function should return a string, returned %#v", res[0]))
+		}
+		description = res[0].String()
+	default:
+		panic(fmt.Sprintf("Description can either be a string or a function, got %#v", descriptionValue))
+	}
+
+	if t.Pending {
+		global.Suite.PushItNode(description, func() {}, types.FlagTypePending, t.codeLocation, 0)
+		return
+	}
+
+	values := castParameters(itBody, t.Parameters)
+	body := func() {
+		itBody.Call(values)
+	}
+
+	if t.Focused {
+		global.Suite.PushItNode(description, body, types.FlagTypeFocused, t.codeLocation, global.DefaultTimeout)
+	} else {
+		global.Suite.PushItNode(description, body, types.FlagTypeNone, t.codeLocation, global.DefaultTimeout)
+	}
+}
+
+func castParameters(function reflect.Value, parameters []interface{}) []reflect.Value {
+	res := make([]reflect.Value, len(parameters))
+	funcType := function.Type()
+	for i, param := range parameters {
+		if param == nil {
+			inType := funcType.In(i)
+			res[i] = reflect.Zero(inType)
+		} else {
+			res[i] = reflect.ValueOf(param)
+		}
+	}
+	return res
+}
+
+/*
+Entry constructs a TableEntry.
+
+The first argument is a required description (this becomes the content of the generated Ginkgo `It`).
+Subsequent parameters are saved off and sent to the callback passed in to `DescribeTable`.
+
+Each Entry ends up generating an individual Ginkgo It.
+*/
+func Entry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      false,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can focus a particular entry with FEntry.  This is equivalent to FIt.
+*/
+func FEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      false,
+		Focused:      true,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can mark a particular entry as pending with PEntry.  This is equivalent to PIt.
+*/
+func PEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      true,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can mark a particular entry as pending with XEntry.  This is equivalent to XIt.
+*/
+func XEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      true,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -205,6 +205,7 @@ github.com/olekukonko/tablewriter
 ## explicit
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
+github.com/onsi/ginkgo/extensions/table
 github.com/onsi/ginkgo/formatter
 github.com/onsi/ginkgo/internal/codelocation
 github.com/onsi/ginkgo/internal/containernode


### PR DESCRIPTION
This introduces the ability to detect `@all` in the ScanSettings roles.
When used, the scansettingbinding controller will set an empty
`nodeSelector` which will then match all nodes available.

This is mostly intended for non-openshift deployments, and, as expected,
this won't work with remediations.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>