### PR TITLE
Update api-resource-collector cluster role to check if GitOps operator is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   [bug](https://bugzilla.redhat.com/show_bug.cgi?id=2072431) for more
   information.
 
+- The `api-resource-collector` `ClusterRole` has been updated to fetch network
+  resources for the `gitopsservices.pipelines.openshift.io` API group. This is
+  necessary to automate checks that ensure the cluster is using GitOps operator.
+
 ### Fixes
 
 -

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1227,4 +1227,12 @@ rules:
   verbs:
   - get
   - list
-
+# Necessary to check GitOps operator present for high requirements
+- apiGroups:
+  - gitopsservices.pipelines.openshift.io
+  resources:
+  - gitopsservices
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Added permission for `api-resource-collector` to fetch network resources for the `gitopsservices.pipelines.openshift.io` API group, so that we can if the cluster is using GitOps operator