### PR TITLE
Increase e2e timeout

### DIFF
--- a/tests/e2e/constants.go
+++ b/tests/e2e/constants.go
@@ -4,7 +4,7 @@ import "time"
 
 const (
 	retryInterval                 = time.Second * 5
-	timeout                       = time.Minute * 20
+	timeout                       = time.Minute * 30
 	cleanupRetryInterval          = time.Second * 1
 	cleanupTimeout                = time.Minute * 5
 	machineOperationTimeout       = time.Minute * 25


### PR DESCRIPTION
We added one more parallel test, and some tests like `TestSuiteWithContentThatDoesNotMatch` are getting timeout because of this, let's increase the timeout to 30 mins instead.