### PR TITLE
Use Quay compliance-operator/compliance-operator-content for content …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixes
 
--
+- The compliance content images have moved to
+  [compliance-operator/compliance-operator-content](https://quay.io/repository/compliance-operator/compliance-operator-content)
+  Quay repository. This should be a transparent change for end users and fixes
+  CI that relies on content for end-to-end testing.
 
 ### Internal Changes
 

--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,8 @@ E2E_SKIP_CONTAINER_BUILD?=false
 E2E_GO_TEST_FLAGS?=-test.v -test.timeout 120m
 
 # Specifies the image path to use for the content in the tests
-DEFAULT_CONTENT_IMAGE_PATH=quay.io/complianceascode/ocp4:latest
-E2E_CONTENT_IMAGE_PATH?=quay.io/complianceascode/ocp4:latest
+DEFAULT_CONTENT_IMAGE_PATH=quay.io/compliance-operator/compliance-operator-content:latest
+E2E_CONTENT_IMAGE_PATH?=quay.io/compliance-operator/compliance-operator-content:latest
 # We specifically omit the tag here since we use this for testing
 # different images referenced by different tags.
 E2E_BROKEN_CONTENT_IMAGE_PATH?=quay.io/compliance-operator/test-broken-content

--- a/deploy/compliance-operator-chart/templates/deployment.yaml
+++ b/deploy/compliance-operator-chart/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - name: RELATED_IMAGE_OPERATOR
               value: "quay.io/compliance-operator/compliance-operator:latest"
             - name: RELATED_IMAGE_PROFILE
-              value: "quay.io/complianceascode/ocp4:latest"
+              value: "quay.io/compliance-operator/compliance-operator-content:latest"
           volumeMounts:
             - name: serving-cert
               mountPath: /var/run/secrets/serving-cert

--- a/deploy/crds/compliance.openshift.io_v1alpha1_compliancesuite_cr.yaml
+++ b/deploy/crds/compliance.openshift.io_v1alpha1_compliancesuite_cr.yaml
@@ -9,11 +9,11 @@ spec:
     - name: workers-scan
       profile: xccdf_org.ssgproject.content_profile_moderate
       content: ssg-rhcos4-ds.xml
-      contentImage: quay.io/complianceascode/ocp4:latest
+      contentImage: quay.io/compliance-operator/compliance-operator-content:latest
       nodeSelector:
         node-role.kubernetes.io/worker: ""
     - name: platform-scan
       scanType: Platform
       profile: xccdf_org.ssgproject.content_profile_moderate
       content: ssg-ocp4-ds.xml
-      contentImage: quay.io/complianceascode/ocp4:latest
+      contentImage: quay.io/compliance-operator/compliance-operator-content:latest

--- a/deploy/crds/compliance.openshift.io_v1alpha1_profilebundle_cr.yaml
+++ b/deploy/crds/compliance.openshift.io_v1alpha1_profilebundle_cr.yaml
@@ -3,5 +3,5 @@ kind: ProfileBundle
 metadata:
   name: ocp4
 spec:
-  contentImage: quay.io/complianceascode/ocp4:latest
+  contentImage: quay.io/compliance-operator/compliance-operator-content:latest
   contentFile: ssg-ocp4-ds.xml

--- a/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/compliance-operator/manifests/compliance-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
             "scans": [
               {
                 "content": "ssg-rhcos4-ds.xml",
-                "contentImage": "quay.io/complianceascode/ocp4:latest",
+                "contentImage": "quay.io/compliance-operator/compliance-operator-content:latest",
                 "name": "workers-scan",
                 "nodeSelector": {
                   "node-role.kubernetes.io/worker": ""
@@ -47,7 +47,7 @@ metadata:
               },
               {
                 "content": "ssg-ocp4-ds.xml",
-                "contentImage": "quay.io/complianceascode/ocp4:latest",
+                "contentImage": "quay.io/compliance-operator/compliance-operator-content:latest",
                 "name": "platform-scan",
                 "profile": "xccdf_org.ssgproject.content_profile_moderate",
                 "scanType": "Platform"
@@ -64,7 +64,7 @@ metadata:
           },
           "spec": {
             "contentFile": "ssg-ocp4-ds.xml",
-            "contentImage": "quay.io/complianceascode/ocp4:latest"
+            "contentImage": "quay.io/compliance-operator/compliance-operator-content:latest"
           }
         },
         {
@@ -1291,7 +1291,7 @@ spec:
                 - name: RELATED_IMAGE_OPERATOR
                   value: quay.io/compliance-operator/compliance-operator:0.1.49
                 - name: RELATED_IMAGE_PROFILE
-                  value: quay.io/complianceascode/ocp4:latest
+                  value: quay.io/compliance-operator/compliance-operator-content:latest
                 image: quay.io/compliance-operator/compliance-operator:0.1.49
                 imagePullPolicy: Always
                 name: compliance-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -51,7 +51,7 @@ spec:
             - name: RELATED_IMAGE_OPERATOR
               value: "quay.io/compliance-operator/compliance-operator:latest"
             - name: RELATED_IMAGE_PROFILE
-              value: "quay.io/complianceascode/ocp4:latest"
+              value: "quay.io/compliance-operator/compliance-operator-content:latest"
           volumeMounts:
             - name: serving-cert
               mountPath: /var/run/secrets/serving-cert

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -42,7 +42,7 @@ An example `ProfileBundle` object looks like this:
     namespace: openshift-compliance
   spec:
     contentFile: ssg-ocp4-ds.xml
-    contentImage: quay.io/complianceascode/ocp4:latest
+    contentImage: quay.io/compliance-operator/compliance-operator-content:latest
   status:
     dataStreamStatus: VALID
 ```
@@ -57,7 +57,7 @@ Where:
 * **status.errorMessage**: In case parsing of the content files fails, this
   attribute will contain a human-readable explanation.
 
-The ComplianceAsCode upstream image is located at `quay.io/complianceascode/ocp4:latest`.
+The ComplianceAsCode upstream image is located at `quay.io/compliance-operator/compliance-operator-content:latest`.
 For OCP4, the two most used `contentFile` values would be `ssg-ocp4-ds.xml` which contain
 the platform (Kubernetes) checks and `ssg-rhcos4-ds.xml` file which contains the node
 (OS level) checks. For these two files, the corresponding `ProfileBundle` objects are created
@@ -474,7 +474,7 @@ spec:
       scanType: Node
       profile: xccdf_org.ssgproject.content_profile_moderate
       content: ssg-rhcos4-ds.xml
-      contentImage: quay.io/complianceascode/ocp4:latest
+      contentImage: quay.io/compliance-operator/compliance-operator-content:latest
       rule: "xccdf_org.ssgproject.content_rule_no_netrc_files"
       nodeSelector:
         node-role.kubernetes.io/worker: ""
@@ -545,7 +545,7 @@ spec:
   scanType: Node
   profile: xccdf_org.ssgproject.content_profile_moderate
   content: ssg-ocp4-ds.xml
-  contentImage: quay.io/complianceascode/ocp4:latest
+  contentImage: quay.io/compliance-operator/compliance-operator-content:latest
   rule: "xccdf_org.ssgproject.content_rule_no_netrc_files"
   nodeSelector:
     node-role.kubernetes.io/worker: ""

--- a/doc/tutorials/workshop/content/exercises/03-creating-your-first-scan.md
+++ b/doc/tutorials/workshop/content/exercises/03-creating-your-first-scan.md
@@ -35,12 +35,12 @@ usability:
     product where product might be `ocp4` or `rhcos4`.
 
 By default, the Compliance Operator creates two `profilebundle` objects, one for
-OCP and one for RHCOS based on the [upstream ComplianceAsCode content images](https://quay.io/repository/complianceascode/ocp4):
+OCP and one for RHCOS based on the [upstream ComplianceAsCode content images](https://quay.io/repository/compliance-operator/compliance-operator-content):
 ```
 $ oc get profilebundle.compliance
 NAME     CONTENTIMAGE                           CONTENTFILE         STATUS
-ocp4     quay.io/complianceascode/ocp4:latest   ssg-ocp4-ds.xml     VALID
-rhcos4   quay.io/complianceascode/ocp4:latest   ssg-rhcos4-ds.xml   VALID
+ocp4     quay.io/compliance-operator/compliance-operator-content:latest   ssg-ocp4-ds.xml     VALID
+rhcos4   quay.io/compliance-operator/compliance-operator-content:latest   ssg-rhcos4-ds.xml   VALID
 ```
 
 Inspecting the ProfileBundle objects, you'll see that they mostly point to the
@@ -56,7 +56,7 @@ metadata:
   uid: f5516313-5f16-4ff8-9c69-d79d44126b8b
 spec:
   contentFile: ssg-rhcos4-ds.xml
-  contentImage: quay.io/complianceascode/ocp4:latest
+  contentImage: quay.io/compliance-operator/compliance-operator-content:latest
 status:
   dataStreamStatus: VALID
 ```

--- a/images/testcontent/Dockerfile.ci
+++ b/images/testcontent/Dockerfile.ci
@@ -1,1 +1,1 @@
-FROM quay.io/complianceascode/ocp4:latest
+FROM quay.io/compliance-operator/compliance-operator-content:latest

--- a/pkg/controller/compliancescan/utils.go
+++ b/pkg/controller/compliancescan/utils.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	DefaultContentContainerImage = "quay.io/complianceascode/ocp4:latest"
+	DefaultContentContainerImage = "quay.io/compliance-operator/compliance-operator-content:latest"
 	CACertDataKey                = "ca.crt"
 	CAKeyDataKey                 = "ca.key"
 	ServerCertInstanceSuffix     = "-rs"

--- a/pkg/controller/scansettingbinding/scansettingbinding_controller_test.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 				Namespace: common.GetComplianceOperatorNamespace(),
 			},
 			Spec: compv1alpha1.ProfileBundleSpec{
-				ContentImage: "quay.io/complianceascode/ocp4:latest",
+				ContentImage: "quay.io/compliance-operator/compliance-operator-content:latest",
 				ContentFile:  "ssg-rhcos4-ds.xml",
 			},
 			Status: compv1alpha1.ProfileBundleStatus{

--- a/pkg/utils/images.go
+++ b/pkg/utils/images.go
@@ -16,7 +16,7 @@ var componentDefaults = []struct {
 }{
 	{"quay.io/compliance-operator/openscap-ocp:1.3.3", "RELATED_IMAGE_OPENSCAP"},
 	{"quay.io/compliance-operator/compliance-operator:latest", "RELATED_IMAGE_OPERATOR"},
-	{"quay.io/complianceascode/ocp4:latest", "RELATED_IMAGE_PROFILE"},
+	{"quay.io/compliance-operator/compliance-operator-content:latest", "RELATED_IMAGE_PROFILE"},
 }
 
 // GetComponentImage returns a full image pull spec for a given component


### PR DESCRIPTION
…images

We recently started updating the compliance content and publishing it in
a different repository. The previous home for the content hadn't been
updated and contained stale container image builds, causing CI failures.

  https://quay.io/repository/compliance-operator/compliance-operator-content