### PR TITLE
bug #2059611: scan: Only scan Linux nodes with node scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   proceed with generating scans in case the binding used to point to 
   TailoredProfile that had been marked with an error, but was subsequently
   fixed ([upstream issue 791](https://github.com/openshift/compliance-operator/issues/791))
+- Node scans are only scheduled on nodes running Linux. This allows running
+  scans on cluster with a mix of Linux and Windows nodes. ([RHBZ #2059611](https://bugzilla.redhat.com/show_bug.cgi?id=2059611))
 
 ### Internal Changes
 

--- a/pkg/controller/compliancescan/compliancescan_controller_test.go
+++ b/pkg/controller/compliancescan/compliancescan_controller_test.go
@@ -61,12 +61,14 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 		// Nodes in the deployment
 		nodeinstance1 = &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node-1",
+				Name:   "node-1",
+				Labels: map[string]string{"kubernetes.io/os": "linux"},
 			},
 		}
 		nodeinstance2 = &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node-2",
+				Name:   "node-2",
+				Labels: map[string]string{"kubernetes.io/os": "linux"},
 			},
 		}
 

--- a/pkg/controller/compliancescan/scantype.go
+++ b/pkg/controller/compliancescan/scantype.go
@@ -85,8 +85,10 @@ func (nh *nodeScanTypeHandler) getTargetNodes() ([]corev1.Node, error) {
 	case compv1alpha1.ScanTypePlatform:
 		return nodes.Items, nil // Nodes are only relevant to the node scan type. Return the empty node list otherwise.
 	case compv1alpha1.ScanTypeNode:
+		// we only scan Linux nodes
+		nodeScanSelector := map[string]string{"kubernetes.io/os": "linux"}
 		listOpts := client.ListOptions{
-			LabelSelector: labels.SelectorFromSet(nh.scan.Spec.NodeSelector),
+			LabelSelector: labels.SelectorFromSet(labels.Merge(nh.scan.Spec.NodeSelector, nodeScanSelector)),
 		}
 
 		if err := nh.r.client.List(context.TODO(), &nodes, &listOpts); err != nil {


### PR DESCRIPTION
The node scans can only be scheduled on Linux nodes because the OpenScap
scanner is compiled as a Linux binary. Remediations work fine because
even if a pool consists of multiple OSs, the machineConfigPool only
contains Linux nodes.

Most containers (e.g. aggregator, resultserver), when running on OCP, are
already scheduled on master nodes by default anyway, which only run Linux.

JIRA: [OCPBUGSM-41212](https://issues.redhat.com/browse/OCPBUGSM-41212)