### PR TITLE
Add network to api-resources we always fetch

### DIFF
--- a/cmd/manager/scap.go
+++ b/cmd/manager/scap.go
@@ -151,6 +151,10 @@ func (c *scapContentDataStream) FigureResources(profile string) error {
 			ObjPath:  "/apis/config.openshift.io/v1/infrastructures/cluster",
 			DumpPath: "/apis/config.openshift.io/v1/infrastructures/cluster",
 		},
+		{
+			ObjPath:  "/apis/config.openshift.io/v1/networks/cluster",
+			DumpPath: "/apis/config.openshift.io/v1/networks/cluster",
+		},
 	}
 	effectiveProfile := profile
 	var valuesList map[string]string


### PR DESCRIPTION
The network resource helps us determine the network type of the platform we're running on. 

We add it to the list of resources we always fetch to be able to write a CPE that will verify if the cluster has an OVN/SDN network type

This PR works in conjunction with: https://github.com/ComplianceAsCode/content/pull/8134