### PR TITLE
use default value for DumpPath to enable runtime resource path customization without modification of ComplianceAsCode rule schema and macros

### DIFF
--- a/cmd/manager/scap_test.go
+++ b/cmd/manager/scap_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Testing SCAP parsing and storage", func() {
 				},
 				{
 					ObjPath:  "/api/v1/namespaces/customized/configmaps/kas-config",
-					DumpPath: "/api/v1/namespaces/customized/configmaps/kas-config",
+					DumpPath: "/api/v1/namespaces/master-mycluster1/configmaps/kas-config",
 				},
 			}
 			_, valuesList := getResourcePaths(tpContentDS, contentDS, "xccdf_org.ssgproject.content_profile_platform-moderate", nil)


### PR DESCRIPTION

### Background
Runtime customization expands the capability of compliance operator from standard installation to customized installation such as [HyperShift](https://github.com/openshift/hypershift). In [another PR](https://github.com/openshift/compliance-operator/pull/750), we have enabled customization of API resource collection.  In addition to that, we also need to customize the scan target filepath.

### Solution
There are two solution candidates. One solution is introducing new variable in `yamlfile_value` template of ComplianceAsCode/content as I created in [a PR](https://github.com/ComplianceAsCode/content/pull/7928). However, it duplicates the variable definition in two positions (`.warnings` and `.template.vars`) and it may cause *update anomarly* in future.

In this PR, we leverage the difference of `ObjPath` and `DumpPath` to trick `oscap` command. The API resource collector accesses `ObjPath`, which is locked to a default value. And then it saves the resource to `DumpPath`, which is specified as custom value.

You can find an example in [an issue](https://github.com/tmishina/compliance-operator/issues/2).

### Discussion Point
- I modified `valuesList` from `map[string]string` to `map[string]map[string]string`, but is this good solution? Do we need to introduce some well-defined type for our porpose?
- I will also check the behavior for rules with `jqfilter`.

