### PR TITLE
doc: Document the strictNodeScan setting better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,7 +210,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changes
  - enhancements
      - Add option to make scan scheduling strict/not strict - adds a new
-       ComplianceScan/Suite/ScanSetting option called strictNode scan.
+       ComplianceScan/Suite/ScanSetting option called strictNodeScan.
        This option defaults to true meaning that the operator will error
        out of a scan pod can't be scheduled. Switching the option to
        true makes the scan more permissive and go forward. Useful for

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -366,7 +366,11 @@ The following attributes can be set in the `ScanSetting:
 * **rawResultStorage.tolerations**:  Specifies tolerations needed
   for the result server to run on the nodes. This is useful in
   case the target set of nodes have custom taints that don't allow certain
-	workloads to run. Defaults to allowing scheduling on master nodes.
+  workloads to run. Defaults to allowing scheduling on master nodes.
+* **strictNodeScan**: Defines whether the scan should proceed if we're not able to
+  scan all the nodes or not. `true` means that the operator
+  should be strict and error out. `false` means that we don't
+  need to be strict and we can proceed.
 
 A single `ScanSetting` object can also be reused for multiple scans,
 as it merely defines the settings.

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -28,6 +28,15 @@ to a (CRD document)[crds.md] to learn more API objects.
      the `debug` option to be set. Enabling this option increases verbosity
      of the openscap scanner pods as well as some other helper pods.
 
+   * Many CRs, most importantly `ComplianceSuite` and `ScanSetting` allow
+     the `debug` option to be set. Enabling this option increases verbosity
+     of the openscap scanner pods as well as some other helper pods.
+
+   * The same CRs contain options that allow more precise scheduling of scanner
+     pods, such as `strictNodeScan` which controls whether the scan should 
+     proceed even if not all nodes can be scanned.
+     See `oc explain scansettings` for the full list of options.
+
    * If a single rule is passing or failing unexpectedly, it could be helpful
      to run a single scan or a suite with only that rule - you can find the
      rule ID from the corresponding `ComplianceCheckResult` object and use it


### PR DESCRIPTION
There seemed to be several real use-cases for the strictNodeScan option
lately, but it seems that the option is not very well discoverable.

Fix the option name in the changelog and mention it in the crds.md document
as well as add a blurb in the troubleshooting document.