### PR TITLE
Reconcile ScanSettingBindings when a TailoredProfile changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixes
 
--
+- When a TailoredProfile transitions from Ready to Error, the corresponding
+  ConfigMap is removed. This prevents the ConfigMap from being reused with
+  obsolete data while the parent object is in fact marked with an error
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - When a TailoredProfile transitions from Ready to Error, the corresponding
   ConfigMap is removed. This prevents the ConfigMap from being reused with
   obsolete data while the parent object is in fact marked with an error
+- The ScanSettingBinding controller now reconciles TailoredProfile instances
+  related to a ScanSettingBinding. This ensures that the controller can
+  proceed with generating scans in case the binding used to point to 
+  TailoredProfile that had been marked with an error, but was subsequently
+  fixed ([upstream issue 791](https://github.com/openshift/compliance-operator/issues/791))
 
 ### Internal Changes
 

--- a/pkg/controller/scansettingbinding/scansettingbinding_controller.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller.go
@@ -72,10 +72,19 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// Watch for changes to secordary resource ScanSetting. Since Setting does not link directly to a Binding,
+	// Watch for changes to secondary resource ScanSetting. Since Setting does not link directly to a Binding,
 	// but the other way around, we use a mapper to enqueue requests for Binding(s) used by a Setting
 	err = c.Watch(&source.Kind{Type: &compliancev1alpha1.ScanSetting{}}, &handler.EnqueueRequestsFromMapFunc{
 		ToRequests: &scanSettingMapper{mgr.GetClient()},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to secondary resource TailoredProfile. Since TailoredProfile does not link directly to a Binding,
+	// but the other way around, we use a mapper to enqueue requests for TailoredProfiles(s) used by a Setting
+	err = c.Watch(&source.Kind{Type: &compliancev1alpha1.TailoredProfile{}}, &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: &tailoredProfileMapper{mgr.GetClient()},
 	})
 	if err != nil {
 		return err

--- a/pkg/controller/scansettingbinding/tailored_profile_mapper.go
+++ b/pkg/controller/scansettingbinding/tailored_profile_mapper.go
@@ -1,0 +1,53 @@
+package scansettingbinding
+
+import (
+	"context"
+	"github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type tailoredProfileMapper struct {
+	client.Client
+}
+
+func (s *tailoredProfileMapper) Map(obj handler.MapObject) []reconcile.Request {
+	var requests []reconcile.Request
+
+	ssbList := v1alpha1.ScanSettingBindingList{}
+	err := s.List(context.TODO(), &ssbList, &client.ListOptions{})
+	if err != nil {
+		return requests
+	}
+
+	for _, ssb := range ssbList.Items {
+		add := false
+
+		for _, profRef := range ssb.Profiles {
+			if profRef.Kind != "TailoredProfile" {
+				continue
+			}
+
+			if profRef.Name != obj.Meta.GetName() {
+				continue
+			}
+
+			add = true
+			break
+		}
+
+		if add == false {
+			continue
+		}
+
+		objKey := types.NamespacedName{
+			Name:      ssb.GetName(),
+			Namespace: ssb.GetNamespace(),
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: objKey})
+	}
+
+	return requests
+}


### PR DESCRIPTION
Modifies the ScanSettingBinding controller to also watch for
TailoredProfile CRs which link to a TP. This allows to reconcile
ScanSettingBindings in case a TailoredProfile is modified, typically
after fixing issues in a TailoredProfile without having to recreate the
TailoredProfile.

Fixes: #791

NOTE: I haven't had the chance to test the e2e addition at all. Feedback is welcome
in the meantime and maybe the tests will even pass :-)
