### PR TITLE
Fix memory pointer crash loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   before unpause affected pool. [1]
   ([1]https://bugzilla.redhat.com/show_bug.cgi?id=2071854).
 
+- Fixes memory pointer crashloop when there is invalid `MachineConfigPool` in the
+  cluster. 
+  [Cusomter Case](https://access.redhat.com/support/cases/#/case/03199627) for more
+  information
+
 ### Internal Changes
 
 - Added node resource to the list of resources we always fetch so that arch CPEs will

--- a/pkg/utils/nodeutils.go
+++ b/pkg/utils/nodeutils.go
@@ -208,7 +208,15 @@ func McfgPoolLabelMatches(nodeSelector map[string]string, pool *mcfgv1.MachineCo
 	if nodeSelector == nil {
 		return false
 	}
+
+	if pool.Spec.NodeSelector == nil {
+		return false
+	}
 	// TODO(jaosorior): Make this work with MatchExpression
+	if pool.Spec.NodeSelector.MatchLabels == nil {
+		return false
+	}
+
 	return reflect.DeepEqual(nodeSelector, pool.Spec.NodeSelector.MatchLabels)
 }
 

--- a/pkg/utils/nodeutils_test.go
+++ b/pkg/utils/nodeutils_test.go
@@ -227,4 +227,49 @@ var _ = Describe("Nodeutils", func() {
 			Entry("@all", "@all", map[string]string{}),
 		)
 	})
+
+	Context("MachineConfig Pool with no node selector", func() {
+		targetNodeSelector := map[string]string{
+			"test-node-role": "",
+		}
+
+		mcp := &mcfgv1.MachineConfigPool{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "MachineConfigPool",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "invalidpool",
+			},
+			Spec: mcfgv1.MachineConfigPoolSpec{
+				Paused: false,
+			},
+		}
+		It("It should evaluate as false", func() {
+			isMatchingPool := utils.McfgPoolLabelMatches(targetNodeSelector, mcp)
+			Expect(isMatchingPool).To(BeFalse())
+
+		})
+
+		// no matching labels
+		mcp = &mcfgv1.MachineConfigPool{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "MachineConfigPool",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "invalidpool",
+			},
+			Spec: mcfgv1.MachineConfigPoolSpec{
+				NodeSelector: &metav1.LabelSelector{},
+				Paused:       false,
+			},
+		}
+		It("It should evaluate as false", func() {
+			isMatchingPool := utils.McfgPoolLabelMatches(targetNodeSelector, mcp)
+			Expect(isMatchingPool).To(BeFalse())
+
+		})
+
+	})
 })

--- a/tests/e2e/constants.go
+++ b/tests/e2e/constants.go
@@ -12,6 +12,7 @@ const (
 	maxRetries                    = 5
 	workerPoolName                = "worker"
 	testPoolName                  = "e2e"
+	testInvalidPoolName           = "e2e-invalid"
 	rhcosContentFile              = "ssg-rhcos4-ds.xml"
 	ocpContentFile                = "ssg-ocp4-ds.xml"
 	unexistentResourceContentFile = "ocp4-unexistent-resource.xml"

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -3272,6 +3272,8 @@ func TestE2E(t *testing.T) {
 					},
 				}
 				mcTctx.ensureE2EPool()
+				// To prevent pod from crashing when there is an invalid machine config pool in the cluster
+				mcTctx.ensureInvalidE2EPool()
 				createTPErr := f.Client.Create(goctx.TODO(), tp, getCleanupOpts(ctx))
 				if createTPErr != nil {
 					return createTPErr


### PR DESCRIPTION
Fix compliance operator crashloop issue when there is `MachineConfigPool` that does not have `NodeSelector`, this pr will check if there is `NodeSelector` in a `MachineConfigPool` before comparing the match.

Related customer case: https://access.redhat.com/support/cases/#/case/03199627