### PR TITLE
e2e: Fix TestInconsistentResult

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -2616,8 +2616,8 @@ func TestE2E(t *testing.T) {
 				} else if len(workerNodes) == 2 {
 					// example: ip-10-0-184-135.us-west-1.compute.internal:PASS,ip-10-0-226-48.us-west-1.compute.internal:FAIL
 					var expectedInconsistentSource [2]string
-					expectedInconsistentSource[0] = workerNodes[0].Name + ":" + string(compv1alpha1.CheckResultPass) + "," + workerNodes[1].Name + string(compv1alpha1.CheckResultFail)
-					expectedInconsistentSource[1] = workerNodes[1].Name + ":" + string(compv1alpha1.CheckResultFail) + "," + workerNodes[0].Name + string(compv1alpha1.CheckResultPass)
+					expectedInconsistentSource[0] = workerNodes[0].Name + ":" + string(compv1alpha1.CheckResultPass) + "," + workerNodes[1].Name + ":" + string(compv1alpha1.CheckResultFail)
+					expectedInconsistentSource[1] = workerNodes[1].Name + ":" + string(compv1alpha1.CheckResultFail) + "," + workerNodes[0].Name + ":" + string(compv1alpha1.CheckResultPass)
 
 					inconsistentSources := rootLoginCheck.Annotations[compv1alpha1.ComplianceCheckResultInconsistentSourceAnnotation]
 					if inconsistentSources != expectedInconsistentSource[0] && inconsistentSources != expectedInconsistentSource[1] {


### PR DESCRIPTION
The TestInconsistentResult e2e test is relying on an annotation to determine the test result. In the case of 2 worker nodes, the expected annotation is not correctly built, so the test fails.

This patch fixes the expected annotation.