### PR TITLE
feat: variable substitution for jqfilter directive

### DIFF
--- a/cmd/manager/scap.go
+++ b/cmd/manager/scap.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"io/ioutil"
 	"os"
@@ -220,7 +221,7 @@ func getResourcePaths(profileDefs *xmlquery.Node, ruleDefs *xmlquery.Node, profi
 				if val.SelectAttr("selector") == "" {
 					// It is not an enum choice, but a default value instead
 					if strings.HasPrefix(variable.SelectAttr("id"), valuePrefix) {
-						valuesList[strings.TrimPrefix(variable.SelectAttr("id"), valuePrefix)] = val.OutputXML(false)
+						valuesList[strings.TrimPrefix(variable.SelectAttr("id"), valuePrefix)] = html.UnescapeString(val.OutputXML(false))
 					}
 				}
 			}
@@ -228,7 +229,7 @@ func getResourcePaths(profileDefs *xmlquery.Node, ruleDefs *xmlquery.Node, profi
 		allSetValues := xmlquery.Find(def, "//xccdf-1.2:set-value")
 		for _, variable := range allSetValues {
 			if strings.HasPrefix(variable.SelectAttr("idref"), valuePrefix) {
-				valuesList[strings.TrimPrefix(variable.SelectAttr("idref"), valuePrefix)] = variable.OutputXML(false)
+				valuesList[strings.TrimPrefix(variable.SelectAttr("idref"), valuePrefix)] = html.UnescapeString(variable.OutputXML(false))
 			}
 		}
 	}

--- a/cmd/manager/scap_test.go
+++ b/cmd/manager/scap_test.go
@@ -76,6 +76,7 @@ var _ = Describe("Testing SCAP parsing and storage", func() {
 				{
 					ObjPath:  "/api/v1/namespaces/master-mycluster1/configmaps/kas-config",
 					DumpPath: "/api/v1/namespaces/master-mycluster1/configmaps/kas-config",
+					Filter:   ".apiServerArguments",
 				},
 			}
 			got, _ := getResourcePaths(contentDS, contentDS, "xccdf_org.ssgproject.content_profile_platform-moderate", nil)
@@ -150,6 +151,7 @@ var _ = Describe("Testing SCAP parsing and storage", func() {
 				{
 					ObjPath:  "/api/v1/namespaces/customized/configmaps/kas-config",
 					DumpPath: "/api/v1/namespaces/customized/configmaps/kas-config",
+					Filter:   ".data[\"config.yaml\"] | fromjson | .apiServerArguments",
 				},
 			}
 			_, valuesList := getResourcePaths(tpContentDS, contentDS, "xccdf_org.ssgproject.content_profile_platform-moderate", nil)

--- a/pkg/utils/parse_arf_result.go
+++ b/pkg/utils/parse_arf_result.go
@@ -104,7 +104,11 @@ func GetPathFromWarningXML(in *xmlquery.Node, valuesList map[string]string) ([]R
 				filterNode := in.SelectElement(fmt.Sprintf(`//*[@id="filter-%s"]`, pathID))
 				dumpNode := in.SelectElement(fmt.Sprintf(`//*[@id="dump-%s"]`, pathID))
 				if filterNode != nil && dumpNode != nil {
-					filter = filterNode.InnerText()
+					filter, _, err = RenderValues(filterNode.InnerText(), valuesList)
+					if err != nil {
+						errMsgs = append(errMsgs, err.Error())
+						continue
+					}
 					dumpPath = dumpNode.InnerText()
 				}
 			}

--- a/pkg/utils/parse_arf_result.go
+++ b/pkg/utils/parse_arf_result.go
@@ -3,12 +3,12 @@ package utils
 import (
 	"bytes"
 	"fmt"
-	"html/template"
 	"io"
 	"net/url"
 	"regexp"
 	"sort"
 	"strings"
+	"text/template"
 	"text/template/parse"
 
 	"github.com/antchfx/xmlquery"
@@ -104,12 +104,12 @@ func GetPathFromWarningXML(in *xmlquery.Node, valuesList map[string]string) ([]R
 				filterNode := in.SelectElement(fmt.Sprintf(`//*[@id="filter-%s"]`, pathID))
 				dumpNode := in.SelectElement(fmt.Sprintf(`//*[@id="dump-%s"]`, pathID))
 				if filterNode != nil && dumpNode != nil {
-					filter, _, err = RenderValues(filterNode.InnerText(), valuesList)
+					filter, _, err = RenderValues(XmlNodeAsMarkdown(filterNode), valuesList)
 					if err != nil {
 						errMsgs = append(errMsgs, err.Error())
 						continue
 					}
-					dumpPath = dumpNode.InnerText()
+					dumpPath, _, err = RenderValues(XmlNodeAsMarkdown(dumpNode), valuesList)
 				}
 			}
 			apiPaths = append(apiPaths, ResourcePath{ObjPath: path, DumpPath: dumpPath, Filter: filter})

--- a/pkg/utils/xml2text.go
+++ b/pkg/utils/xml2text.go
@@ -3,9 +3,9 @@ package utils
 import (
 	"bytes"
 	"encoding/xml"
-	"html/template"
 	"io"
 	"strings"
+	"text/template"
 
 	"github.com/antchfx/xmlquery"
 	"github.com/jaytaylor/html2text"

--- a/tests/data/tailored-profile.xml
+++ b/tests/data/tailored-profile.xml
@@ -8,5 +8,6 @@
     <xccdf-1.2:description override="true">CIS Benchmark for Hypershift</xccdf-1.2:description>
     <xccdf-1.2:select idref="xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd" selected="true"/>
     <xccdf-1.2:set-value idref="xccdf_org.ssgproject.content_value_openshift_kube_apiserver_config_namespace">customized</xccdf-1.2:set-value>
+    <xccdf-1.2:set-value idref="xccdf_org.ssgproject.content_value_jqfilter">.data["config.yaml"] | fromjson | .apiServerArguments</xccdf-1.2:set-value>
   </xccdf-1.2:Profile>
 </xccdf-1.2:Tailoring></ds:component></ds:data-stream-collection>


### PR DESCRIPTION

This pull request provides one more customization capability to Compliance Operator in addition to the previous PR #750.

#750 supports customization of API resource path, and this PR supports customization of jqfilter.
When this PR has been merged, anyone can write a  jqfilter string with variables in a [ComplianceAsCode](https://github.com/ComplianceAsCode/content) rule like below.

```
{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
```
In this example, `{{.var_openshift_kube_apiserver_config_data_name}}` in the first line will be substituted with the value of variable `var_openshift_kube_apiserver_config_data_name`. 

This is a concrete example rule for [HyperShift](https://github.com/openshift/hypershift). Configuration data of OpenShift API Server in a HyperShift environment is stored in `.data."config.json"` while that of standard OpenShift API Server is in `.data."config.yaml"`.

By using this feature, we can support more platforms like HyperShift and other managed environments in addition to standard OpenShift installations.