### PR TITLE
Break the release process apart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Internal Changes
 
--
+- Implemented a multi-step release process to prevent unintentional changes
+  from making their way into the release
+  ([bug](https://github.com/openshift/compliance-operator/issues/783))
 
 ### Deprecations
 

--- a/Makefile
+++ b/Makefile
@@ -490,16 +490,22 @@ git-release: package-version-to-tag changelog
 	git add "CHANGELOG.md"
 	git commit -m "Release v$(TAG)"
 	git tag "v$(TAG)"
-	git push origin "v$(TAG)"
-	git push origin "release-v$(TAG)"
 
 .PHONY: fetch-git-tags
 fetch-git-tags:
 	# Make sure we are caught up with tags
 	git fetch -t
 
-.PHONY: release
-release: fetch-git-tags release-tag-image bundle push push-index undo-deploy-tag-image git-release ## Do an official release (Requires permissions)
+.PHONY: prepare-release
+prepare-release: bundle
+
+.PHONY: push-release
+push-release: ## Do an official release (Requires permissions)
+	git push origin "v$(TAG)"
+	git push origin "release-v$(TAG)"
+
+.PHONY: release-images
+release-images:release-tag-image push push-index undo-deploy-tag-image
 	# This will ensure that we also push to the latest tag
 	$(MAKE) push TAG=latest
 

--- a/README.md
+++ b/README.md
@@ -523,3 +523,34 @@ The following is an example release note for a feature with a security note.
     deployment, its infrastructure, or applications. Make sure you send raw
     results to trusted nodes.
 ```
+
+### Proposing Releases
+
+The release process is separated into three phases, with dedicated `make`
+targets. All targets require that you supply the `OPERATOR_VERSION` prior to
+running `make`, which should be a semantic version formatted string (e.g.,
+`OPERATOR_VERSION=0.1.49`).
+
+#### Preparing the Release
+
+The first phase of the release process is preparing the release locally. You
+can do this by running the `make prepare-release` target. All changes are
+committed locally. This is intentional so that you have the opportunity to
+review the changes before proposing the release in the next step.
+
+#### Proposing the Release
+
+The second phase of the release is to push the release to a dedicated branch
+against the origin repository. You can perform this step using the `make
+push-release` target.
+
+Please note, this step makes changes to the upstream repository, so it is
+imperative that you review the changes you're committing prior to this step.
+This steps also requires that you have necessary permissions on the repository.
+
+#### Releasing Images
+
+The third and final step of the release is to build new images and push them to
+an offical image registry. You can build new images and push using `make
+release-images`. Note that this operation also requires you have proper
+permissions on the remote registry.


### PR DESCRIPTION
The `make release` target lumped the entire release process together,
which was nice for simplicity, but it doesn't give you, the person
proposing the release, an opportunity to review the changes before
they're proposed.

In the event something is incorrect (e.g., if the operator-sdk did
something we didn't expect), we should have the ability to catch that
and fix it before proposing the release. Otherwise, we will need to fix
upstream branches and update outdated tags.

Fixes #783