### PR TITLE
Bug 2075029: scans: Delete scan pods and aggregator when they're done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   [Cusomter Case](https://access.redhat.com/support/cases/#/case/03199627) for more
   information
 
+- The scan pods and the aggregator pod were never removed after a scan run which
+  might have [prevented](https://bugzilla.redhat.com/show_bug.cgi?id=2075029)
+  the cluster-autoscaler from running.
+
 ### Internal Changes
 
 - Added node resource to the list of resources we always fetch so that arch CPEs will
@@ -59,7 +63,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Enhancements
 
 - Added necessary permessions for api-resource-collector so that the new rule
-  `cluster_logging_operator_exist` can be evaluate properly. [1]
+  `cluster_logging_operator_exist` can be evaluated properly. [1]
   [1] https://github.com/ComplianceAsCode/content/pull/8511
 
 ### Fixes

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -116,6 +116,7 @@ func (r *ReconcileComplianceScan) launchAggregatorPod(scanInstance *compv1alpha1
 }
 
 func (r *ReconcileComplianceScan) deleteAggregator(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
+	logger.Info("Deleting aggregator pod")
 	aggregator := r.newAggregatorPod(instance, logger)
 	err := r.client.Delete(context.TODO(), aggregator)
 	if err != nil && !errors.IsNotFound(err) {

--- a/pkg/controller/compliancescan/scantype.go
+++ b/pkg/controller/compliancescan/scantype.go
@@ -273,6 +273,7 @@ func (nh *nodeScanTypeHandler) gatherResults() (compv1alpha1.ComplianceScanStatu
 }
 
 func (nh *nodeScanTypeHandler) cleanup() error {
+	nh.l.Info("Deleting node scan pods")
 	if err := nh.r.deleteScanPods(nh.scan, nh.nodes, nh.l); err != nil {
 		nh.l.Error(err, "Cannot delete scan pods")
 		return err
@@ -384,6 +385,7 @@ func (ph *platformScanTypeHandler) gatherResults() (compv1alpha1.ComplianceScanS
 }
 
 func (ph *platformScanTypeHandler) cleanup() error {
+	ph.l.Info("Deleting platform scan pods")
 	if err := ph.r.deletePlatformScanPod(ph.scan, ph.l); err != nil {
 		ph.l.Error(err, "Cannot delete platform scan pod")
 		return err


### PR DESCRIPTION
We didn't delete scan pods and the aggregator after a scan was done
unless the delete was forced by the scan object being deleted. This
appears to be breaking the cluster-autoscaler which can't drain pods
from nodes that are not backed by a replicating controller.

Since there appears to be no reason to keep the pods around unless the
debug=true option is set, let's remove those pods when the scan reaches
done and only keep the other resources around that are needed for
eventually re-running the scan.

Jira: [OCPBUGSM-43262](https://issues.redhat.com//browse/OCPBUGSM-43262)
