### PR TITLE
Fetch node resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Internal Changes
 
--
+- Added node resource to the list of resources we always fetch so that arch CPEs will
+  be evaluated appropriately.
 
 ### Deprecations
 

--- a/cmd/manager/scap.go
+++ b/cmd/manager/scap.go
@@ -156,6 +156,10 @@ func (c *scapContentDataStream) FigureResources(profile string) error {
 			ObjPath:  "/apis/config.openshift.io/v1/networks/cluster",
 			DumpPath: "/apis/config.openshift.io/v1/networks/cluster",
 		},
+		{
+			ObjPath:  "/api/v1/nodes",
+			DumpPath: "/api/v1/nodes",
+		},
 	}
 	effectiveProfile := profile
 	var valuesList map[string]string


### PR DESCRIPTION
Added node resource to the list of resources we always fetch so that arch CPEs will be evaluated appropriately.