### PR TITLE
Added permission for api-resource-collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,21 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 -
 
+## [0.1.50] - 2022-04-05
+
+### Enhancements
+
+- Added necessary permessions for api-resource-collector so that the new rule
+  `cluster_logging_operator_exist` can be evaluate properly. [1]
+  [1] https://github.com/ComplianceAsCode/content/pull/8511
+
+### Fixes
+
+- 
+
+### Removals
+
+- 
 
 ## [0.1.49] - 2022-03-22
 

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1146,6 +1146,16 @@ rules:
   - list
   - watch
 - apiGroups:
+  - logging.openshift.io
+  resources:
+  - clusterloggings
+  resourceNames:
+  - instance
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - flowcontrol.apiserver.k8s.io
   resources:
   - flowschemas


### PR DESCRIPTION
We are going to have a new rule to check if cluster logging operator has been installed, that requires api-resource-collector to have additional permission to read clusterloggings resources.[1] PR to the new rule: https://github.com/ComplianceAsCode/content/pull/8511