### PR TITLE
Make sure we convert the release version to tag in all release targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -512,14 +512,14 @@ fetch-git-tags:
 prepare-release: release-tag-image bundle git-release
 
 .PHONY: push-release
-push-release: ## Do an official release (Requires permissions)
+push-release: package-version-to-tag ## Do an official release (Requires permissions)
 	git commit -m "Release v$(TAG)"
 	git tag "v$(TAG)"
 	git push origin "v$(TAG)"
 	git push origin "release-v$(TAG)"
 
 .PHONY: release-images
-release-images: push push-index undo-deploy-tag-image
+release-images: package-version-to-tag push push-index undo-deploy-tag-image
 	# This will ensure that we also push to the latest tag
 	$(MAKE) push TAG=latest
 


### PR DESCRIPTION
We recently broke apart the release process, but we forgot to add the
conversion of the release version to the tag in the last two steps.

This commit adds that step to the last two parts of the release process
so it doesn't fail or assume 'latest' for the release version.