### PR TITLE
Add a note to README.md pointing to CaC/compliance-operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ The compliance-operator is a OpenShift Operator that allows an administrator
 to run compliance scans and provide remediations for the issues found. The
 operator leverages OpenSCAP under the hood to perform the scans.
 
+:warning: **This repository is not actively maintained and has been moved to
+the
+[ComplianceAsCode/compliance-operator](https://github.com/ComplianceAsCode/compliance-operator)
+repository. Please use that repository for all releases newer than 0.1.49.**
+
 ## Table of Contents
 
 [Installation Guide](doc/install.md)


### PR DESCRIPTION
We've moved the compliance-operator to a new home under the
ComplianceAsCode organization. Let's make sure we describe that here so
people know where to look for new compliance-operator releases.