### PR TITLE
Update the TailoredProfile example to include a description

### DIFF
--- a/deploy/crds/compliance.openshift.io_v1alpha1_tailoredprofile_cr.yaml
+++ b/deploy/crds/compliance.openshift.io_v1alpha1_tailoredprofile_cr.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   extends: ocp4-moderate
   title: My little profile
+  description: 'Example of a tailoredProfile that extends OCP4 FedRAMP Moderate'
   disableRules:
     - name: ocp4-file-permissions-node-config
       rationale: This breaks X application.


### PR DESCRIPTION
A previous commit (68a9a0b73d229663ecea2dd334f92b15d3919938) required
`TailoredProfiles` to have `description` and `title` attributes, but we
forgot to update the example custom resource in deploy/crds. If you try
and apply the custom resource to a deployment, it will fail validation.

This commit updates the example custom resource so that you can apply it
as is.