### PR TITLE
Modify the api-resource-collector to fetch network operator resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Enhancements
 
--
+- The `api-resource-collector` `ClusterRole` has been updated to fetch network
+  resources for the `operator.openshift.io` API group. This is necessary to
+  automate checks that ensure the cluster is using a CNI that supports network
+  policies. Please refere to the
+  [bug](https://bugzilla.redhat.com/show_bug.cgi?id=2072431) for more
+  information.
 
 ### Fixes
 

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -414,6 +414,7 @@ rules:
   - ingresscontrollers
   - kubeapiservers
   - openshiftapiservers
+  - networks
   verbs:
   - get
   - list


### PR DESCRIPTION
The CIS benchmarks recommends using a CNI that supports network
policies. Previously, this was a manual check in the profile, but it's
actually something we can check by querying the K8S operator API.

This commit adds the network resource to the operator.openshift.io API
group so that the api-resource container can fetch that resource. This
change is required to automate this check and used in:

  https://github.com/ComplianceAsCode/content/pull/8524

Partial-Fix: https://bugzilla.redhat.com/show_bug.cgi?id=2072431