### PR TITLE
Fix bugs where kubeletconfig gets deletes when unapplying

### DIFF
--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -279,6 +279,12 @@ func (r *ReconcileComplianceRemediation) patchRemediation(remObj *unstructured.U
 }
 
 func (r *ReconcileComplianceRemediation) deleteRemediation(remObj *unstructured.Unstructured, foundObj *unstructured.Unstructured, logger logr.Logger) error {
+
+	if utils.IsKubeletConfig(remObj) {
+		logger.Info("Can't unapply since it is KubeletConfig Remediation")
+		return nil
+	}
+
 	logger.Info("Remediation will be deleted")
 
 	if !compv1alpha1.RemediationWasCreatedByOperator(foundObj) {


### PR DESCRIPTION
Related Bugzilla link: https://bugzilla.redhat.com/show_bug.cgi?id=2032420

As for right now, let's not support unapplying kubeletconfig remediation, we need to come up with a plan later on that