### PR TITLE
e2e: Don't rely on order of inconsistent results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Implemented a multi-step release process to prevent unintentional changes
   from making their way into the release
   ([bug](https://github.com/openshift/compliance-operator/issues/783)).
+- The TestInconsistentResult e2e test was relying on a certain order of results.
+  This bug was fixed and the test now passes with any order of results.
 
 ### Deprecations
 


### PR DESCRIPTION
The TestInconsistentResult e2e test was relying on a certain order in
which a test result is labeled. If the result order was swapped, even if
it contained the same results, the test would fail.

This patch fixes the test to accept either of the two possible
orderings. Since there's only two, both are hardcoded and checked, if we
ever have more combinations, we'll refactor the code so that it is more
generic.
