### PR TITLE
Add EKS deployment manifest

### DIFF
--- a/deploy/eks.yaml
+++ b/deploy/eks.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: compliance-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: compliance-operator
+  template:
+    metadata:
+      labels:
+        name: compliance-operator
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    spec:
+      serviceAccountName: compliance-operator
+      containers:
+        - name: compliance-operator
+          image: "quay.io/compliance-operator/compliance-operator:latest"
+          command:
+          - compliance-operator
+          - operator
+          - --platform
+          - eks
+          imagePullPolicy: Always
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              memory: "20Mi"
+              cpu: "10m"
+            limits:
+              memory: "200Mi"
+              cpu: "100m"
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: RELATED_IMAGE_OPENSCAP
+              # Hardcoding this temporarily until its propagated to CI
+              value: "quay.io/compliance-operator/openscap-ocp:1.3.5"
+            - name: RELATED_IMAGE_OPERATOR
+              value: "quay.io/compliance-operator/compliance-operator:latest"
+            - name: RELATED_IMAGE_PROFILE
+              value: "quay.io/complianceascode/ocp4:latest"
+          volumeMounts:
+            - name: serving-cert
+              mountPath: /var/run/secrets/serving-cert
+              readOnly: true
+      volumes:
+        - name: serving-cert
+          secret:
+            secretName: compliance-operator-serving-cert
+            optional: true


### PR DESCRIPTION
This adds a simple deployment manifest for EKS. The idea would be
that this would be generated by kustomize at some point. But let's
have this here while that gets worked out.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>