### PR TITLE
Address follow-up comments to PR 786

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Implemented a multi-step release process to prevent unintentional changes
   from making their way into the release
-  ([bug](https://github.com/openshift/compliance-operator/issues/783))
+  ([bug](https://github.com/openshift/compliance-operator/issues/783)).
 
 ### Deprecations
 

--- a/Makefile
+++ b/Makefile
@@ -488,8 +488,6 @@ git-release: package-version-to-tag changelog
 	git add "deploy/olm-catalog/compliance-operator/"
 	git add "deploy/compliance-operator-chart/Chart.yaml"
 	git add "CHANGELOG.md"
-	git commit -m "Release v$(TAG)"
-	git tag "v$(TAG)"
 
 .PHONY: fetch-git-tags
 fetch-git-tags:
@@ -497,15 +495,17 @@ fetch-git-tags:
 	git fetch -t
 
 .PHONY: prepare-release
-prepare-release: bundle
+prepare-release: release-tag-image bundle git-release
 
 .PHONY: push-release
 push-release: ## Do an official release (Requires permissions)
+	git commit -m "Release v$(TAG)"
+	git tag "v$(TAG)"
 	git push origin "v$(TAG)"
 	git push origin "release-v$(TAG)"
 
 .PHONY: release-images
-release-images:release-tag-image push push-index undo-deploy-tag-image
+release-images: push push-index undo-deploy-tag-image
 	# This will ensure that we also push to the latest tag
 	$(MAKE) push TAG=latest
 

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ running `make`, which should be a semantic version formatted string (e.g.,
 
 The first phase of the release process is preparing the release locally. You
 can do this by running the `make prepare-release` target. All changes are
-committed locally. This is intentional so that you have the opportunity to
+staged locally. This is intentional so that you have the opportunity to
 review the changes before proposing the release in the next step.
 
 #### Proposing the Release


### PR DESCRIPTION
We recently refactored our release process to give maintainers the
ability to review changes before offically submitting the release.

There were some follow on comments during the review and this commit
addresses them.