### PR TITLE
Bug 2040401: fix can't find owner of 98-<pool>-generated-kubelet

### DIFF
--- a/pkg/utils/nodeutils.go
+++ b/pkg/utils/nodeutils.go
@@ -84,7 +84,8 @@ func IsMcfgPoolUsingKC(pool *mcfgv1.MachineConfigPool) (bool, string, error) {
 	var currentKCMC string
 	for i := range pool.Spec.Configuration.Source {
 		kcName := pool.Spec.Configuration.Source[i].Name
-		if strings.Contains(kcName, generatedKubelet) {
+		// The prefix has to start with 99 since the kubeletconfig generated machine config will always start with 99
+		if strings.HasPrefix(kcName, "99-") && strings.Contains(kcName, generatedKubelet) {
 			// First find if there is just one cutom KubeletConfig
 			if maxNum == -1 {
 				if strings.HasSuffix(kcName, generatedKubeletSuffix) {

--- a/pkg/utils/nodeutils_test.go
+++ b/pkg/utils/nodeutils_test.go
@@ -100,6 +100,54 @@ var _ = Describe("Nodeutils", func() {
 
 		})
 
+		Context("MachineConfig Pool with no custom KubeletConfig", func() {
+			targetNodeSelector := map[string]string{
+				"test-node-role": "",
+			}
+
+			mcp := &mcfgv1.MachineConfigPool{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "MachineConfigPool",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testPool Name",
+				},
+				Spec: mcfgv1.MachineConfigPoolSpec{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: targetNodeSelector,
+					},
+					Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{
+						Source: []corev1.ObjectReference{
+							{
+								APIVersion: "machineconfiguration.openshift.io/v1",
+								Kind:       "MachineConfig",
+								Name:       "01-worker-kubelet",
+							},
+							{
+								APIVersion: "machineconfiguration.openshift.io/v1",
+								Kind:       "MachineConfig",
+								Name:       "50-workers-chrony-configuration",
+							},
+							{
+								APIVersion: "machineconfiguration.openshift.io/v1",
+								Kind:       "MachineConfig",
+								Name:       "98-worker-generated-kubelet",
+							},
+						},
+					},
+				},
+			}
+			It("Get correct custom KC name", func() {
+				isUsingKC, kc, err := utils.IsMcfgPoolUsingKC(mcp)
+				Expect(err).To(BeNil())
+				Expect(isUsingKC).To(BeFalse())
+				Expect(kc).To(BeEmpty())
+
+			})
+
+		})
+
 		Context("MachineConfig Pool with many custom KubeletConfig", func() {
 			targetNodeSelector := map[string]string{
 				"test-node-role": "",


### PR DESCRIPTION
the vsphere-upi installer created some kubelet configuration files `98-<pool>-generated-kubelet`, and they were recognized as `kubeletconfig` generated mc by CO, to fix that we added an additional check to check if the prefix of kubelet mc have `99-`. since the custom `kubeletconfig` will always generate mc with name scheme `99-<pool>-generated-kubelet-<num>`

Related Bugzilla Link: https://bugzilla.redhat.com/show_bug.cgi?id=2040401