### PR TITLE
Inherit scheduling for workloads from Compliance Operator manager

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -42,7 +42,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "compliance-operator"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: RELATED_IMAGE_OPENSCAP
               # Hardcoding this temporarily until its propagated to CI
               value: "quay.io/compliance-operator/openscap-ocp:1.3.5"
@@ -65,11 +67,3 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
-        - key: "node.kubernetes.io/unreachable"
-          operator: "Exists"
-          effect: "NoExecute"
-          tolerationSeconds: 120
-        - key: "node.kubernetes.io/not-ready"
-          operator: "Exists"
-          effect: "NoExecute"
-          tolerationSeconds: 120

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -1,12 +1,17 @@
 package common
 
 import (
+	"io/ioutil"
 	"os"
-
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"strings"
 )
 
-var complianceOperatorNamespace = "openshift-compliance"
+var (
+	complianceOperatorNamespace = "openshift-compliance"
+	complianceOperatorName      = "compliance-operator"
+)
+
+type RunModeType string
 
 const (
 	// OpenSCAPExitCodeCompliant defines a success coming from OpenSCAP
@@ -15,9 +20,19 @@ const (
 	OpenSCAPExitCodeNonCompliant string = "2"
 	// PodUnschedulableExitCode is a custom error that indicates that we couldn't schedule the pod
 	PodUnschedulableExitCode string = "unschedulable"
+
+	// taken from k8sutil
+	ForceRunModeEnv             = "OSDK_FORCE_RUN_MODE"
+	LocalRunMode    RunModeType = "local"
+	ClusterRunMode  RunModeType = "cluster"
 )
 
 func init() {
+	name, ok := os.LookupEnv("OPERATOR_NAME")
+	if ok {
+		complianceOperatorName = name
+	}
+
 	if isRunModeLocal() {
 		ns, ok := os.LookupEnv("OPERATOR_NAMESPACE")
 		if ok {
@@ -29,19 +44,26 @@ func init() {
 			}
 		}
 	} else {
-		ns, err := k8sutil.GetOperatorNamespace()
-		if err == nil {
-			complianceOperatorNamespace = ns
+		nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		if err != nil {
+			return
 		}
+		complianceOperatorNamespace = strings.TrimSpace(string(nsBytes))
 	}
 }
 
 func isRunModeLocal() bool {
-	return os.Getenv(k8sutil.ForceRunModeEnv) == string(k8sutil.LocalRunMode)
+	return os.Getenv(ForceRunModeEnv) == string(LocalRunMode)
 }
 
 // GetComplianceOperatorNamespace gets the namespace that the operator is
 // currently running on.
 func GetComplianceOperatorNamespace() string {
 	return complianceOperatorNamespace
+}
+
+// GetComplianceOperatorName gets the name that the operator is
+// currently running with.
+func GetComplianceOperatorName() string {
+	return complianceOperatorName
 }

--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -42,7 +42,7 @@ const (
 
 // Add creates a new ComplianceRemediation Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, met *metrics.Metrics) error {
+func Add(mgr manager.Manager, met *metrics.Metrics, _ utils.CtlplaneSchedulingInfo) error {
 	return add(mgr, newReconciler(mgr, met))
 }
 

--- a/pkg/controller/compliancescan/scantype.go
+++ b/pkg/controller/compliancescan/scantype.go
@@ -305,7 +305,7 @@ func (ph *platformScanTypeHandler) validate() (bool, error) {
 
 func (ph *platformScanTypeHandler) createScanWorkload() error {
 	ph.l.Info("Creating a Platform scan pod")
-	pod := newPlatformScanPod(ph.scan, ph.l)
+	pod := ph.r.newPlatformScanPod(ph.scan, ph.l)
 	return ph.r.launchScanPod(ph.scan, pod, ph.l)
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,22 +1,27 @@
 package controller
 
 import (
-	"github.com/openshift/compliance-operator/pkg/controller/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/openshift/compliance-operator/pkg/controller/metrics"
+	"github.com/openshift/compliance-operator/pkg/utils"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager, *metrics.Metrics) error
+var AddToManagerFuncs []func(manager.Manager, *metrics.Metrics, utils.CtlplaneSchedulingInfo) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager, met *metrics.Metrics) error {
+func AddToManager(m manager.Manager,
+	met *metrics.Metrics,
+	si utils.CtlplaneSchedulingInfo,
+) error {
 	// Add metrics Startup to the manager
 	if err := m.Add(met); err != nil {
 		return err
 	}
 
 	for _, f := range AddToManagerFuncs {
-		if err := f(m, met); err != nil {
+		if err := f(m, met, si); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/scansettingbinding/scansettingbinding_controller.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller.go
@@ -37,7 +37,7 @@ const (
 
 var log = logf.Log.WithName("scansettingbindingctrl")
 
-func Add(mgr manager.Manager, met *metrics.Metrics) error {
+func Add(mgr manager.Manager, met *metrics.Metrics, _ utils.CtlplaneSchedulingInfo) error {
 	return add(mgr, newReconciler(mgr, met))
 }
 

--- a/pkg/controller/scansettingbinding/scansettingbinding_controller_test.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller_test.go
@@ -224,7 +224,11 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 		err = mockMetrics.Register()
 		Expect(err).To(BeNil())
 
-		reconciler = ReconcileScanSettingBinding{client: client, scheme: scheme, metrics: mockMetrics}
+		reconciler = ReconcileScanSettingBinding{
+			client:  client,
+			scheme:  scheme,
+			metrics: mockMetrics,
+		}
 	})
 
 	Context("Creates a simple suite from a Profile", func() {

--- a/pkg/controller/tailoredprofile/tailoredprofile_controller.go
+++ b/pkg/controller/tailoredprofile/tailoredprofile_controller.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/openshift/compliance-operator/pkg/controller/metrics"
+	"github.com/openshift/compliance-operator/pkg/utils"
 
 	"github.com/go-logr/logr"
 	"github.com/openshift/compliance-operator/pkg/controller/common"
@@ -36,7 +37,7 @@ const (
 
 // Add creates a new TailoredProfile Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, met *metrics.Metrics) error {
+func Add(mgr manager.Manager, met *metrics.Metrics, _ utils.CtlplaneSchedulingInfo) error {
 	return add(mgr, newReconciler(mgr, met))
 }
 

--- a/pkg/utils/ctlplaneinfo.go
+++ b/pkg/utils/ctlplaneinfo.go
@@ -1,0 +1,10 @@
+package utils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+type CtlplaneSchedulingInfo struct {
+	Selector    map[string]string
+	Tolerations []corev1.Toleration
+}


### PR DESCRIPTION
When the Compliance Operator was first coded, some assumptions were made
that were specific to Openshift. One of these assumptions was the fact
that the `node-role.kubernetes.io/` was more actively used amongst other
distros. An even worst assumption was that the `master` role was always
available. These statements hold true for OpenShift, but not for other
distros like EKS.

This PR removes that assumption by making every workload inherit the
same `nodeSelector` and `tolerations` from the controller manager. This
is done by passing this information to every controller. However, using
the information is optional.

When CO begins, the manager will query it's own pod and fetch this
information. Failure to do so will result in an error.

Since we fetch the operator name and namespace from constants, the
constants were modified to not depend any more on k8sutils. the
aforementioned library will no longer be available in further versions
of operator-sdk, so it's better to move away from it now little by
little.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>