### PR TITLE
Initialize inherited selector and tolerations if null

### DIFF
--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -406,9 +406,19 @@ func getSchedulingInfo(ctx context.Context, cli client.Reader) (utils.CtlplaneSc
 	if err := cli.Get(ctx, key, &pod); err != nil {
 		return utils.CtlplaneSchedulingInfo{}, err
 	}
+
+	sel := pod.Spec.NodeSelector
+	if sel == nil {
+		sel = map[string]string{}
+	}
+	tol := pod.Spec.Tolerations
+	if tol == nil {
+		tol = []corev1.Toleration{}
+	}
+
 	return utils.CtlplaneSchedulingInfo{
-		Selector:    pod.Spec.NodeSelector,
-		Tolerations: pod.Spec.Tolerations,
+		Selector:    sel,
+		Tolerations: tol,
 	}, nil
 }
 

--- a/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -84,8 +84,6 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    default:
-                      node-role.kubernetes.io/master: ""
                     description: By setting this, it's possible to configure where
                       the result server instances are run. These instances will mount
                       a Persistent Volume to store the raw results, so special care
@@ -123,10 +121,6 @@ spec:
                     nullable: true
                     type: string
                   tolerations:
-                    default:
-                    - effect: NoSchedule
-                      key: node-role.kubernetes.io/master
-                      operator: Exists
                     description: Specifies tolerations needed for the result server
                       to run on the nodes. This is useful in case the target set of
                       nodes have custom taints that don't allow certain workloads

--- a/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -105,8 +105,6 @@ spec:
                         nodeSelector:
                           additionalProperties:
                             type: string
-                          default:
-                            node-role.kubernetes.io/master: ""
                           description: By setting this, it's possible to configure
                             where the result server instances are run. These instances
                             will mount a Persistent Volume to store the raw results,
@@ -147,10 +145,6 @@ spec:
                           nullable: true
                           type: string
                         tolerations:
-                          default:
-                          - effect: NoSchedule
-                            key: node-role.kubernetes.io/master
-                            operator: Exists
                           description: Specifies tolerations needed for the result
                             server to run on the nodes. This is useful in case the
                             target set of nodes have custom taints that don't allow

--- a/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_scansettings_crd.yaml
@@ -58,8 +58,6 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                default:
-                  node-role.kubernetes.io/master: ""
                 description: By setting this, it's possible to configure where the
                   result server instances are run. These instances will mount a Persistent
                   Volume to store the raw results, so special care should be taken
@@ -97,10 +95,6 @@ spec:
                 nullable: true
                 type: string
               tolerations:
-                default:
-                - effect: NoSchedule
-                  key: node-role.kubernetes.io/master
-                  operator: Exists
                 description: Specifies tolerations needed for the result server to
                   run on the nodes. This is useful in case the target set of nodes
                   have custom taints that don't allow certain workloads to run. Defaults

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -145,12 +145,10 @@ type RawResultStorageSettings struct {
 	// By setting this, it's possible to configure where the result server instances
 	// are run. These instances will mount a Persistent Volume to store the raw
 	// results, so special care should be taken to schedule these in trusted nodes.
-	// +kubebuilder:default={"node-role.kubernetes.io/master": ""}
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Specifies tolerations needed for the result server to run on the nodes. This is useful
 	// in case the target set of nodes have custom taints that don't allow certain
 	// workloads to run. Defaults to allowing scheduling on master nodes.
-	// +kubebuilder:default={{key: "node-role.kubernetes.io/master", operator: "Exists", effect: "NoSchedule"}}
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 


### PR DESCRIPTION
This prevents the default to kick in and instead uses the actual
inherited value.

This also changes the CRDs to stop defaulting the raw storage scheduling to the master nodes.
Instead relying on the inherited values from the main compliance-operator
deployment.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>