### PR TITLE
Add labels to indicate availability for other arches

### DIFF
--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -169,7 +169,6 @@ metadata:
   namespace: placeholder
   labels:
     operatorframework.io/arch.amd64: supported
-    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
 spec:

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -167,6 +167,11 @@ metadata:
     support: Red Hat Inc.
   name: compliance-operator.v0.1.47
   namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:


### PR DESCRIPTION
We have done the validation for the ocp4-cis and ocp4-cis-node profiles on ppc64le and are ready to for this operator to be supported on this architecture.